### PR TITLE
Disable quickhash-1 for TIFFs with smallest layer > 5 MB

### DIFF
--- a/src/openslide.c
+++ b/src/openslide.c
@@ -292,9 +292,12 @@ openslide_t *openslide_open(const char *filename) {
   }
 
   // set hash property
-  g_hash_table_insert(osr->properties,
-                      g_strdup(OPENSLIDE_PROPERTY_NAME_QUICKHASH1),
-                      g_strdup(_openslide_hash_get_string(quickhash1)));
+  const char *hash_str = _openslide_hash_get_string(quickhash1);
+  if (hash_str != NULL) {
+    g_hash_table_insert(osr->properties,
+                        g_strdup(OPENSLIDE_PROPERTY_NAME_QUICKHASH1),
+                        g_strdup(hash_str));
+  }
   _openslide_hash_destroy(quickhash1);
 
   // set other properties

--- a/tools/openslide-quickhash1sum.c
+++ b/tools/openslide-quickhash1sum.c
@@ -44,9 +44,15 @@ static void process(const char *progname, const char *file) {
     return;
   }
 
-  printf("%s  %s\n",
-	 openslide_get_property_value(osr, "openslide.quickhash-1"),
-	 file);
+  const char *hash = openslide_get_property_value(osr,
+        "openslide.quickhash-1");
+  if (hash != NULL) {
+    printf("%s  %s\n", hash, file);
+  } else {
+    fprintf(stderr, "%s: %s: No quickhash-1 available\n", progname, file);
+    fflush(stderr);
+  }
+
   openslide_close(osr);
 }
 


### PR DESCRIPTION
The quickhash-1 for TIFF files includes the smallest (top) layer of the
image.  For non-pyramidal generic TIFFs (or pathological pyramidal TIFFs)
this could be hundreds of megabytes, causing quickhash calculation in
openslide_open() to take an arbitrary amount of time.

It's not clear how to subset the tile data for these files such that the
quickhash is reasonably collision-resistant.  In the meantime, this patch
fixes the performance problem.

Workaround for #79.
