### PR TITLE
WIP: openslide.pc: list required dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,9 +68,12 @@ PKG_CHECK_MODULES(OPENJPEG2, [libopenjp2 >= 2.1.0], [
    OPENJPEG_CFLAGS="$OPENJPEG2_CFLAGS"
    OPENJPEG_LIBS="$OPENJPEG2_LIBS"
    FEATURE_FLAGS="$FEATURE_FLAGS openjpeg-2"
+   OPENJPEG2_DEP="libopenjp2"
  ], [
   dnl Fall back to OpenJPEG 1.x
-  PKG_CHECK_MODULES(OPENJPEG, [libopenjpeg1], [], [
+  PKG_CHECK_MODULES(OPENJPEG, [libopenjpeg1], [
+    OPENJPEG2_DEP="libopenjpeg1"
+  ], [
     dnl OpenJPEG < 1.4 has no pkg-config file
 
     AC_MSG_CHECKING([for OpenJPEG (fallback)])
@@ -104,6 +107,7 @@ PKG_CHECK_MODULES(OPENJPEG2, [libopenjp2 >= 2.1.0], [
   ])
   FEATURE_FLAGS="$FEATURE_FLAGS openjpeg-1"
 ])
+AC_SUBST([OPENJPEG2_DEP])
 
 PKG_CHECK_MODULES(LIBTIFF, [libtiff-4], [], [
   dnl libtiff < 4 has no pkg-config file

--- a/openslide.pc.in
+++ b/openslide.pc.in
@@ -9,3 +9,4 @@ Description: A library for reading whole slide images.
 Version: @VERSION@
 Libs: -L${libdir} -lopenslide
 Cflags: -I${includedir}/openslide
+Requires: zlib, libjpeg, @OPENJPEG2_DEP@, libtiff-4, glib-2.0, gthread-2.0, gio-2.0, gobject-2.0, cairo, libpng, gdk-pixbuf-2.0, libxml-2.0, sqlite3


### PR DESCRIPTION
Fixes #185.

---
Not sure how to get `OPENJPEG2_DEP` to get replaced properly, but that looks to be the only thing missing here.