### PR TITLE
Fix to read Aperio svs images with one or more "broken" tiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Makefile.in
 /stamp-h1
 /*.pc
 
+.vscode
 /mingw32-config.cache
 
 /src/make-tables

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -159,12 +159,11 @@ static bool decode_tile(struct level *l,
     break;
   default:
     // not for us? fallback
-    bool ok = _openslide_tiff_read_tile(tiffl, tiff, dest,
-                                     tile_col, tile_row,
-                                     err);
     // If the tile could not be read/rendered, (maybe because of garbled tile data)
     // try to render it using data at other levels using render_missing_tile()
-    return ok || render_missing_tile(l, tiff, dest, tile_col, tile_row, err);
+    return
+      _openslide_tiff_read_tile(tiffl, tiff, dest, tile_col, tile_row, err) ||
+      render_missing_tile(l, tiff, dest, tile_col, tile_row, err);
   }
 
   // read raw tile

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -159,9 +159,12 @@ static bool decode_tile(struct level *l,
     break;
   default:
     // not for us? fallback
-    return _openslide_tiff_read_tile(tiffl, tiff, dest,
+    bool ok = _openslide_tiff_read_tile(tiffl, tiff, dest,
                                      tile_col, tile_row,
                                      err);
+    // If the tile could not be read/rendered, (maybe because of garbled tile data)
+    // try to render it using data at other levels using render_missing_tile()
+    return ok || render_missing_tile(l, tiff, dest, tile_col, tile_row, err);
   }
 
   // read raw tile


### PR DESCRIPTION
In some Aperio images, one tile (typically 0, 0), in one or more levels, is partly overwritten with some unknown data. This seems to happen from byte 0 or byte 1 of the tile data, thereby overwriting the JPEG marker. The first erroneous byte always seems to be a 0x11, so it is very easy and safe to detect the bug.

In such cases Openslide would just return a black image.

The fix is to return false from _openslide_tiff_read_tile() when the erroneous data is detected, and to call render_missing_tile() if _openslide_tiff_read_tile() retruns false.