### PR TITLE
fix crash on Alpine Linux with glib 2.50+ --- remove explicit g_type_init()

### DIFF
--- a/src/openslide.c
+++ b/src/openslide.c
@@ -60,8 +60,10 @@ static void __attribute__((constructor)) _openslide_init(void) {
   if (!g_thread_supported()) {
     g_thread_init(NULL);
   }
-  // initialize GObject
+  // not needed since glib 2.36, and causes problems with musl on 2.50+
+#if !GLIB_CHECK_VERSION(2, 36, 0)
   g_type_init();
+#endif
   // work around thread-safety problems in glib < 2.48.1 with first
   // g_key_file_new() call
   // https://bugzilla.gnome.org/show_bug.cgi?id=748474


### PR DESCRIPTION
`g_type_init()` has not been needed since glib 2.36. Calling it anyway is
normally harmless, except on Alpine Linux with glib 2.50+, where it
triggers an assert fail due to differences in the way the libcs handle
startup.

This patch stop openslide calling `g_type_init()` if glibc is later than
2.36.

Related issue: https://github.com/jcupitt/libvips/issues/874