### PR TITLE
Support for Tile Joint Left Direction

### DIFF
--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -67,6 +67,7 @@ static const char ATTR_TILE1[] = "Tile1";
 static const char ATTR_TILE2[] = "Tile2";
 static const char ATTR_OVERLAP_X[] = "OverlapX";
 static const char ATTR_OVERLAP_Y[] = "OverlapY";
+static const char DIRECTION_LEFT[] = "LEFT";
 static const char DIRECTION_RIGHT[] = "RIGHT";
 static const char DIRECTION_UP[] = "UP";
 
@@ -572,7 +573,7 @@ static struct bif *parse_level0_xml(const char *xml,
       bool ok;
       bool direction_y = false;
       //g_debug("%s, tile1 %"PRId64" %"PRId64", tile2 %"PRId64" %"PRId64, (char *) direction, tile1_col, tile1_row, tile2_col, tile2_row);
-      if (!xmlStrcmp(direction, BAD_CAST DIRECTION_RIGHT)) {
+      if (!xmlStrcmp(direction, BAD_CAST DIRECTION_RIGHT) || !xmlStrcmp(direction, BAD_CAST DIRECTION_LEFT)) {
         // get left joint of right tile
         struct tile *tile =
           area->tiles[tile2_row * area->tiles_across + tile2_col];


### PR DESCRIPTION
I have access to some .bif files which have the TileJointInfo direction attribute set to LEFT rather than RIGHT. Openslide doesn’t currently support such files so I have made some simple changes so they can be opened. I have done some testing opening .bif files containing the LEFT join direction and the resulting image is almost exactly the same when processed as if it had the direction attribute set to RIGHT. Please could you consider merging this change into openslide to support files with this attribute!