### PR TITLE
Copy one version of zip file with name that doesn't change

### DIFF
--- a/DockerFiles/Dockerfile
+++ b/DockerFiles/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:16.04
+
+# Install missing dependencies
+RUN apt-get update && apt-get install -qq --no-install-recommends git autoconf automake libtool pkg-config mingw-w64 nasm openjdk-8-jdk ant cmake gettext libglib2.0-0 wget xz-utils build-essential pkg-config python libglib2.0-dev libglib2.0-bin zip autoconf libjpeg-dev libopenjpeg-dev libtiff-dev libglib2.0-dev libcairo-dev libpng-dev libgdk-pixbuf2.0-dev libxml2-dev libsqlite3-dev valgrind libopenjp2-7-dev libgtk2.0-dev doxygen
+
+# Install dependencies for deb package
+RUN apt-get update && apt-get install -qq vim dpkg-dev debhelper devscripts curl
+
+# Copy build script to build directory
+WORKDIR /build
+COPY build_win.sh /build
+COPY build_linux.sh /build
+COPY build_linux_deb.sh /build
+
+CMD ["bash"]

--- a/DockerFiles/README.md
+++ b/DockerFiles/README.md
@@ -1,0 +1,21 @@
+# Compiling OpenSlide
+
+This directory contains a docker image and docker-compose configuration to build openslide for windows on linux using 
+docker and for building a linux debian package.
+
+
+```bash
+# Start the docker container
+docker-compose run openslide
+
+# In the container run one of the following scripts:
+bash build_win.sh 
+bash build_linux.sh
+bash build_linux_deb.sh
+
+# Alternatively, run the build directly:
+docker-compose run openslide bash build_win.sh
+docker-compose run openslide bash build_linux.sh
+docker-compose run openslide bash build_linux_deb.sh
+
+```

--- a/DockerFiles/build_linux.sh
+++ b/DockerFiles/build_linux.sh
@@ -1,0 +1,12 @@
+# Change to the folder mapped into the container
+cd /build
+
+# Clone or copy the openslide version to be built
+git clone https://github.com/sderaedt/openslide.git
+cd openslide
+
+# Generate the configuration file and run configure
+autoreconf -i && ./configure && make distcheck -j8
+
+# Copy compiled file to release folder mapped in docker image
+cp openslide-*.tar.gz ../release/

--- a/DockerFiles/build_linux_deb.sh
+++ b/DockerFiles/build_linux_deb.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Fetch the archive from github
+wget https://github.com/sderaedt/openslide/archive/v3.4.3.tar.gz
+
+# Uncompress archive
+tar -zxvf v3.4.3.tar.gz 
+
+# Clone debian package
+git clone https://salsa.debian.org/med-team/openslide.git
+
+# Copy debian package into source code directory
+cp -r openslide/debian/ openslide-3.4.3/
+cd openslide-3.4.3/
+
+# Change the debhelper version
+echo 9 > debian/compat 
+sed -i "s/Build-Depends: debhelper (>= .*),/Build-Depends: debhelper (>= 9~),/g" debian/control
+
+# Add the changelog
+vi debian/changelog
+
+# Run configure to generate the necessary files 
+autoreconf -i
+./configure 
+make
+
+# Create the source archive
+tar -zcvf ../openslide_3.4.3.orig.tar.gz ../openslide-3.4.3/
+
+# Build package
+debuild -us -uc
+
+# Copy to release folder
+cp ../*openslide*.deb ../release/

--- a/DockerFiles/build_win.sh
+++ b/DockerFiles/build_win.sh
@@ -26,3 +26,4 @@ bash build.sh -m64 -j16 bdist
 
 # Copy compiled file to release folder mapped in docker image
 cp openslide-win64-*.zip ../release/
+cp openslide-win64-*.zip ../release/openslide-win64-latest.zip

--- a/DockerFiles/build_win.sh
+++ b/DockerFiles/build_win.sh
@@ -1,0 +1,28 @@
+# Change to the folder mapped into the container
+cd /build
+
+# Clone the winbuild script and change to the directory
+git clone https://github.com/openslide/openslide-winbuild.git
+cd openslide-winbuild
+
+# Create the override directory to build a custom openslide version
+# Otherwise the last release from the official openslide github will be built
+mkdir override
+cd override
+
+# Clone or copy the openslide version to be built
+git clone https://github.com/sderaedt/openslide.git
+cd openslide
+
+# Generate the configuration file and run configure
+autoreconf -i && ./configure && make distcheck
+
+# Change back to the root directory and run build.sh bdist
+cd ../../
+bash build.sh -m64 -j16 bdist
+
+# -m64 specifies to build a 64bit version (-m32 for 32bit)
+# -j16 parallel build with 16 threads
+
+# Copy compiled file to release folder mapped in docker image
+cp openslide-win64-*.zip ../release/

--- a/DockerFiles/docker-compose.yml
+++ b/DockerFiles/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  openslide:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: sderaedt/openslide:3.4.3-1
+    working_dir: /build
+    stdin_open: true
+    tty: true
+    shm_size: 2g
+    volumes:
+      - ../release:/build/release

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT([OpenSlide], [3.4.1], [openslide-users@lists.andrew.cmu.edu], [openslide], [https://openslide.org])
+AC_INIT([OpenSlide], [3.4.3], [openslide-users@lists.andrew.cmu.edu], [openslide], [https://openslide.org])
 AC_CONFIG_SRCDIR([src])
 AC_CONFIG_HEADER([config.h])
 AM_INIT_AUTOMAKE([foreign subdir-objects 1.11.1 dist-xz])

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -298,6 +298,16 @@ bool _openslide_tiff_read_tile(struct _openslide_tiff_level *tiffl,
                                         err)) {
       return false;
     }
+    // In some Aperio images, one tile (typically 0, 0), in one or more levels,
+    // is partly overwritten with some unknown data. This seems to happen
+    // from byte 0 or byte 1 of the tile data. Such garbled tiles are
+    // impossible to read, so just return false!
+    // The other half of this fix/hack consists of calling render_missing_tile
+    // from decode_tile (in openslide-vendor-aperio) if _openslide_tiff_read_tile
+    // returns false.
+    const unsigned char *bytes = buf;
+    if (bytes[0] == 0x11 || (bytes[0] == 0xff && bytes[1] == 0x11))
+      return false; // Garbled tile
 
     // decompress
     bool ret = decode_jpeg(buf, buflen, tables, tables_len,

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -159,9 +159,32 @@ static bool decode_tile(struct level *l,
     break;
   default:
     // not for us? fallback
-    return _openslide_tiff_read_tile(tiffl, tiff, dest,
+    
+    if (!_openslide_tiff_read_tile(tiffl, tiff, dest,
                                      tile_col, tile_row,
-                                     err);
+                                     err)) {
+      
+      // In some Aperio images, one tile (typically 0, 0), in one or more levels,
+      // is partly overwritten with some unknown data. This seems to happen
+      // from byte 0 or byte 1 of the tile data. Such garbled tiles are
+      // impossible to read, so just return false!
+      // The other half of this fix/hack consists of calling render_missing_tile
+      // if _openslide_tiff_read_tile_data returns false.
+      void *buf;
+      int32_t buflen;
+      if (_openslide_tiff_read_tile_data(tiffl, tiff,
+      	                      &buf, &buflen,
+       	                      tile_col, tile_row,
+       	                      err)) {
+        const unsigned char *bytes = buf;
+        if (bytes[0] == 0x11 || (bytes[0] == 0xff && bytes[1] == 0x11)) {
+          return render_missing_tile(l, tiff, dest, tile_col, tile_row, err);
+        } else {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   // read raw tile

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -2255,8 +2255,13 @@ static bool hamamatsu_ndpi_open(openslide_t *osr, const char *filename,
     TIFF_GET_UINT_OR_FAIL(tl, dir, TIFFTAG_ROWSPERSTRIP, rows_per_strip);
     TIFF_GET_UINT_OR_FAIL(tl, dir, TIFFTAG_STRIPOFFSETS, start_in_file);
     TIFF_GET_UINT_OR_FAIL(tl, dir, TIFFTAG_STRIPBYTECOUNTS, num_bytes);
-    start_in_file = _openslide_tifflike_uint_fix_offset_ndpi(tl, dir,
-                                                             start_in_file);
+    
+    // do not fix offset for first dir
+    // fix for ndpi files > 4gb
+    if(dir>0) {
+      start_in_file = _openslide_tifflike_uint_fix_offset_ndpi(tl, dir,
+                                                               start_in_file);
+    }
 
     double lens =
       _openslide_tifflike_get_float(tl, dir, NDPI_SOURCELENS, &tmp_err);


### PR DESCRIPTION
In the bash script that builds openslide for windows, copy one version of the zip file with a name that doesn't changes, to make it easier to use it in scripts.