### PR TITLE
Add support for NDPI images >4GB

### DIFF
--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -175,18 +175,6 @@ static uint32_t get_value_size(uint16_t type, uint64_t *count) {
   }
 }
 
-// Re-add implied high-order bits to a 32-bit offset.
-// Heuristic: maximize high-order bits while keeping the offset below diroff.
-static uint64_t fix_offset_ndpi(uint64_t diroff, uint64_t offset) {
-  uint64_t result = (diroff & ~(uint64_t) UINT32_MAX) | (offset & UINT32_MAX);
-  if (result >= diroff) {
-    // ensure result doesn't wrap around
-    result = MIN(result - UINT32_MAX - 1, result);
-  }
-  //g_debug("diroff %"PRIx64": %"PRIx64" -> %"PRIx64, diroff, offset, result);
-  return result;
-}
-
 #define ALLOC_VALUES_OR_FAIL(OUT, TYPE, COUNT) do {			\
     OUT = g_try_new(TYPE, COUNT);					\
     if (!OUT) {								\
@@ -403,7 +391,6 @@ static void tiff_item_destroy(gpointer data) {
 }
 
 static struct tiff_directory *read_directory(FILE *f, int64_t *diroff,
-                                             struct tiff_directory *first_dir,
                                              GHashTable *loop_detector,
                                              bool bigtiff,
                                              bool ndpi,
@@ -492,24 +479,58 @@ static struct tiff_directory *read_directory(FILE *f, int64_t *diroff,
     }
 
     // read in the value/offset
-    uint8_t value[bigtiff ? 8 : 4];
-    if (fread(value, sizeof(value), 1, f) != 1) {
+    uint8_t value[(bigtiff || ndpi) ? 8 : 4];
+    size_t read_size = (bigtiff ? 8 : 4);
+    
+    if (fread(value, read_size, 1, f) != 1) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Cannot read value/offset");
       goto FAIL;
     }
+    
+    bool is_value = (value_size * count <= read_size);
+
+    // in ndpi files all values/offsets have a 4 byte extension at the end of the IFD
+    // append this to the current value/offset
+    if (ndpi) {
+      // seek to value/offset extension
+      if (fseeko(f, off+(12L*dircount)+(4L*n)+10L, SEEK_SET) != 0) {
+        _openslide_io_error(err, "Cannot seek to value/offset extension.");
+        goto FAIL;
+      }
+        
+      // read in the value/offset extension
+      if (fread(value+4, 4, 1, f) != 1) {
+        g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                    "Cannot read value/offset extension");
+        goto FAIL;
+      }
+      
+      // if the value/offset contains the value and the extension is nonzero, update the value size and item type
+      if (is_value && (value[4] > 0 || value[5] > 0 || value[6] > 0 || value[7] > 0)) {
+        value_size = 8;
+        item->type = TIFF_LONG8;
+      }
+      
+      // seek back to the tag's position in the IFD
+      if (fseeko(f, off+(12L*(n+1))+2L, SEEK_SET) != 0) {
+        _openslide_io_error(err, "Seeking back to IFD failed.");
+        goto FAIL;
+      }
+    }
 
     // does value/offset contain the value?
-    if (value_size * count <= sizeof(value)) {
+    if (is_value) {
       // yes
       fix_byte_order(value, value_size, count, big_endian);
+      
       if (!set_item_values(item, value, err)) {
         goto FAIL;
       }
 
     } else {
       // no; store offset
-      if (bigtiff) {
+      if (bigtiff || ndpi) {
         memcpy(&item->offset, value, 8);
         fix_byte_order(&item->offset, sizeof(item->offset), 1, big_endian);
       } else {
@@ -517,19 +538,6 @@ static struct tiff_directory *read_directory(FILE *f, int64_t *diroff,
         memcpy(&off32, value, 4);
         fix_byte_order(&off32, sizeof(off32), 1, big_endian);
         item->offset = off32;
-      }
-
-      if (ndpi) {
-        // heuristically set high-order bits of offset
-        // if this tag has the same offset in the first IFD, reuse that value
-        struct tiff_item *first_dir_item = NULL;
-        if (first_dir) {
-          first_dir_item = g_hash_table_lookup(first_dir->items,
-                                               GINT_TO_POINTER(tag));
-        }
-        if (!first_dir_item || first_dir_item->offset != item->offset) {
-          item->offset = fix_offset_ndpi(off, item->offset);
-        }
       }
     }
   }
@@ -635,7 +643,6 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   if (!bigtiff && diroff != 0) {
     int64_t trial_diroff = diroff;
     struct tiff_directory *d = read_directory(f, &trial_diroff,
-                                              NULL,
                                               loop_detector,
                                               bigtiff, true, big_endian,
                                               NULL);
@@ -669,7 +676,6 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   while (diroff != 0) {
     // read a directory
     struct tiff_directory *d = read_directory(f, &diroff,
-                                              first_dir,
                                               loop_detector,
                                               bigtiff, tl->ndpi, big_endian,
                                               err);
@@ -978,16 +984,6 @@ bool _openslide_tifflike_is_tiled(struct _openslide_tifflike *tl,
                                   int64_t dir) {
   return _openslide_tifflike_get_value_count(tl, dir, TIFFTAG_TILEWIDTH) &&
          _openslide_tifflike_get_value_count(tl, dir, TIFFTAG_TILELENGTH);
-}
-
-uint64_t _openslide_tifflike_uint_fix_offset_ndpi(struct _openslide_tifflike *tl,
-                                                  int64_t dir, uint64_t offset) {
-  g_assert(dir >= 0 && dir < tl->directories->len);
-  if (!tl->ndpi) {
-    return offset;
-  }
-  struct tiff_directory *d = tl->directories->pdata[dir];
-  return fix_offset_ndpi(d->offset, offset);
 }
 
 static const char *store_string_property(struct _openslide_tifflike *tl,

--- a/src/openslide-decode-tifflike.h
+++ b/src/openslide-decode-tifflike.h
@@ -65,11 +65,6 @@ const uint64_t *_openslide_tifflike_get_uints(struct _openslide_tifflike *tl,
                                               int64_t dir, int32_t tag,
                                               GError **err);
 
-// if the file was detected as NDPI, heuristically add high-order bits to
-// the specified offset
-uint64_t _openslide_tifflike_uint_fix_offset_ndpi(struct _openslide_tifflike *tl,
-                                                  int64_t dir, uint64_t offset);
-
 // TIFF_SBYTE, TIFF_SSHORT, TIFF_SLONG
 int64_t _openslide_tifflike_get_sint(struct _openslide_tifflike *tl,
                                      int64_t dir, int32_t tag,

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -2376,6 +2376,13 @@ static bool hamamatsu_ndpi_open(openslide_t *osr, const char *filename,
                 jp->start_in_file + unreliable_mcu_starts_low_bytes[tile] + (unreliable_mcu_starts_high_bytes[tile] << 32);
               //g_debug("mcu start at %"PRId64, jp->unreliable_mcu_starts[tile] + (unreliable_mcu_starts_high_bytes[tile] << 32));
             }
+          } else if (unreliable_mcu_starts_low_bytes) {
+            jp->unreliable_mcu_starts = g_new(int64_t, mcu_start_count);
+            for (int64_t tile = 0; tile < mcu_start_count; tile++) {
+              jp->unreliable_mcu_starts[tile] =
+                jp->start_in_file + unreliable_mcu_starts_low_bytes[tile];
+              //g_debug("mcu start at %"PRId64, jp->unreliable_mcu_starts[tile]);
+            }
           } else {
             //g_debug("failed to load MCU starts for directory %"PRId64, dir);
           }


### PR DESCRIPTION
Addresses issue #174 (and possibly others), regarding the reading of large NDPI files. This issue stems from the fact that classical TIFF (and by extension, NDPI) images only support up to 32 bit values for tagged metadata. However, due to the nature of whole slide image data, it isn't uncommon for the size of an NDPI to exceed the 32 bit range. This means that key metadata, such as the byte positions of image layers or their size in bytes, may be too large to store in a traditional TIFF IFD entry.

Currently OpenSlide relies on heuristics to determine the high bits of 64 bit addresses, which fail in some cases. However, this is unnecessary, as NDPI actually stores the high bits of the offset/value of each tag in 4 byte blocks immediately after the end of the IFD.

This fix modifies openslide-decode-tifflike.c to append these extra 4 bytes to each IFD entry's value/offset and, if necessary, modifies its type to LONG8.

This fix also modifies openslide-vendor-hamamatsu.c to construct correct restart marker addresses. Currently only the values in TIFF tag 65426 are used, which are only the lower 32 bits of each address. High bits are stored in TIFF tag 65432, so these are now appended before mcu_starts are calculated