### PR TITLE
Add exported cache management API

### DIFF
--- a/src/openslide-cache.c
+++ b/src/openslide-cache.c
@@ -161,24 +161,6 @@ void _openslide_cache_destroy(struct _openslide_cache *cache) {
   g_slice_free(struct _openslide_cache, cache);
 }
 
-
-int _openslide_cache_get_capacity(struct _openslide_cache *cache) {
-  g_mutex_lock(&cache->mutex);
-  int capacity = cache->capacity;
-  g_mutex_unlock(&cache->mutex);
-  return capacity;
-}
-
-void _openslide_cache_set_capacity(struct _openslide_cache *cache,
-				   int capacity_in_bytes) {
-  g_assert(capacity_in_bytes >= 0);
-
-  g_mutex_lock(&cache->mutex);
-  cache->capacity = capacity_in_bytes;
-  possibly_evict(cache, 0);
-  g_mutex_unlock(&cache->mutex);
-}
-
 // put and get
 
 // the cache retains one reference, and the caller gets another one.  the

--- a/src/openslide-cache.c
+++ b/src/openslide-cache.c
@@ -56,6 +56,7 @@ struct _openslide_cache {
   GQueue *list;
   GHashTable *hashtable;
   int refcount;
+  bool released;
 
   uint64_t capacity;
   uint64_t total_size;
@@ -184,6 +185,16 @@ static void cache_unref(struct _openslide_cache *cache) {
 
   // destroy struct
   g_slice_free(struct _openslide_cache, cache);
+}
+
+void _openslide_cache_release(struct _openslide_cache *cache) {
+  g_mutex_lock(&cache->mutex);
+  bool already_released = cache->released;
+  cache->released = true;
+  g_mutex_unlock(&cache->mutex);
+  g_return_if_fail(!already_released);
+
+  cache_unref(cache);
 }
 
 struct _openslide_cache_binding *_openslide_cache_binding_create(void) {

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -260,6 +260,9 @@ struct _openslide_cache *_openslide_cache_create(int capacity_in_bytes);
 // binding a cache to an openslide_t
 struct _openslide_cache_binding *_openslide_cache_binding_create(void);
 
+void _openslide_cache_binding_set(struct _openslide_cache_binding *cb,
+                                  struct _openslide_cache *cache);
+
 void _openslide_cache_binding_destroy(struct _openslide_cache_binding *cb);
 
 // put and get

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -254,8 +254,10 @@ void _openslide_set_bounds_props_from_grid(openslide_t *osr,
 struct _openslide_cache_binding;
 struct _openslide_cache_entry;
 
-// create
+// create/release
 struct _openslide_cache *_openslide_cache_create(uint64_t capacity_in_bytes);
+
+void _openslide_cache_release(struct _openslide_cache *cache);
 
 // binding a cache to an openslide_t
 struct _openslide_cache_binding *_openslide_cache_binding_create(void);

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -67,7 +67,7 @@ struct _openslide {
   const char **property_names; // filled in automatically from hashtable
 
   // cache
-  struct _openslide_cache *cache;
+  struct _openslide_cache_binding *cache;
 
   // error handling, NULL if no error
   gpointer error; // must use g_atomic_pointer!
@@ -251,8 +251,7 @@ void _openslide_set_bounds_props_from_grid(openslide_t *osr,
 
 
 /* Cache */
-#define _OPENSLIDE_USEFUL_CACHE_SIZE 1024*1024*32
-
+struct _openslide_cache_binding;
 struct _openslide_cache_entry;
 
 // constructor/destructor
@@ -260,8 +259,13 @@ struct _openslide_cache *_openslide_cache_create(int capacity_in_bytes);
 
 void _openslide_cache_destroy(struct _openslide_cache *cache);
 
+// binding a cache to an openslide_t
+struct _openslide_cache_binding *_openslide_cache_binding_create(void);
+
+void _openslide_cache_binding_destroy(struct _openslide_cache_binding *cb);
+
 // put and get
-void _openslide_cache_put(struct _openslide_cache *cache,
+void _openslide_cache_put(struct _openslide_cache_binding *cb,
 			  void *plane,  // coordinate plane (level or grid)
 			  int64_t x,
 			  int64_t y,
@@ -269,7 +273,7 @@ void _openslide_cache_put(struct _openslide_cache *cache,
 			  int size_in_bytes,
 			  struct _openslide_cache_entry **entry);
 
-void *_openslide_cache_get(struct _openslide_cache *cache,
+void *_openslide_cache_get(struct _openslide_cache_binding *cb,
 			   void *plane,
 			   int64_t x,
 			   int64_t y,

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -260,12 +260,6 @@ struct _openslide_cache *_openslide_cache_create(int capacity_in_bytes);
 
 void _openslide_cache_destroy(struct _openslide_cache *cache);
 
-// cache size
-int _openslide_cache_get_capacity(struct _openslide_cache *cache);
-
-void _openslide_cache_set_capacity(struct _openslide_cache *cache,
-				   int capacity_in_bytes);
-
 // put and get
 void _openslide_cache_put(struct _openslide_cache *cache,
 			  void *plane,  // coordinate plane (level or grid)

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -254,10 +254,8 @@ void _openslide_set_bounds_props_from_grid(openslide_t *osr,
 struct _openslide_cache_binding;
 struct _openslide_cache_entry;
 
-// constructor/destructor
+// create
 struct _openslide_cache *_openslide_cache_create(int capacity_in_bytes);
-
-void _openslide_cache_destroy(struct _openslide_cache *cache);
 
 // binding a cache to an openslide_t
 struct _openslide_cache_binding *_openslide_cache_binding_create(void);

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -255,15 +255,15 @@ struct _openslide_cache_binding;
 struct _openslide_cache_entry;
 
 // create/release
-struct _openslide_cache *_openslide_cache_create(uint64_t capacity_in_bytes);
+openslide_cache_t *_openslide_cache_create(uint64_t capacity_in_bytes);
 
-void _openslide_cache_release(struct _openslide_cache *cache);
+void _openslide_cache_release(openslide_cache_t *cache);
 
 // binding a cache to an openslide_t
 struct _openslide_cache_binding *_openslide_cache_binding_create(void);
 
 void _openslide_cache_binding_set(struct _openslide_cache_binding *cb,
-                                  struct _openslide_cache *cache);
+                                  openslide_cache_t *cache);
 
 void _openslide_cache_binding_destroy(struct _openslide_cache_binding *cb);
 

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -255,7 +255,7 @@ struct _openslide_cache_binding;
 struct _openslide_cache_entry;
 
 // create
-struct _openslide_cache *_openslide_cache_create(int capacity_in_bytes);
+struct _openslide_cache *_openslide_cache_create(uint64_t capacity_in_bytes);
 
 // binding a cache to an openslide_t
 struct _openslide_cache_binding *_openslide_cache_binding_create(void);
@@ -271,7 +271,7 @@ void _openslide_cache_put(struct _openslide_cache_binding *cb,
 			  int64_t x,
 			  int64_t y,
 			  void *data,
-			  int size_in_bytes,
+			  uint64_t size_in_bytes,
 			  struct _openslide_cache_entry **entry);
 
 void *_openslide_cache_get(struct _openslide_cache_binding *cb,

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -317,8 +317,7 @@ openslide_t *openslide_open(const char *filename) {
   osr->property_names = strv_from_hashtable_keys(osr->properties);
 
   // start cache
-  osr->cache = _openslide_cache_create(_OPENSLIDE_USEFUL_CACHE_SIZE);
-  //osr->cache = _openslide_cache_create(0);
+  osr->cache = _openslide_cache_binding_create();
 
   return osr;
 }
@@ -336,7 +335,7 @@ void openslide_close(openslide_t *osr) {
   g_free(osr->property_names);
 
   if (osr->cache) {
-    _openslide_cache_destroy(osr->cache);
+    _openslide_cache_binding_destroy(osr->cache);
   }
 
   g_free(g_atomic_pointer_get(&osr->error));

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -2,6 +2,7 @@
  *  OpenSlide, a library for reading whole slide image files
  *
  *  Copyright (c) 2007-2012 Carnegie Mellon University
+ *  Copyright (c) 2021      Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -698,6 +699,21 @@ void openslide_read_associated_image(openslide_t *osr,
 
     g_free(buf);
   }
+}
+
+openslide_cache_t *openslide_cache_create(size_t capacity) {
+  return _openslide_cache_create(capacity);
+}
+
+void openslide_set_cache(openslide_t *osr, openslide_cache_t *cache) {
+  if (openslide_get_error(osr)) {
+    return;
+  }
+  _openslide_cache_binding_set(osr->cache, cache);
+}
+
+void openslide_cache_release(openslide_cache_t *cache) {
+  _openslide_cache_release(cache);
 }
 
 const char *openslide_get_version(void) {

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -2,6 +2,7 @@
  *  OpenSlide, a library for reading whole slide image files
  *
  *  Copyright (c) 2007-2014 Carnegie Mellon University
+ *  Copyright (c) 2021      Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -32,6 +33,7 @@
 
 #include "openslide-features.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -427,6 +429,52 @@ OPENSLIDE_PUBLIC()
 void openslide_read_associated_image(openslide_t *osr,
 				     const char *name,
 				     uint32_t *dest);
+//@}
+
+/**
+ * @name Caching
+ * Managing the in-memory tile cache.
+ *
+ * By default, each OpenSlide object has its own internal cache.  These
+ * functions can be used to configure a cache with a custom size, which may
+ * be shared between multiple OpenSlide objects.
+ */
+//@{
+
+/**
+ * Create a new tile cache, unconnected to any OpenSlide object.  The cache
+ * can be attached to one or more OpenSlide objects with openslide_set_cache().
+ * The cache must be released with openslide_cache_release() when done.
+ *
+ * @param capacity The capacity of the cache, in bytes.
+ * @return A new cache.
+ * @since 3.5.0
+ */
+OPENSLIDE_PUBLIC()
+openslide_cache_t *openslide_cache_create(size_t capacity);
+
+/**
+ * Attach a cache to the specified OpenSlide object, replacing the
+ * current cache.
+ *
+ * @param osr The OpenSlide object.
+ * @param cache The cache to attach.
+ * @since 3.5.0
+ */
+OPENSLIDE_PUBLIC()
+void openslide_set_cache(openslide_t *osr, openslide_cache_t *cache);
+
+/**
+ * Release the cache.  The cache may be released while it is still attached
+ * to OpenSlide objects.  It will be freed once the last attached OpenSlide
+ * object is closed.
+ *
+ * @param cache The cache to release.
+ * @since 3.5.0
+ */
+OPENSLIDE_PUBLIC()
+void openslide_cache_release(openslide_cache_t *cache);
+
 //@}
 
 /**

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -43,6 +43,11 @@ extern "C" {
  */
 typedef struct _openslide openslide_t;
 
+/**
+ * An OpenSlide tile cache.
+ */
+typedef struct _openslide_cache openslide_cache_t;
+
 
 /**
  * @name Basic Usage

--- a/test/extended.c
+++ b/test/extended.c
@@ -129,6 +129,81 @@ static void check_cloexec_leaks(const char *slide G_GNUC_UNUSED,
                                 int64_t y G_GNUC_UNUSED) {}
 #endif /* !NONATOMIC_CLOEXEC && !WIN32 */
 
+#define CACHE_THREADS 5
+
+struct cache_thread_params {
+  GThread *thread;
+  openslide_t *osr[CACHE_THREADS];
+  int64_t w, h;
+  size_t cache_size;
+  gint *stop; // atomic ops
+};
+
+static void *cache_thread(void *data) {
+  struct cache_thread_params *params = data;
+  uint32_t *buf = g_malloc(4 * params->w * params->h);
+  while (!g_atomic_int_get(params->stop)) {
+    // read some tiles
+    openslide_read_region(params->osr[0], buf, 0, 0, 0, params->w, params->h);
+    // replace everyone's caches
+    openslide_cache_t *cache = openslide_cache_create(params->cache_size);
+    // redundantly set cache several times
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < CACHE_THREADS; j++) {
+        openslide_set_cache(params->osr[j], cache);
+      }
+    }
+    openslide_cache_release(cache);
+  }
+  g_free(buf);
+  return NULL;
+}
+
+static void cache_thread_start(struct cache_thread_params *param_array,
+                               openslide_t **osrs,
+                               int idx,
+                               int64_t w, int64_t h,
+                               size_t cache_size,
+                               gint *stop) {
+  struct cache_thread_params *params = &param_array[idx];
+  for (int i = 0; i < CACHE_THREADS; i++) {
+    params->osr[i] = osrs[(idx + i) % CACHE_THREADS];
+  }
+  params->w = w;
+  params->h = h;
+  params->cache_size = cache_size;
+  params->stop = stop;
+  params->thread = g_thread_new("cache-thread", cache_thread, params);
+}
+
+// test sharing cache among multiple handles
+static void check_shared_cache(const char *slide) {
+  openslide_t *osrs[CACHE_THREADS];
+  for (int i = 0; i < CACHE_THREADS; i++) {
+    osrs[i] = openslide_open(slide);
+    g_assert(osrs[i]);
+    g_assert(openslide_get_error(osrs[i]) == NULL);
+  }
+
+  struct cache_thread_params params[CACHE_THREADS];
+  gint stop = 0;
+  cache_thread_start(params, osrs, 0, 1000, 1000, 4000000, &stop);
+  cache_thread_start(params, osrs, 1, 1000, 1000, 4000000, &stop);
+  cache_thread_start(params, osrs, 2,  500,  500,  250000, &stop);
+  cache_thread_start(params, osrs, 3,  100,  100,  250000, &stop);
+  cache_thread_start(params, osrs, 4,  100,  100,       0, &stop);
+
+  // let them run
+  sleep(1);
+
+  g_atomic_int_set(&stop, 1);
+  for (int i = 0; i < CACHE_THREADS; i++) {
+    g_thread_join(params[i].thread);
+  }
+  for (int i = 0; i < CACHE_THREADS; i++) {
+    openslide_close(osrs[i]);
+  }
+}
 
 int main(int argc, char **argv) {
   common_fix_argv(&argc, &argv);
@@ -236,6 +311,8 @@ int main(int argc, char **argv) {
   openslide_close(osr);
 
   check_cloexec_leaks(path, argv[0], bounds_xx, bounds_yy);
+
+  check_shared_cache(path);
 
   return 0;
 }


### PR DESCRIPTION
Create a slide handle with a default cache, but allow the user to separately allocate a cache of any size (including zero) and attach it to one or more slide handles.  This allows sharing a cache between slides.  The public API is:

```C
// allocate new cache
openslide_cache_t *openslide_cache_create(int64_t capacity);

// set cache for slide handle, replacing the existing cache
void openslide_set_cache(openslide_t *osr, openslide_cache_t *cache);

// release application's reference to a cache; cache is not freed until
// all attached slides are detached or closed
void openslide_cache_release(openslide_cache_t *cache);
```

For now, don't support resizing an existing cache, nor external caches implemented by the application.  Those features can be added within the existing API if they turn out to be needed.

Fixes #38.

Still needed:
- [x] Tests