### PR TITLE
configure.ac: fix Autoconf 2.70 deprecation warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.61)
+AC_PREREQ(2.69)
 AC_INIT([OpenSlide], [3.4.1], [openslide-users@lists.andrew.cmu.edu], [openslide], [https://openslide.org])
 AC_CONFIG_SRCDIR([src])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign subdir-objects 1.11.1 dist-xz])
 AM_SILENT_RULES([yes])
 AC_CONFIG_MACRO_DIR([m4])
@@ -15,7 +15,7 @@ AC_CANONICAL_HOST
 
 # Checks for programs.
 AM_PROG_CC_C_O
-AC_PROG_CC_C99
+AC_PROG_CC
 
 # Largefile
 AC_SYS_LARGEFILE

--- a/m4/visibility.m4
+++ b/m4/visibility.m4
@@ -1,5 +1,5 @@
-# visibility.m4 serial 1 (gettext-0.15)
-dnl Copyright (C) 2005 Free Software Foundation, Inc.
+# visibility.m4 serial 8
+dnl Copyright (C) 2005, 2008, 2010-2021 Free Software Foundation, Inc.
 dnl This file is free software; the Free Software Foundation
 dnl gives unlimited permission to copy and/or distribute it,
 dnl with or without modifications, as long as this notice is preserved.
@@ -12,7 +12,7 @@ dnl __attribute__((__visibility__("hidden"))) and
 dnl __attribute__((__visibility__("default"))).
 dnl Does *not* test for __visibility__("protected") - which has tricky
 dnl semantics (see the 'vismain' test in glibc) and does not exist e.g. on
-dnl MacOS X.
+dnl Mac OS X.
 dnl Does *not* test for __visibility__("internal") - which has processor
 dnl dependent semantics.
 dnl Does *not* test for #pragma GCC visibility push(hidden) - which is
@@ -26,20 +26,50 @@ AC_DEFUN([gl_VISIBILITY],
   CFLAG_VISIBILITY=
   HAVE_VISIBILITY=0
   if test -n "$GCC"; then
-    AC_MSG_CHECKING([for simple visibility declarations])
-    AC_CACHE_VAL(gl_cv_cc_visibility, [
-      gl_save_CFLAGS="$CFLAGS"
-      CFLAGS="$CFLAGS -fvisibility=hidden -Werror"
-      AC_TRY_COMPILE(
-        [extern __attribute__((__visibility__("hidden"))) int hiddenvar;
-         extern __attribute__((__visibility__("default"))) int exportedvar;
-         extern __attribute__((__visibility__("hidden"))) int hiddenfunc (void);
-         extern __attribute__((__visibility__("default"))) int exportedfunc (void);],
-        [],
-        gl_cv_cc_visibility=yes,
-        gl_cv_cc_visibility=no)
-      CFLAGS="$gl_save_CFLAGS"])
-    AC_MSG_RESULT([$gl_cv_cc_visibility])
+    dnl First, check whether -Werror can be added to the command line, or
+    dnl whether it leads to an error because of some other option that the
+    dnl user has put into $CC $CFLAGS $CPPFLAGS.
+    AC_CACHE_CHECK([whether the -Werror option is usable],
+      [gl_cv_cc_vis_werror],
+      [gl_save_CFLAGS="$CFLAGS"
+       CFLAGS="$CFLAGS -Werror"
+       AC_COMPILE_IFELSE(
+         [AC_LANG_PROGRAM([[]], [[]])],
+         [gl_cv_cc_vis_werror=yes],
+         [gl_cv_cc_vis_werror=no])
+       CFLAGS="$gl_save_CFLAGS"
+      ])
+    dnl Now check whether visibility declarations are supported.
+    AC_CACHE_CHECK([for simple visibility declarations],
+      [gl_cv_cc_visibility],
+      [gl_save_CFLAGS="$CFLAGS"
+       CFLAGS="$CFLAGS -fvisibility=hidden"
+       dnl We use the option -Werror and a function dummyfunc, because on some
+       dnl platforms (Cygwin 1.7) the use of -fvisibility triggers a warning
+       dnl "visibility attribute not supported in this configuration; ignored"
+       dnl at the first function definition in every compilation unit, and we
+       dnl don't want to use the option in this case.
+       if test $gl_cv_cc_vis_werror = yes; then
+         CFLAGS="$CFLAGS -Werror"
+       fi
+       AC_COMPILE_IFELSE(
+         [AC_LANG_PROGRAM(
+            [[extern __attribute__((__visibility__("hidden"))) int hiddenvar;
+              extern __attribute__((__visibility__("default"))) int exportedvar;
+              extern __attribute__((__visibility__("hidden"))) int hiddenfunc (void);
+              extern __attribute__((__visibility__("default"))) int exportedfunc (void);
+              void dummyfunc (void);
+              int hiddenvar;
+              int exportedvar;
+              int hiddenfunc (void) { return 51; }
+              int exportedfunc (void) { return 1225736919; }
+              void dummyfunc (void) {}
+            ]],
+            [[]])],
+         [gl_cv_cc_visibility=yes],
+         [gl_cv_cc_visibility=no])
+       CFLAGS="$gl_save_CFLAGS"
+      ])
     if test $gl_cv_cc_visibility = yes; then
       CFLAG_VISIBILITY="-fvisibility=hidden"
       HAVE_VISIBILITY=1

--- a/m4/warnings.m4
+++ b/m4/warnings.m4
@@ -1,5 +1,5 @@
-# warnings.m4 serial 11
-dnl Copyright (C) 2008-2016 Free Software Foundation, Inc.
+# warnings.m4 serial 16
+dnl Copyright (C) 2008-2021 Free Software Foundation, Inc.
 dnl This file is free software; the Free Software Foundation
 dnl gives unlimited permission to copy and/or distribute it,
 dnl with or without modifications, as long as this notice is preserved.
@@ -20,10 +20,10 @@ m4_ifdef([AS_VAR_APPEND],
 # -----------------------------------------------------------------
 # Check if the compiler supports OPTION when compiling PROGRAM.
 #
-# FIXME: gl_Warn must be used unquoted until we can assume Autoconf
-# 2.64 or newer.
+# The effects of this macro depend on the current language (_AC_LANG).
 AC_DEFUN([gl_COMPILER_OPTION_IF],
-[AS_VAR_PUSHDEF([gl_Warn], [gl_cv_warn_[]_AC_LANG_ABBREV[]_$1])dnl
+[
+AS_VAR_PUSHDEF([gl_Warn], [gl_cv_warn_[]_AC_LANG_ABBREV[]_$1])dnl
 AS_VAR_PUSHDEF([gl_Flags], [_AC_LANG_PREFIX[]FLAGS])dnl
 AS_LITERAL_IF([$1],
   [m4_pushdef([gl_Positive], m4_bpatsubst([$1], [^-Wno-], [-W]))],
@@ -32,13 +32,13 @@ case $gl_positive in
   -Wno-*) gl_positive=-W`expr "X$gl_positive" : 'X-Wno-\(.*\)'` ;;
 esac
 m4_pushdef([gl_Positive], [$gl_positive])])dnl
-AC_CACHE_CHECK([whether _AC_LANG compiler handles $1], m4_defn([gl_Warn]), [
+AC_CACHE_CHECK([whether _AC_LANG compiler handles $1], [gl_Warn], [
   gl_save_compiler_FLAGS="$gl_Flags"
   gl_AS_VAR_APPEND(m4_defn([gl_Flags]),
     [" $gl_unknown_warnings_are_errors ]m4_defn([gl_Positive])["])
-  AC_LINK_IFELSE([m4_default([$4], [AC_LANG_PROGRAM([])])],
-                 [AS_VAR_SET(gl_Warn, [yes])],
-                 [AS_VAR_SET(gl_Warn, [no])])
+  AC_LINK_IFELSE([m4_default([$4], [AC_LANG_PROGRAM([[]])])],
+                 [AS_VAR_SET([gl_Warn], [yes])],
+                 [AS_VAR_SET([gl_Warn], [no])])
   gl_Flags="$gl_save_compiler_FLAGS"
 ])
 AS_VAR_IF(gl_Warn, [yes], [$2], [$3])
@@ -51,27 +51,58 @@ AS_VAR_POPDEF([gl_Warn])dnl
 # ------------------------------
 # Clang doesn't complain about unknown warning options unless one also
 # specifies -Wunknown-warning-option -Werror.  Detect this.
+#
+# The effects of this macro depend on the current language (_AC_LANG).
 AC_DEFUN([gl_UNKNOWN_WARNINGS_ARE_ERRORS],
+[_AC_LANG_DISPATCH([$0], _AC_LANG, $@)])
+
+# Specialization for _AC_LANG = C. This macro can be AC_REQUIREd.
+AC_DEFUN([gl_UNKNOWN_WARNINGS_ARE_ERRORS(C)],
+[
+  AC_LANG_PUSH([C])
+  gl_UNKNOWN_WARNINGS_ARE_ERRORS_IMPL
+  AC_LANG_POP([C])
+])
+
+# Specialization for _AC_LANG = C++. This macro can be AC_REQUIREd.
+AC_DEFUN([gl_UNKNOWN_WARNINGS_ARE_ERRORS(C++)],
+[
+  AC_LANG_PUSH([C++])
+  gl_UNKNOWN_WARNINGS_ARE_ERRORS_IMPL
+  AC_LANG_POP([C++])
+])
+
+# Specialization for _AC_LANG = Objective C. This macro can be AC_REQUIREd.
+AC_DEFUN([gl_UNKNOWN_WARNINGS_ARE_ERRORS(Objective C)],
+[
+  AC_LANG_PUSH([Objective C])
+  gl_UNKNOWN_WARNINGS_ARE_ERRORS_IMPL
+  AC_LANG_POP([Objective C])
+])
+
+AC_DEFUN([gl_UNKNOWN_WARNINGS_ARE_ERRORS_IMPL],
 [gl_COMPILER_OPTION_IF([-Werror -Wunknown-warning-option],
    [gl_unknown_warnings_are_errors='-Wunknown-warning-option -Werror'],
    [gl_unknown_warnings_are_errors=])])
 
-# gl_WARN_ADD(OPTION, [VARIABLE = WARN_CFLAGS],
+# gl_WARN_ADD(OPTION, [VARIABLE = WARN_CFLAGS/WARN_CXXFLAGS],
 #             [PROGRAM = AC_LANG_PROGRAM()])
-# ---------------------------------------------
-# Adds parameter to WARN_CFLAGS if the compiler supports it when
-# compiling PROGRAM.  For example, gl_WARN_ADD([-Wparentheses]).
+# -----------------------------------------------------------
+# Adds parameter to WARN_CFLAGS/WARN_CXXFLAGS if the compiler supports it
+# when compiling PROGRAM.  For example, gl_WARN_ADD([-Wparentheses]).
 #
 # If VARIABLE is a variable name, AC_SUBST it.
+#
+# The effects of this macro depend on the current language (_AC_LANG).
 AC_DEFUN([gl_WARN_ADD],
-[AC_REQUIRE([gl_UNKNOWN_WARNINGS_ARE_ERRORS])
+[AC_REQUIRE([gl_UNKNOWN_WARNINGS_ARE_ERRORS(]_AC_LANG[)])
 gl_COMPILER_OPTION_IF([$1],
-  [gl_AS_VAR_APPEND(m4_if([$2], [], [[WARN_CFLAGS]], [[$2]]), [" $1"])],
+  [gl_AS_VAR_APPEND(m4_if([$2], [], [[WARN_]_AC_LANG_PREFIX[FLAGS]], [[$2]]), [" $1"])],
   [],
   [$3])
 m4_ifval([$2],
          [AS_LITERAL_IF([$2], [AC_SUBST([$2])])],
-         [AC_SUBST([WARN_CFLAGS])])dnl
+         [AC_SUBST([WARN_]_AC_LANG_PREFIX[FLAGS])])dnl
 ])
 
 # Local Variables:


### PR DESCRIPTION
Autoconf 2.69 was released in 2012; bump the minimum version to that since we don't test on earlier ones.