### PR TITLE
test/extended: fix missing include on Windows

### DIFF
--- a/test/extended.c
+++ b/test/extended.c
@@ -22,11 +22,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <unistd.h>
 #include <inttypes.h>
 
 #ifndef WIN32
 #include <sys/types.h>
-#include <unistd.h>
 #include <fcntl.h>
 #endif
 


### PR DESCRIPTION
`sleep(3)` requires `unistd.h`.