### PR TITLE
test/driver: fix test case unpacking on macOS

### DIFF
--- a/test/driver.in
+++ b/test/driver.in
@@ -467,7 +467,8 @@ def _try_reflink(inpath, outpath):
         except FileNotFoundError:
             pass
     elif system == 'Darwin':
-        if subprocess.call(['cp', '-c', inpath, outpath], stderr=DEVNULL) == 0:
+        if subprocess.call(['cp', '-c', inpath, outpath],
+                stderr=subprocess.DEVNULL) == 0:
             return True
     # If we fail once, don't try again.  It's possible that we might succeed
     # under other circumstances (e.g. inpath and outpath might be on different


### PR DESCRIPTION
This got through CI because CI was only unpacking a frozen archive, and not unpacking any tests from scratch.

Fixes #362.