### PR TITLE
Fix synthetic test on Windows, and also CI

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -137,8 +137,8 @@ jobs:
     needs: windows_setup
     uses: openslide/openslide-winbuild/.github/workflows/windows.yml@main
     with:
-      openslide_repo: openslide/openslide
-      openslide_ref: main
+      openslide_repo: ${{ github.repository }}
+      openslide_ref: ${{ github.ref }}
       pkgver: ${{ needs.windows_setup.outputs.pkgver }}
       werror: true
 

--- a/test/synth.c
+++ b/test/synth.c
@@ -26,7 +26,7 @@
 
 int main(int argc, char **argv) {
   if (argc < 2 || !g_str_equal(argv[1], "child")) {
-    setenv("OPENSLIDE_DEBUG", "synthetic", 1);
+    putenv("OPENSLIDE_DEBUG=synthetic");
     // OpenSlide already evaluated debug flags, so we need to rerun
     // ourselves.  Do it in a cross-platform way.
     char *child_argv[] = {argv[0], "child", NULL};


### PR DESCRIPTION
`putenv()` is available but `setenv()` [isn't](https://sourceforge.net/p/mingw/mailman/message/35495004/).

Windows CI didn't catch this because it was always building `main` instead of the actual PR content.  Fix that too.