### PR TITLE
test/synth: define `_XOPEN_SOURCE`

### DIFF
--- a/test/synth.c
+++ b/test/synth.c
@@ -19,6 +19,9 @@
  *
  */
 
+// for putenv
+#define _XOPEN_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <glib.h>


### PR DESCRIPTION
On some systems this is necessary to get the prototype for `putenv()`.