### PR TITLE
Use wrapper functions for all file I/O

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ src_libopenslide_la_SOURCES = \
 	src/openslide-decode-tifflike.c \
 	src/openslide-decode-xml.c \
 	src/openslide-error.c \
+	src/openslide-file.c \
 	src/openslide-grid.c \
 	src/openslide-hash.c \
 	src/openslide-jdatasrc.c \

--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -167,7 +167,7 @@ DONE:
 }
 
 static size_t file_read_callback(void *out, void *in, size_t size) {
-  return fread(out, 1, size, in);
+  return _openslide_fread(in, out, size);
 }
 
 bool _openslide_gdkpixbuf_read(const char *format,
@@ -177,18 +177,18 @@ bool _openslide_gdkpixbuf_read(const char *format,
                                uint32_t *dest,
                                int32_t w, int32_t h,
                                GError **err) {
-  FILE *f = _openslide_fopen(filename, err);
+  struct _openslide_file *f = _openslide_fopen(filename, err);
   if (!f) {
     return false;
   }
-  if (fseeko(f, offset, SEEK_SET)) {
+  if (_openslide_fseek(f, offset, SEEK_SET)) {
     _openslide_io_error(err, "Couldn't fseek %s", filename);
-    fclose(f);
+    _openslide_fclose(f);
     return false;
   }
   bool ret = gdkpixbuf_read(format, file_read_callback, f, length,
                             dest, w, h, err);
-  fclose(f);
+  _openslide_fclose(f);
   return ret;
 }
 

--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -177,7 +177,7 @@ bool _openslide_gdkpixbuf_read(const char *format,
                                uint32_t *dest,
                                int32_t w, int32_t h,
                                GError **err) {
-  FILE *f = _openslide_fopen(filename, "rb", err);
+  FILE *f = _openslide_fopen(filename, err);
   if (!f) {
     return false;
   }

--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -181,8 +181,8 @@ bool _openslide_gdkpixbuf_read(const char *format,
   if (!f) {
     return false;
   }
-  if (_openslide_fseek(f, offset, SEEK_SET)) {
-    _openslide_io_error(err, "Couldn't fseek %s", filename);
+  if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
+    g_prefix_error(err, "Couldn't fseek %s: ", filename);
     _openslide_fclose(f);
     return false;
   }

--- a/src/openslide-decode-jpeg.c
+++ b/src/openslide-decode-jpeg.c
@@ -324,8 +324,8 @@ bool _openslide_jpeg_read_dimensions(const char *filename,
   if (f == NULL) {
     return false;
   }
-  if (offset && _openslide_fseek(f, offset, SEEK_SET) == -1) {
-    _openslide_io_error(err, "Cannot seek to offset");
+  if (offset && !_openslide_fseek(f, offset, SEEK_SET, err)) {
+    g_prefix_error(err, "Cannot seek to offset: ");
     _openslide_fclose(f);
     return false;
   }
@@ -398,8 +398,8 @@ bool _openslide_jpeg_read(const char *filename,
   if (f == NULL) {
     return false;
   }
-  if (offset && _openslide_fseek(f, offset, SEEK_SET) == -1) {
-    _openslide_io_error(err, "Cannot seek to offset");
+  if (offset && !_openslide_fseek(f, offset, SEEK_SET, err)) {
+    g_prefix_error(err, "Cannot seek to offset: ");
     _openslide_fclose(f);
     return false;
   }

--- a/src/openslide-decode-jpeg.c
+++ b/src/openslide-decode-jpeg.c
@@ -320,7 +320,7 @@ bool _openslide_jpeg_read_dimensions(const char *filename,
                                      int64_t offset,
                                      int32_t *w, int32_t *h,
                                      GError **err) {
-  FILE *f = _openslide_fopen(filename, "rb", err);
+  FILE *f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return false;
   }
@@ -394,7 +394,7 @@ bool _openslide_jpeg_read(const char *filename,
                           GError **err) {
   //g_debug("read JPEG: %s %"PRId64, filename, offset);
 
-  FILE *f = _openslide_fopen(filename, "rb", err);
+  FILE *f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return false;
   }

--- a/src/openslide-decode-jpeg.c
+++ b/src/openslide-decode-jpeg.c
@@ -273,7 +273,7 @@ void _openslide_jpeg_decompress_destroy(struct _openslide_jpeg_decompress *dc) {
   g_slice_free(struct _openslide_jpeg_decompress, dc);
 }
 
-static bool jpeg_get_dimensions(FILE *f,  // or:
+static bool jpeg_get_dimensions(struct _openslide_file *f,  // or:
                                 const void *buf, uint32_t buflen,
                                 int32_t *w, int32_t *h,
                                 GError **err) {
@@ -320,19 +320,19 @@ bool _openslide_jpeg_read_dimensions(const char *filename,
                                      int64_t offset,
                                      int32_t *w, int32_t *h,
                                      GError **err) {
-  FILE *f = _openslide_fopen(filename, err);
+  struct _openslide_file *f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return false;
   }
-  if (offset && fseeko(f, offset, SEEK_SET) == -1) {
+  if (offset && _openslide_fseek(f, offset, SEEK_SET) == -1) {
     _openslide_io_error(err, "Cannot seek to offset");
-    fclose(f);
+    _openslide_fclose(f);
     return false;
   }
 
   bool success = jpeg_get_dimensions(f, NULL, 0, w, h, err);
 
-  fclose(f);
+  _openslide_fclose(f);
   return success;
 }
 
@@ -342,7 +342,7 @@ bool _openslide_jpeg_decode_buffer_dimensions(const void *buf, uint32_t len,
   return jpeg_get_dimensions(NULL, buf, len, w, h, err);
 }
 
-static bool jpeg_decode(FILE *f,  // or:
+static bool jpeg_decode(struct _openslide_file *f,  // or:
                         const void *buf, uint32_t buflen,
                         void *dest, bool grayscale,
                         int32_t w, int32_t h,
@@ -394,19 +394,19 @@ bool _openslide_jpeg_read(const char *filename,
                           GError **err) {
   //g_debug("read JPEG: %s %"PRId64, filename, offset);
 
-  FILE *f = _openslide_fopen(filename, err);
+  struct _openslide_file *f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return false;
   }
-  if (offset && fseeko(f, offset, SEEK_SET) == -1) {
+  if (offset && _openslide_fseek(f, offset, SEEK_SET) == -1) {
     _openslide_io_error(err, "Cannot seek to offset");
-    fclose(f);
+    _openslide_fclose(f);
     return false;
   }
 
   bool success = jpeg_decode(f, NULL, 0, dest, false, w, h, err);
 
-  fclose(f);
+  _openslide_fclose(f);
   return success;
 }
 

--- a/src/openslide-decode-jpeg.h
+++ b/src/openslide-decode-jpeg.h
@@ -68,7 +68,8 @@ bool _openslide_jpeg_add_associated_image(openslide_t *osr,
  * On Windows, we cannot fopen a file and pass it to another DLL that does fread.
  * So we need to compile all our freading into the OpenSlide DLL directly.
  */
-void _openslide_jpeg_stdio_src(j_decompress_ptr cinfo, FILE *infile);
+void _openslide_jpeg_stdio_src(j_decompress_ptr cinfo,
+                               struct _openslide_file *infile);
 
 /*
  * Some libjpegs don't provide mem_src, so we have our own copy.

--- a/src/openslide-decode-png.c
+++ b/src/openslide-decode-png.c
@@ -179,8 +179,8 @@ bool _openslide_png_read(const char *filename,
   if (!f) {
     return false;
   }
-  if (_openslide_fseek(f, offset, SEEK_SET)) {
-    _openslide_io_error(err, "Couldn't fseek %s", filename);
+  if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
+    g_prefix_error(err, "Couldn't fseek %s: ", filename);
     _openslide_fclose(f);
     return false;
   }

--- a/src/openslide-decode-png.c
+++ b/src/openslide-decode-png.c
@@ -175,7 +175,7 @@ bool _openslide_png_read(const char *filename,
                          uint32_t *dest,
                          int64_t w, int64_t h,
                          GError **err) {
-  FILE *f = _openslide_fopen(filename, "rb", err);
+  FILE *f = _openslide_fopen(filename, err);
   if (!f) {
     return false;
   }

--- a/src/openslide-decode-png.c
+++ b/src/openslide-decode-png.c
@@ -164,8 +164,8 @@ DONE:
 }
 
 static void file_read_callback(png_struct *png, png_byte *buf, png_size_t len) {
-  FILE *f = png_get_io_ptr(png);
-  if (fread(buf, len, 1, f) != 1) {
+  struct _openslide_file *f = png_get_io_ptr(png);
+  if (_openslide_fread(f, buf, len) != len) {
     png_error(png, "Read failed");
   }
 }
@@ -175,17 +175,17 @@ bool _openslide_png_read(const char *filename,
                          uint32_t *dest,
                          int64_t w, int64_t h,
                          GError **err) {
-  FILE *f = _openslide_fopen(filename, err);
+  struct _openslide_file *f = _openslide_fopen(filename, err);
   if (!f) {
     return false;
   }
-  if (fseeko(f, offset, SEEK_SET)) {
+  if (_openslide_fseek(f, offset, SEEK_SET)) {
     _openslide_io_error(err, "Couldn't fseek %s", filename);
-    fclose(f);
+    _openslide_fclose(f);
     return false;
   }
   bool ret = png_read(file_read_callback, f, dest, w, h, err);
-  fclose(f);
+  _openslide_fclose(f);
   return ret;
 }
 

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -501,7 +501,7 @@ static tsize_t tiff_do_read(thandle_t th, tdata_t buf, tsize_t size) {
 
   // don't leave the file handle open between calls
   // also ensures FD_CLOEXEC is set
-  FILE *f = _openslide_fopen(hdl->tc->filename, "rb", NULL);
+  FILE *f = _openslide_fopen(hdl->tc->filename, NULL);
   if (f == NULL) {
     return 0;
   }
@@ -557,7 +557,7 @@ static toff_t tiff_do_size(thandle_t th) {
 #undef TIFFClientOpen
 static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
   // open
-  FILE *f = _openslide_fopen(tc->filename, "rb", err);
+  FILE *f = _openslide_fopen(tc->filename, err);
   if (f == NULL) {
     return NULL;
   }

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -505,7 +505,7 @@ static tsize_t tiff_do_read(thandle_t th, tdata_t buf, tsize_t size) {
   if (f == NULL) {
     return 0;
   }
-  if (_openslide_fseek(f, hdl->offset, SEEK_SET)) {
+  if (!_openslide_fseek(f, hdl->offset, SEEK_SET, NULL)) {
     _openslide_fclose(f);
     return 0;
   }
@@ -573,8 +573,8 @@ static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
   }
 
   // get size
-  if (_openslide_fseek(f, 0, SEEK_END) == -1) {
-    _openslide_io_error(err, "Couldn't seek to end of %s", tc->filename);
+  if (!_openslide_fseek(f, 0, SEEK_END, err)) {
+    g_prefix_error(err, "Couldn't seek to end of %s: ", tc->filename);
     _openslide_fclose(f);
     return NULL;
   }

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -573,14 +573,9 @@ static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
   }
 
   // get size
-  if (!_openslide_fseek(f, 0, SEEK_END, err)) {
-    g_prefix_error(err, "Couldn't seek to end of %s: ", tc->filename);
-    _openslide_fclose(f);
-    return NULL;
-  }
-  int64_t size = _openslide_ftell(f, err);
+  int64_t size = _openslide_fsize(f, err);
   if (size == -1) {
-    g_prefix_error(err, "Couldn't _openslide_ftell() for %s: ", tc->filename);
+    g_prefix_error(err, "Couldn't get size of %s: ", tc->filename);
     _openslide_fclose(f);
     return NULL;
   }

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -578,9 +578,9 @@ static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
     _openslide_fclose(f);
     return NULL;
   }
-  int64_t size = _openslide_ftell(f);
+  int64_t size = _openslide_ftell(f, err);
   if (size == -1) {
-    _openslide_io_error(err, "Couldn't _openslide_ftell() for %s", tc->filename);
+    g_prefix_error(err, "Couldn't _openslide_ftell() for %s: ", tc->filename);
     _openslide_fclose(f);
     return NULL;
   }

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -350,8 +350,8 @@ static bool populate_item(struct _openslide_tifflike *tl,
   }
 
   //g_debug("reading tiff value: len: %"PRId64", offset %"PRIu64, len, item->offset);
-  if (_openslide_fseek(f, item->offset, SEEK_SET)) {
-    _openslide_io_error(err, "Couldn't seek to read TIFF value");
+  if (!_openslide_fseek(f, item->offset, SEEK_SET, err)) {
+    g_prefix_error(err, "Couldn't seek to read TIFF value: ");
     goto FAIL;
   }
   if (_openslide_fread(f, buf, len) != (size_t) len) {
@@ -427,8 +427,8 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
   g_hash_table_insert(loop_detector, key, NULL);
 
   // no loop, let's seek
-  if (_openslide_fseek(f, off, SEEK_SET) != 0) {
-    _openslide_io_error(err, "Cannot seek to offset");
+  if (!_openslide_fseek(f, off, SEEK_SET, err)) {
+    g_prefix_error(err, "Cannot seek to offset: ");
     goto FAIL;
   }
 

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -331,7 +331,7 @@ static bool populate_item(struct _openslide_tifflike *tl,
     return true;
   }
 
-  FILE *f = _openslide_fopen(tl->filename, "rb", err);
+  FILE *f = _openslide_fopen(tl->filename, err);
   if (!f) {
     goto FAIL;
   }
@@ -550,7 +550,7 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   GHashTable *loop_detector = NULL;
 
   // open file
-  FILE *f = _openslide_fopen(filename, "rb", err);
+  FILE *f = _openslide_fopen(filename, err);
   if (!f) {
     goto FAIL;
   }

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -97,11 +97,12 @@ static void fix_byte_order(void *data, int32_t size, int64_t count,
 }
 
 // only sets *ok on failure
-static uint64_t read_uint(FILE *f, int32_t size, bool big_endian, bool *ok) {
+static uint64_t read_uint(struct _openslide_file *f, int32_t size,
+                          bool big_endian, bool *ok) {
   g_assert(ok != NULL);
 
   uint8_t buf[size];
-  if (fread(buf, size, 1, f) != 1) {
+  if (_openslide_fread(f, buf, size) != (size_t) size) {
     *ok = false;
     return 0;
   }
@@ -331,7 +332,7 @@ static bool populate_item(struct _openslide_tifflike *tl,
     return true;
   }
 
-  FILE *f = _openslide_fopen(tl->filename, err);
+  struct _openslide_file *f = _openslide_fopen(tl->filename, err);
   if (!f) {
     goto FAIL;
   }
@@ -349,11 +350,11 @@ static bool populate_item(struct _openslide_tifflike *tl,
   }
 
   //g_debug("reading tiff value: len: %"PRId64", offset %"PRIu64, len, item->offset);
-  if (fseeko(f, item->offset, SEEK_SET)) {
+  if (_openslide_fseek(f, item->offset, SEEK_SET)) {
     _openslide_io_error(err, "Couldn't seek to read TIFF value");
     goto FAIL;
   }
-  if (fread(buf, len, 1, f) != 1) {
+  if (_openslide_fread(f, buf, len) != (size_t) len) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Couldn't read TIFF value");
     goto FAIL;
@@ -370,7 +371,7 @@ FAIL:
   g_mutex_unlock(&tl->value_lock);
   g_free(buf);
   if (f) {
-    fclose(f);
+    _openslide_fclose(f);
   }
   return success;
 }
@@ -393,7 +394,8 @@ static void tiff_item_destroy(gpointer data) {
   g_slice_free(struct tiff_item, item);
 }
 
-static struct tiff_directory *read_directory(FILE *f, int64_t *diroff,
+static struct tiff_directory *read_directory(struct _openslide_file *f,
+                                             int64_t *diroff,
                                              struct tiff_directory *first_dir,
                                              GHashTable *loop_detector,
                                              bool bigtiff,
@@ -425,7 +427,7 @@ static struct tiff_directory *read_directory(FILE *f, int64_t *diroff,
   g_hash_table_insert(loop_detector, key, NULL);
 
   // no loop, let's seek
-  if (fseeko(f, off, SEEK_SET) != 0) {
+  if (_openslide_fseek(f, off, SEEK_SET) != 0) {
     _openslide_io_error(err, "Cannot seek to offset");
     goto FAIL;
   }
@@ -484,7 +486,7 @@ static struct tiff_directory *read_directory(FILE *f, int64_t *diroff,
 
     // read in the value/offset
     uint8_t value[bigtiff ? 8 : 4];
-    if (fread(value, sizeof(value), 1, f) != 1) {
+    if (_openslide_fread(f, value, sizeof(value)) != sizeof(value)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Cannot read value/offset");
       goto FAIL;
@@ -550,14 +552,14 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   GHashTable *loop_detector = NULL;
 
   // open file
-  FILE *f = _openslide_fopen(filename, err);
+  struct _openslide_file *f = _openslide_fopen(filename, err);
   if (!f) {
     goto FAIL;
   }
 
   // read and check magic
   uint16_t magic;
-  if (fread(&magic, sizeof magic, 1, f) != 1) {
+  if (_openslide_fread(f, &magic, sizeof magic) != sizeof magic) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Can't read TIFF magic number");
     goto FAIL;
@@ -685,7 +687,7 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   }
 
   g_hash_table_unref(loop_detector);
-  fclose(f);
+  _openslide_fclose(f);
   return tl;
 
 FAIL:
@@ -694,7 +696,7 @@ FAIL:
     g_hash_table_unref(loop_detector);
   }
   if (f) {
-    fclose(f);
+    _openslide_fclose(f);
   }
   return NULL;
 }

--- a/src/openslide-error.c
+++ b/src/openslide-error.c
@@ -25,8 +25,6 @@
 #include "openslide-error.h"
 
 #include <glib.h>
-#include <stdarg.h>
-#include <errno.h>
 
 // public error functions
 const char *openslide_get_error(openslide_t *osr) {
@@ -47,18 +45,6 @@ void _openslide_propagate_error(openslide_t *osr, GError *err) {
 // internal error propagation
 GQuark _openslide_error_quark(void) {
   return g_quark_from_string("openslide-error-quark");
-}
-
-void _openslide_io_error(GError **err, const char *fmt, ...) {
-  int my_errno = errno;
-  va_list ap;
-
-  va_start(ap, fmt);
-  char *msg = g_strdup_vprintf(fmt, ap);
-  g_set_error(err, G_FILE_ERROR, g_file_error_from_errno(my_errno),
-              "%s: %s", msg, g_strerror(my_errno));
-  g_free(msg);
-  va_end(ap);
 }
 
 bool _openslide_check_cairo_status(cairo_t *cr, GError **err) {

--- a/src/openslide-file.c
+++ b/src/openslide-file.c
@@ -158,6 +158,6 @@ void _openslide_fclose(struct _openslide_file *file) {
   g_slice_free(struct _openslide_file, file);
 }
 
-bool _openslide_fexists(const char *path) {
+bool _openslide_fexists(const char *path, GError **err G_GNUC_UNUSED) {
   return g_file_test(path, G_FILE_TEST_EXISTS);
 }

--- a/src/openslide-file.c
+++ b/src/openslide-file.c
@@ -66,11 +66,9 @@ static FILE *do_fopen(const char *path, const char *mode, GError **err) {
 }
 #define fopen _OPENSLIDE_POISON(_openslide_fopen)
 
-FILE *_openslide_fopen(const char *path, const char *mode, GError **err)
+FILE *_openslide_fopen(const char *path, GError **err)
 {
-  char *m = g_strconcat(mode, FOPEN_CLOEXEC_FLAG, NULL);
-  FILE *f = do_fopen(path, m, err);
-  g_free(m);
+  FILE *f = do_fopen(path, "rb" FOPEN_CLOEXEC_FLAG, err);
   if (f == NULL) {
     return NULL;
   }

--- a/src/openslide-file.c
+++ b/src/openslide-file.c
@@ -1,0 +1,102 @@
+/*
+ *  OpenSlide, a library for reading whole slide image files
+ *
+ *  Copyright (c) 2007-2015 Carnegie Mellon University
+ *  Copyright (c) 2015 Benjamin Gilbert
+ *  All rights reserved.
+ *
+ *  OpenSlide is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, version 2.1.
+ *
+ *  OpenSlide is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with OpenSlide. If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <config.h>
+
+#include "openslide-private.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <glib.h>
+
+#ifdef HAVE_FCNTL
+#include <unistd.h>
+#include <fcntl.h>
+#endif
+
+#undef fopen
+static FILE *do_fopen(const char *path, const char *mode, GError **err) {
+  FILE *f;
+
+#ifdef HAVE__WFOPEN
+  wchar_t *path16 = (wchar_t *) g_utf8_to_utf16(path, -1, NULL, NULL, err);
+  if (path16 == NULL) {
+    g_prefix_error(err, "Couldn't open %s: ", path);
+    return NULL;
+  }
+  wchar_t *mode16 = (wchar_t *) g_utf8_to_utf16(mode, -1, NULL, NULL, err);
+  if (mode16 == NULL) {
+    g_prefix_error(err, "Bad file mode %s: ", mode);
+    g_free(path16);
+    return NULL;
+  }
+  f = _wfopen(path16, mode16);
+  if (f == NULL) {
+    _openslide_io_error(err, "Couldn't open %s", path);
+  }
+  g_free(mode16);
+  g_free(path16);
+#else
+  f = fopen(path, mode);
+  if (f == NULL) {
+    _openslide_io_error(err, "Couldn't open %s", path);
+  }
+#endif
+
+  return f;
+}
+#define fopen _OPENSLIDE_POISON(_openslide_fopen)
+
+FILE *_openslide_fopen(const char *path, const char *mode, GError **err)
+{
+  char *m = g_strconcat(mode, FOPEN_CLOEXEC_FLAG, NULL);
+  FILE *f = do_fopen(path, m, err);
+  g_free(m);
+  if (f == NULL) {
+    return NULL;
+  }
+
+  /* Unnecessary if FOPEN_CLOEXEC_FLAG is non-empty.  Not built on Windows. */
+#ifdef HAVE_FCNTL
+  if (!FOPEN_CLOEXEC_FLAG[0]) {
+    int fd = fileno(f);
+    if (fd == -1) {
+      _openslide_io_error(err, "Couldn't fileno() %s", path);
+      fclose(f);
+      return NULL;
+    }
+    long flags = fcntl(fd, F_GETFD);
+    if (flags == -1) {
+      _openslide_io_error(err, "Couldn't F_GETFD %s", path);
+      fclose(f);
+      return NULL;
+    }
+    if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC)) {
+      _openslide_io_error(err, "Couldn't F_SETFD %s", path);
+      fclose(f);
+      return NULL;
+    }
+  }
+#endif
+
+  return f;
+}

--- a/src/openslide-file.c
+++ b/src/openslide-file.c
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 #include <glib.h>
 
 #ifdef HAVE_FCNTL
@@ -120,8 +121,14 @@ size_t _openslide_fread(struct _openslide_file *file, void *buf, size_t size) {
   return total;
 }
 
-int _openslide_fseek(struct _openslide_file *file, off_t offset, int whence) {
-  return fseeko(file->fp, offset, whence);
+bool _openslide_fseek(struct _openslide_file *file, off_t offset, int whence,
+                      GError **err) {
+  if (fseeko(file->fp, offset, whence)) {
+    g_set_error(err, G_FILE_ERROR, g_file_error_from_errno(errno),
+                "%s", g_strerror(errno));
+    return false;
+  }
+  return true;
 }
 
 off_t _openslide_ftell(struct _openslide_file *file) {

--- a/src/openslide-file.c
+++ b/src/openslide-file.c
@@ -153,6 +153,24 @@ off_t _openslide_ftell(struct _openslide_file *file, GError **err) {
   return ret;
 }
 
+off_t _openslide_fsize(struct _openslide_file *file, GError **err) {
+  off_t orig = _openslide_ftell(file, err);
+  if (orig == -1) {
+    return -1;
+  }
+  if (!_openslide_fseek(file, 0, SEEK_END, err)) {
+    return -1;
+  }
+  off_t ret = _openslide_ftell(file, err);
+  if (ret == -1) {
+    return -1;
+  }
+  if (!_openslide_fseek(file, orig, SEEK_SET, err)) {
+    return -1;
+  }
+  return ret;
+}
+
 void _openslide_fclose(struct _openslide_file *file) {
   fclose(file->fp);
   g_slice_free(struct _openslide_file, file);

--- a/src/openslide-file.c
+++ b/src/openslide-file.c
@@ -131,8 +131,13 @@ bool _openslide_fseek(struct _openslide_file *file, off_t offset, int whence,
   return true;
 }
 
-off_t _openslide_ftell(struct _openslide_file *file) {
-  return ftello(file->fp);
+off_t _openslide_ftell(struct _openslide_file *file, GError **err) {
+  off_t ret = ftello(file->fp);
+  if (ret == -1) {
+    g_set_error(err, G_FILE_ERROR, g_file_error_from_errno(errno),
+                "%s", g_strerror(errno));
+  }
+  return ret;
 }
 
 void _openslide_fclose(struct _openslide_file *file) {

--- a/src/openslide-hash.c
+++ b/src/openslide-hash.c
@@ -72,8 +72,8 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
 
   if (size == -1) {
     // hash to end of file
-    if (_openslide_fseek(f, 0, SEEK_END)) {
-      _openslide_io_error(err, "Couldn't seek %s", filename);
+    if (!_openslide_fseek(f, 0, SEEK_END, err)) {
+      g_prefix_error(err, "Couldn't seek %s: ", filename);
       goto DONE;
     }
     int64_t len = _openslide_ftell(f);
@@ -86,8 +86,8 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
 
   uint8_t buf[4096];
 
-  if (_openslide_fseek(f, offset, SEEK_SET) == -1) {
-    _openslide_io_error(err, "Can't seek in %s", filename);
+  if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
+    g_prefix_error(err, "Can't seek in %s: ", filename);
     goto DONE;
   }
 

--- a/src/openslide-hash.c
+++ b/src/openslide-hash.c
@@ -72,11 +72,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
 
   if (size == -1) {
     // hash to end of file
-    if (!_openslide_fseek(f, 0, SEEK_END, err)) {
-      g_prefix_error(err, "Couldn't seek %s: ", filename);
-      goto DONE;
-    }
-    int64_t len = _openslide_ftell(f, err);
+    int64_t len = _openslide_fsize(f, err);
     if (len == -1) {
       g_prefix_error(err, "Couldn't get size of %s: ", filename);
       goto DONE;
@@ -86,9 +82,11 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
 
   uint8_t buf[4096];
 
-  if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
-    g_prefix_error(err, "Can't seek in %s: ", filename);
-    goto DONE;
+  if (offset != 0) {
+    if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
+      g_prefix_error(err, "Can't seek in %s: ", filename);
+      goto DONE;
+    }
   }
 
   int64_t bytes_left = size;

--- a/src/openslide-hash.c
+++ b/src/openslide-hash.c
@@ -76,9 +76,9 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
       g_prefix_error(err, "Couldn't seek %s: ", filename);
       goto DONE;
     }
-    int64_t len = _openslide_ftell(f);
+    int64_t len = _openslide_ftell(f, err);
     if (len == -1) {
-      _openslide_io_error(err, "Couldn't get size of %s", filename);
+      g_prefix_error(err, "Couldn't get size of %s: ", filename);
       goto DONE;
     }
     size = len - offset;

--- a/src/openslide-hash.c
+++ b/src/openslide-hash.c
@@ -65,7 +65,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
 			       GError **err) {
   bool success = false;
 
-  FILE *f = _openslide_fopen(filename, "rb", err);
+  FILE *f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return false;
   }

--- a/src/openslide-hash.c
+++ b/src/openslide-hash.c
@@ -65,18 +65,18 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
 			       GError **err) {
   bool success = false;
 
-  FILE *f = _openslide_fopen(filename, err);
+  struct _openslide_file *f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return false;
   }
 
   if (size == -1) {
     // hash to end of file
-    if (fseeko(f, 0, SEEK_END)) {
+    if (_openslide_fseek(f, 0, SEEK_END)) {
       _openslide_io_error(err, "Couldn't seek %s", filename);
       goto DONE;
     }
-    int64_t len = ftello(f);
+    int64_t len = _openslide_ftell(f);
     if (len == -1) {
       _openslide_io_error(err, "Couldn't get size of %s", filename);
       goto DONE;
@@ -86,7 +86,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
 
   uint8_t buf[4096];
 
-  if (fseeko(f, offset, SEEK_SET) == -1) {
+  if (_openslide_fseek(f, offset, SEEK_SET) == -1) {
     _openslide_io_error(err, "Can't seek in %s", filename);
     goto DONE;
   }
@@ -94,7 +94,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
   int64_t bytes_left = size;
   while (bytes_left > 0) {
     int64_t bytes_to_read = MIN((int64_t) sizeof buf, bytes_left);
-    int64_t bytes_read = fread(buf, 1, bytes_to_read, f);
+    int64_t bytes_read = _openslide_fread(f, buf, bytes_to_read);
 
     if (bytes_read != bytes_to_read) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
@@ -112,7 +112,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
   success = true;
 
 DONE:
-  fclose(f);
+  _openslide_fclose(f);
   return success;
 }
 

--- a/src/openslide-jdatasrc.c
+++ b/src/openslide-jdatasrc.c
@@ -32,11 +32,11 @@
 /* Expanded data source object for stdio input */
 
 typedef struct {
-  struct jpeg_source_mgr pub;	/* public fields */
+  struct jpeg_source_mgr pub;		/* public fields */
 
-  FILE * infile;		/* source stream */
-  JOCTET * buffer;		/* start of buffer */
-  boolean start_of_file;	/* have we gotten any data yet? */
+  struct _openslide_file * infile;	/* source stream */
+  JOCTET * buffer;			/* start of buffer */
+  boolean start_of_file;		/* have we gotten any data yet? */
 } my_source_mgr;
 
 typedef my_source_mgr * my_src_ptr;
@@ -104,7 +104,7 @@ static boolean fill_input_buffer (j_decompress_ptr cinfo)
   my_src_ptr src = (my_src_ptr) cinfo->src;
   size_t nbytes;
 
-  nbytes = fread(src->buffer, 1, INPUT_BUF_SIZE, src->infile);
+  nbytes = _openslide_fread(src->infile, src->buffer, INPUT_BUF_SIZE);
 
   if (nbytes <= 0) {
     if (src->start_of_file)	/* Treat empty input file as fatal error */
@@ -208,7 +208,8 @@ static void term_source (j_decompress_ptr cinfo G_GNUC_UNUSED)
  * for closing it after finishing decompression.
  */
 
-void _openslide_jpeg_stdio_src (j_decompress_ptr cinfo, FILE * infile)
+void _openslide_jpeg_stdio_src (j_decompress_ptr cinfo,
+                                struct _openslide_file * infile)
 {
   my_src_ptr src;
 

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -151,7 +151,7 @@ void *_openslide_inflate_buffer(const void *src, int64_t src_len,
                                 GError **err);
 
 /* fopen() wrapper which properly sets FD_CLOEXEC */
-FILE *_openslide_fopen(const char *path, const char *mode, GError **err);
+FILE *_openslide_fopen(const char *path, GError **err);
 
 /* Parse string to double, returning NAN on failure.  Accept both comma
    and period as decimal separator. */

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -179,7 +179,8 @@ struct _openslide_file;
 
 struct _openslide_file *_openslide_fopen(const char *path, GError **err);
 size_t _openslide_fread(struct _openslide_file *file, void *buf, size_t size);
-int _openslide_fseek(struct _openslide_file *file, off_t offset, int whence);
+bool _openslide_fseek(struct _openslide_file *file, off_t offset, int whence,
+                      GError **err);
 off_t _openslide_ftell(struct _openslide_file *file);
 void _openslide_fclose(struct _openslide_file *file);
 bool _openslide_fexists(const char *path);

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -181,7 +181,7 @@ struct _openslide_file *_openslide_fopen(const char *path, GError **err);
 size_t _openslide_fread(struct _openslide_file *file, void *buf, size_t size);
 bool _openslide_fseek(struct _openslide_file *file, off_t offset, int whence,
                       GError **err);
-off_t _openslide_ftell(struct _openslide_file *file);
+off_t _openslide_ftell(struct _openslide_file *file, GError **err);
 void _openslide_fclose(struct _openslide_file *file);
 bool _openslide_fexists(const char *path);
 

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -317,8 +317,6 @@ enum OpenSlideError {
 #define OPENSLIDE_ERROR _openslide_error_quark()
 GQuark _openslide_error_quark(void);
 
-void _openslide_io_error(GError **err, const char *fmt, ...) G_GNUC_PRINTF(2, 3);
-
 bool _openslide_check_cairo_status(cairo_t *cr, GError **err);
 
 /* Debug flags */

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -150,9 +150,6 @@ void *_openslide_inflate_buffer(const void *src, int64_t src_len,
                                 int64_t dst_len,
                                 GError **err);
 
-/* fopen() wrapper which properly sets FD_CLOEXEC */
-FILE *_openslide_fopen(const char *path, GError **err);
-
 /* Parse string to double, returning NAN on failure.  Accept both comma
    and period as decimal separator. */
 double _openslide_parse_double(const char *value);
@@ -175,6 +172,20 @@ bool _openslide_clip_tile(uint32_t *tiledata,
                           int64_t tile_w, int64_t tile_h,
                           int64_t clip_w, int64_t clip_h,
                           GError **err);
+
+
+// File handling
+struct _openslide_file;
+
+struct _openslide_file *_openslide_fopen(const char *path, GError **err);
+size_t _openslide_fread(struct _openslide_file *file, void *buf, size_t size);
+int _openslide_fseek(struct _openslide_file *file, off_t offset, int whence);
+off_t _openslide_ftell(struct _openslide_file *file);
+void _openslide_fclose(struct _openslide_file *file);
+bool _openslide_fexists(const char *path);
+
+typedef struct _openslide_file _openslide_file;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_file, _openslide_fclose)
 
 
 // Grid helpers
@@ -365,8 +376,11 @@ void openslide_cancel_prefetch_hint(openslide_t *osr, int prefetch_id);
    Every @p replacement must be unique to avoid conflicting-type errors. */
 #define _OPENSLIDE_POISON(replacement) error__use_ ## replacement ## _instead
 #define fopen _OPENSLIDE_POISON(_openslide_fopen)
-#define fseek _OPENSLIDE_POISON(fseeko)
-#define ftell _OPENSLIDE_POISON(ftello)
+#define fread _OPENSLIDE_POISON(_openslide_fread)
+#define fseek _OPENSLIDE_POISON(_openslide_fseek)
+#define ftell _OPENSLIDE_POISON(_openslide_ftell)
+#define fclose _OPENSLIDE_POISON(_openslide_fclose)
+#define g_file_test _OPENSLIDE_POISON(_openslide_fexists)
 #define strtod _OPENSLIDE_POISON(_openslide_parse_double)
 #define g_ascii_strtod _OPENSLIDE_POISON(_openslide_parse_double_)
 #define sqlite3_open _OPENSLIDE_POISON(_openslide_sqlite_open)
@@ -377,5 +391,12 @@ void openslide_cancel_prefetch_hint(openslide_t *osr, int prefetch_id);
 #define TIFFOpen _OPENSLIDE_POISON(_openslide_tiffcache_get__)
 #define TIFFSetDirectory _OPENSLIDE_POISON(_openslide_tiff_set_dir)
 
+#ifndef NO_POISON_FSEEKO
+// openslide-file.c needs the original macros
+#undef fseeko
+#undef ftello
+#define fseeko _OPENSLIDE_POISON(_openslide_fseek_)
+#define ftello _OPENSLIDE_POISON(_openslide_ftell_)
+#endif
 
 #endif

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -182,6 +182,7 @@ size_t _openslide_fread(struct _openslide_file *file, void *buf, size_t size);
 bool _openslide_fseek(struct _openslide_file *file, off_t offset, int whence,
                       GError **err);
 off_t _openslide_ftell(struct _openslide_file *file, GError **err);
+off_t _openslide_fsize(struct _openslide_file *file, GError **err);
 void _openslide_fclose(struct _openslide_file *file);
 bool _openslide_fexists(const char *path, GError **err);
 

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -183,7 +183,7 @@ bool _openslide_fseek(struct _openslide_file *file, off_t offset, int whence,
                       GError **err);
 off_t _openslide_ftell(struct _openslide_file *file, GError **err);
 void _openslide_fclose(struct _openslide_file *file);
-bool _openslide_fexists(const char *path);
+bool _openslide_fexists(const char *path, GError **err);
 
 typedef struct _openslide_file _openslide_file;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_file, _openslide_fclose)

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -91,7 +91,7 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
   }
   max_size = MIN(max_size, KEY_FILE_HARD_MAX_SIZE);
 
-  FILE *f = _openslide_fopen(filename, "rb", err);
+  FILE *f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return NULL;
   }

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -125,7 +125,8 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
     total += cur_len;
   }
   if (total != size) {
-    _openslide_io_error(err, "Couldn't read key file %s", filename);
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Couldn't read key file %s", filename);
     goto FAIL;
   }
 

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -33,11 +33,6 @@
 #include <cairo.h>
 #include <zlib.h>
 
-#ifdef HAVE_FCNTL
-#include <unistd.h>
-#include <fcntl.h>
-#endif
-
 #define KEY_FILE_HARD_MAX_SIZE (100 << 20)
 
 static const char DEBUG_ENV_VAR[] = "OPENSLIDE_DEBUG";
@@ -201,74 +196,6 @@ ZLIB_ERROR:
   }
   g_free(dst);
   return NULL;
-}
-
-#undef fopen
-static FILE *do_fopen(const char *path, const char *mode, GError **err) {
-  FILE *f;
-
-#ifdef HAVE__WFOPEN
-  wchar_t *path16 = (wchar_t *) g_utf8_to_utf16(path, -1, NULL, NULL, err);
-  if (path16 == NULL) {
-    g_prefix_error(err, "Couldn't open %s: ", path);
-    return NULL;
-  }
-  wchar_t *mode16 = (wchar_t *) g_utf8_to_utf16(mode, -1, NULL, NULL, err);
-  if (mode16 == NULL) {
-    g_prefix_error(err, "Bad file mode %s: ", mode);
-    g_free(path16);
-    return NULL;
-  }
-  f = _wfopen(path16, mode16);
-  if (f == NULL) {
-    _openslide_io_error(err, "Couldn't open %s", path);
-  }
-  g_free(mode16);
-  g_free(path16);
-#else
-  f = fopen(path, mode);
-  if (f == NULL) {
-    _openslide_io_error(err, "Couldn't open %s", path);
-  }
-#endif
-
-  return f;
-}
-#define fopen _OPENSLIDE_POISON(_openslide_fopen)
-
-FILE *_openslide_fopen(const char *path, const char *mode, GError **err)
-{
-  char *m = g_strconcat(mode, FOPEN_CLOEXEC_FLAG, NULL);
-  FILE *f = do_fopen(path, m, err);
-  g_free(m);
-  if (f == NULL) {
-    return NULL;
-  }
-
-  /* Unnecessary if FOPEN_CLOEXEC_FLAG is non-empty.  Not built on Windows. */
-#ifdef HAVE_FCNTL
-  if (!FOPEN_CLOEXEC_FLAG[0]) {
-    int fd = fileno(f);
-    if (fd == -1) {
-      _openslide_io_error(err, "Couldn't fileno() %s", path);
-      fclose(f);
-      return NULL;
-    }
-    long flags = fcntl(fd, F_GETFD);
-    if (flags == -1) {
-      _openslide_io_error(err, "Couldn't F_GETFD %s", path);
-      fclose(f);
-      return NULL;
-    }
-    if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC)) {
-      _openslide_io_error(err, "Couldn't F_SETFD %s", path);
-      fclose(f);
-      return NULL;
-    }
-  }
-#endif
-
-  return f;
 }
 
 #undef g_ascii_strtod

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -97,8 +97,8 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
   }
 
   // get file size and check against maximum
-  if (_openslide_fseek(f, 0, SEEK_END)) {
-    _openslide_io_error(err, "Couldn't seek %s", filename);
+  if (!_openslide_fseek(f, 0, SEEK_END, err)) {
+    g_prefix_error(err, "Couldn't seek %s: ", filename);
     goto FAIL;
   }
   int64_t size = _openslide_ftell(f);
@@ -113,8 +113,8 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
   }
 
   // read
-  if (_openslide_fseek(f, 0, SEEK_SET)) {
-    _openslide_io_error(err, "Couldn't seek %s", filename);
+  if (!_openslide_fseek(f, 0, SEEK_SET, err)) {
+    g_prefix_error(err, "Couldn't seek %s: ", filename);
     goto FAIL;
   }
   // catch file size changes

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -97,11 +97,7 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
   }
 
   // get file size and check against maximum
-  if (!_openslide_fseek(f, 0, SEEK_END, err)) {
-    g_prefix_error(err, "Couldn't seek %s: ", filename);
-    goto FAIL;
-  }
-  int64_t size = _openslide_ftell(f, err);
+  int64_t size = _openslide_fsize(f, err);
   if (size == -1) {
     g_prefix_error(err, "Couldn't get size of %s: ", filename);
     goto FAIL;
@@ -113,10 +109,6 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
   }
 
   // read
-  if (!_openslide_fseek(f, 0, SEEK_SET, err)) {
-    g_prefix_error(err, "Couldn't seek %s: ", filename);
-    goto FAIL;
-  }
   // catch file size changes
   buf = g_malloc(size + 1);
   int64_t total = 0;

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -101,9 +101,9 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
     g_prefix_error(err, "Couldn't seek %s: ", filename);
     goto FAIL;
   }
-  int64_t size = _openslide_ftell(f);
+  int64_t size = _openslide_ftell(f, err);
   if (size == -1) {
-    _openslide_io_error(err, "Couldn't get size of %s", filename);
+    g_prefix_error(err, "Couldn't get size of %s: ", filename);
     goto FAIL;
   }
   if (size > max_size) {

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -593,7 +593,7 @@ static bool read_from_jpeg(openslide_t *osr,
   volatile bool success = false;
 
   // open file
-  FILE *f = _openslide_fopen(jpeg->filename, "rb", err);
+  FILE *f = _openslide_fopen(jpeg->filename, err);
   if (f == NULL) {
     return false;
   }
@@ -880,7 +880,7 @@ static bool verify_mcu_starts(int32_t num_jpegs, struct jpeg **jpegs,
   for (current_jpeg = 0; current_jpeg < num_jpegs; current_jpeg++) {
     struct jpeg *jp = jpegs[current_jpeg];
     CHK(jp->filename);
-    f = _openslide_fopen(jp->filename, "rb", NULL);
+    f = _openslide_fopen(jp->filename, NULL);
     CHK(f);
     for (current_mcu_start = 1; current_mcu_start < jp->tile_count;
          current_mcu_start++) {
@@ -950,7 +950,7 @@ static gpointer restart_marker_thread_func(gpointer d) {
     struct jpeg *jp = data->all_jpegs[current_jpeg];
     if (jp->tile_count > 1) {
       if (current_file == NULL) {
-	current_file = _openslide_fopen(jp->filename, "rb", &tmp_err);
+	current_file = _openslide_fopen(jp->filename, &tmp_err);
 	if (current_file == NULL) {
 	  //g_debug("restart_marker_thread_func fopen failed");
 	  break;
@@ -1432,7 +1432,7 @@ static bool hamamatsu_vms_part2(openslide_t *osr,
     jp->filename = g_strdup(image_filenames[i]);
 
     FILE *f;
-    if ((f = _openslide_fopen(jp->filename, "rb", err)) == NULL) {
+    if ((f = _openslide_fopen(jp->filename, err)) == NULL) {
       g_prefix_error(err, "Can't open JPEG %d: ", i);
       goto FAIL;
     }
@@ -1597,7 +1597,7 @@ static bool ngr_read_tile(openslide_t *osr,
 
   if (!tiledata) {
     // read the tile data
-    FILE *f = _openslide_fopen(l->filename, "rb", err);
+    FILE *f = _openslide_fopen(l->filename, err);
     if (!f) {
       return false;
     }
@@ -1708,7 +1708,7 @@ static bool hamamatsu_vmu_part2(openslide_t *osr,
     l->filename = g_strdup(image_filenames[i]);
 
     FILE *f;
-    if ((f = _openslide_fopen(l->filename, "rb", err)) == NULL) {
+    if ((f = _openslide_fopen(l->filename, err)) == NULL) {
       goto FAIL;
     }
 
@@ -2013,7 +2013,7 @@ static bool hamamatsu_vms_vmu_open(openslide_t *osr, const char *filename,
       char *optimisation_filename = g_build_filename(dirname, tmp, NULL);
       g_free(tmp);
 
-      optimisation_file = _openslide_fopen(optimisation_filename, "rb", NULL);
+      optimisation_file = _openslide_fopen(optimisation_filename, NULL);
 
       if (optimisation_file == NULL) {
 	// g_debug("Can't open optimisation file");
@@ -2229,7 +2229,7 @@ static bool hamamatsu_ndpi_open(openslide_t *osr, const char *filename,
   bool restart_marker_scan = false;
 
   // open file
-  FILE *f = _openslide_fopen(filename, "rb", err);
+  FILE *f = _openslide_fopen(filename, err);
   if (!f) {
     goto FAIL;
   }

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -1483,12 +1483,7 @@ static bool hamamatsu_vms_part2(openslide_t *osr,
 			  comment);
     }
 
-    if (!_openslide_fseek(f, 0, SEEK_END, err)) {
-      g_prefix_error(err, "Can't seek to end of JPEG %d: ", i);
-      _openslide_fclose(f);
-      goto FAIL;
-    }
-    jp->end_in_file = _openslide_ftell(f, err);
+    jp->end_in_file = _openslide_fsize(f, err);
     if (jp->end_in_file == -1) {
       g_prefix_error(err, "Can't read file size for JPEG %d: ", i);
       _openslide_fclose(f);

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -174,7 +174,7 @@ static GQuark _openslide_hamamatsu_error_quark(void) {
  * as a complete JPEG.  Originally based on jdatasrc.c from IJG libjpeg.
  */
 static bool jpeg_random_access_src(j_decompress_ptr cinfo,
-                                   FILE *infile,
+                                   struct _openslide_file *infile,
                                    int64_t header_start_position,
                                    int64_t sof_position,
                                    int64_t header_stop_position,
@@ -213,11 +213,12 @@ static bool jpeg_random_access_src(j_decompress_ptr cinfo,
 
   // read in the 2 parts
   //  g_debug("reading header from %"PRId64, header_start_position);
-  if (fseeko(infile, header_start_position, SEEK_SET)) {
+  if (_openslide_fseek(infile, header_start_position, SEEK_SET)) {
     _openslide_io_error(err, "Couldn't seek to header start");
     return false;
   }
-  if (!fread(buffer, header_length, 1, infile)) {
+  if (_openslide_fread(infile, buffer, header_length) !=
+      (size_t) header_length) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Cannot read header in JPEG at %"PRId64,
                 header_start_position);
@@ -226,11 +227,12 @@ static bool jpeg_random_access_src(j_decompress_ptr cinfo,
 
   if (data_length) {
     //  g_debug("reading from %"PRId64, start_position);
-    if (fseeko(infile, start_position, SEEK_SET)) {
+    if (_openslide_fseek(infile, start_position, SEEK_SET)) {
       _openslide_io_error(err, "Couldn't seek to data start");
       return false;
     }
-    if (!fread(buffer + header_length, data_length, 1, infile)) {
+    if (_openslide_fread(infile, buffer + header_length, data_length) !=
+        (size_t) data_length) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Cannot read data in JPEG at %"PRId64, start_position);
       return false;
@@ -301,7 +303,7 @@ static void jpeg_destroy_data(int32_t num_jpegs, struct jpeg **jpegs,
   g_free(levels);
 }
 
-static bool find_bitstream_start(FILE *f,
+static bool find_bitstream_start(struct _openslide_file *f,
                                  int64_t *sof_position,
                                  int64_t *header_stop_position,
                                  GError **err) {
@@ -313,8 +315,8 @@ static bool find_bitstream_start(FILE *f,
 
   while (true) {
     // read marker
-    pos = ftello(f);
-    if (fread(buf, sizeof(buf), 1, f) != 1) {
+    pos = _openslide_ftell(f);
+    if (_openslide_fread(f, buf, sizeof(buf)) != sizeof(buf)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Couldn't read JPEG marker at %"PRId64, pos);
       return false;
@@ -340,7 +342,7 @@ static bool find_bitstream_start(FILE *f,
     }
 
     // read length
-    if (fread(buf, sizeof(buf), 1, f) != 1) {
+    if (_openslide_fread(f, buf, sizeof(buf)) != sizeof(buf)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Couldn't read JPEG marker length at %"PRId64, pos);
       return false;
@@ -349,7 +351,7 @@ static bool find_bitstream_start(FILE *f,
     len = GUINT16_FROM_BE(len);
 
     // seek
-    if (fseeko(f, pos + sizeof(buf) + len, SEEK_SET)) {
+    if (_openslide_fseek(f, pos + sizeof(buf) + len, SEEK_SET)) {
       _openslide_io_error(err, "Couldn't seek to next marker");
       return false;
     }
@@ -357,7 +359,7 @@ static bool find_bitstream_start(FILE *f,
     // check for SOS
     if (marker_byte == 0xDA) {
       // found it; done
-      *header_stop_position = ftello(f);
+      *header_stop_position = _openslide_ftell(f);
       //g_debug("found bitstream start at %"PRId64, *header_stop_position);
       break;
     }
@@ -372,7 +374,7 @@ static bool find_bitstream_start(FILE *f,
   return true;
 }
 
-static bool find_next_ff_marker(FILE *f,
+static bool find_next_ff_marker(struct _openslide_file *f,
                                 uint8_t *buf_start,
                                 uint8_t **buf,
                                 int buf_size,
@@ -382,7 +384,7 @@ static bool find_next_ff_marker(FILE *f,
                                 int *bytes_in_buf,
                                 GError **err) {
   //g_debug("bytes_in_buf: %d", *bytes_in_buf);
-  int64_t file_pos = ftello(f);
+  int64_t file_pos = _openslide_ftell(f);
   bool last_was_ff = false;
   while (true) {
     if (*bytes_in_buf == 0) {
@@ -391,8 +393,8 @@ static bool find_next_ff_marker(FILE *f,
       int bytes_to_read = MIN(buf_size, file_size - file_pos);
 
       //g_debug("bytes_to_read: %d", bytes_to_read);
-      size_t result = fread(*buf, bytes_to_read, 1, f);
-      if (result == 0) {
+      if (bytes_to_read == 0 ||
+          _openslide_fread(f, *buf, bytes_to_read) != (size_t) bytes_to_read) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Short read searching for JPEG marker at %"PRId64,
                     file_pos);
@@ -439,7 +441,7 @@ static bool find_next_ff_marker(FILE *f,
 }
 
 static bool _compute_mcu_start(struct jpeg *jpeg,
-			       FILE *f,
+			       struct _openslide_file *f,
 			       int64_t target,
 			       GError **err) {
   // special case for first
@@ -457,14 +459,13 @@ static bool _compute_mcu_start(struct jpeg *jpeg,
     }
     if (offset != -1) {
       uint8_t buf[2];
-      if (fseeko(f, offset - 2, SEEK_SET)) {
+      if (_openslide_fseek(f, offset - 2, SEEK_SET)) {
         _openslide_io_error(err, "Couldn't seek to recorded restart "
                             "marker at %"PRId64, offset - 2);
         return false;
       }
 
-      size_t result = fread(buf, 2, 1, f);
-      if (result == 0 ||
+      if (_openslide_fread(f, buf, 2) != 2 ||
           buf[0] != 0xFF || buf[1] < 0xD0 || buf[1] > 0xD7) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Restart marker not found at recorded position %"PRId64,
@@ -485,7 +486,7 @@ static bool _compute_mcu_start(struct jpeg *jpeg,
   //  g_debug("target: %"PRId64", first_good: %"PRId64, target, first_good);
 
   // now search for the new restart markers
-  if (fseeko(f, jpeg->mcu_starts[first_good], SEEK_SET)) {
+  if (_openslide_fseek(f, jpeg->mcu_starts[first_good], SEEK_SET)) {
     _openslide_io_error(err, "Couldn't seek to first good restart marker");
     return false;
   }
@@ -517,7 +518,7 @@ static bool _compute_mcu_start(struct jpeg *jpeg,
 
 static bool compute_mcu_start(openslide_t *osr,
 			      struct jpeg *jpeg,
-			      FILE *f,
+			      struct _openslide_file *f,
 			      int64_t tileno,
 			      int64_t *start_position,
 			      int64_t *stop_position,
@@ -568,7 +569,7 @@ OUT:
 // clobber warnings in read_from_jpeg() on gcc 4.9
 static bool compute_mcu_start_volatile(openslide_t *osr,
                                        struct jpeg *jpeg,
-                                       FILE *f,
+                                       struct _openslide_file *f,
                                        int64_t tileno,
                                        volatile int64_t *start_position,
                                        volatile int64_t *stop_position,
@@ -593,7 +594,7 @@ static bool read_from_jpeg(openslide_t *osr,
   volatile bool success = false;
 
   // open file
-  FILE *f = _openslide_fopen(jpeg->filename, err);
+  struct _openslide_file *f = _openslide_fopen(jpeg->filename, err);
   if (f == NULL) {
     return false;
   }
@@ -653,7 +654,7 @@ static bool read_from_jpeg(openslide_t *osr,
 
 OUT:
   _openslide_jpeg_decompress_destroy(dc);
-  fclose(f);
+  _openslide_fclose(f);
   return success;
 }
 
@@ -864,7 +865,7 @@ static gint width_compare(gconstpointer a, gconstpointer b) {
                   "assertion: " # ASSERTION,				\
                   current_jpeg, current_mcu_start);			\
       if (f) {								\
-        fclose(f);							\
+        _openslide_fclose(f);						\
       }									\
       return false;							\
     }									\
@@ -873,7 +874,7 @@ static gint width_compare(gconstpointer a, gconstpointer b) {
 // for debugging
 static bool verify_mcu_starts(int32_t num_jpegs, struct jpeg **jpegs,
                               GError **err) {
-  FILE *f = NULL;
+  struct _openslide_file *f = NULL;
   int32_t current_jpeg = 0;
   int32_t current_mcu_start = 0;
 
@@ -886,14 +887,15 @@ static bool verify_mcu_starts(int32_t num_jpegs, struct jpeg **jpegs,
          current_mcu_start++) {
       int64_t offset = jp->mcu_starts[current_mcu_start];
       CHK(offset != -1);
-      int seek_failed = fseeko(f, offset - 2, SEEK_SET);
+      int seek_failed = _openslide_fseek(f, offset - 2, SEEK_SET);
       CHK(!seek_failed);
-      int prefix = getc(f);
-      CHK(prefix == 0xFF);
-      int marker = getc(f);
-      CHK(marker >= 0xD0 && marker <= 0xD7);
+      uint8_t buf[2];
+      size_t count = _openslide_fread(f, buf, sizeof(buf));
+      CHK(count == sizeof(buf));
+      CHK(buf[0] == 0xFF);  // prefix
+      CHK(buf[1] >= 0xD0 && buf[1] <= 0xD7);  // marker
     }
-    fclose(f);
+    _openslide_fclose(f);
     f = NULL;
   }
   return true;
@@ -906,7 +908,7 @@ static gpointer restart_marker_thread_func(gpointer d) {
   int32_t current_jpeg = 0;
   int32_t current_mcu_start = 0;
 
-  FILE *current_file = NULL;
+  struct _openslide_file *current_file = NULL;
 
   GError *tmp_err = NULL;
 
@@ -960,7 +962,7 @@ static gpointer restart_marker_thread_func(gpointer d) {
       if (!compute_mcu_start(osr, jp, current_file, current_mcu_start,
                              NULL, NULL, &tmp_err)) {
         //g_debug("restart_marker_thread_func compute_mcu_start failed");
-        fclose(current_file);
+        _openslide_fclose(current_file);
         break;
       }
 
@@ -968,7 +970,7 @@ static gpointer restart_marker_thread_func(gpointer d) {
       if (current_mcu_start >= jp->tile_count) {
 	current_mcu_start = 0;
 	current_jpeg++;
-	fclose(current_file);
+	_openslide_fclose(current_file);
 	current_file = NULL;
       }
     } else {
@@ -989,7 +991,8 @@ static gpointer restart_marker_thread_func(gpointer d) {
 }
 
 // if !use_jpeg_dimensions, use *w and *h instead of setting them
-static bool validate_jpeg_header(FILE *f, bool use_jpeg_dimensions,
+static bool validate_jpeg_header(struct _openslide_file *f,
+                                 bool use_jpeg_dimensions,
                                  int32_t *w, int32_t *h,
                                  int32_t *tw, int32_t *th,
                                  int64_t *sof_position,
@@ -1003,7 +1006,7 @@ static bool validate_jpeg_header(FILE *f, bool use_jpeg_dimensions,
   }
 
   // find limits of JPEG header
-  int64_t header_start = ftello(f);
+  int64_t header_start = _openslide_ftell(f);
   if (!find_bitstream_start(f, sof_position, header_stop_position, err)) {
     return false;
   }
@@ -1102,7 +1105,7 @@ DONE:
   return success;
 }
 
-static int64_t *extract_optimisations_for_one_jpeg(FILE *opt_f,
+static int64_t *extract_optimisations_for_one_jpeg(struct _openslide_file *opt_f,
                                                    int32_t tiles_down,
                                                    int32_t tiles_across) {
   int32_t tile_count = tiles_across * tiles_down;
@@ -1131,7 +1134,7 @@ static int64_t *extract_optimisations_for_one_jpeg(FILE *opt_f,
       int64_t i64;
     } u;
 
-    if (fread(u.buf, sizeof(u.buf), 1, opt_f) != 1) {
+    if (_openslide_fread(opt_f, u.buf, sizeof(u.buf)) != sizeof(u.buf)) {
       // EOF or error, we've done all we can
 
       if (row == 0) {
@@ -1414,7 +1417,7 @@ static struct jpeg_level *create_jpeg_level(openslide_t *osr,
 static bool hamamatsu_vms_part2(openslide_t *osr,
 				int num_jpegs, char **image_filenames,
 				int num_jpeg_cols, int num_jpeg_rows,
-				FILE *optimisation_file,
+				struct _openslide_file *optimisation_file,
 				GError **err) {
   struct jpeg_level **levels = NULL;
   int32_t level_count = 0;
@@ -1431,7 +1434,7 @@ static bool hamamatsu_vms_part2(openslide_t *osr,
 
     jp->filename = g_strdup(image_filenames[i]);
 
-    FILE *f;
+    struct _openslide_file *f;
     if ((f = _openslide_fopen(jp->filename, err)) == NULL) {
       g_prefix_error(err, "Can't open JPEG %d: ", i);
       goto FAIL;
@@ -1451,7 +1454,7 @@ static bool hamamatsu_vms_part2(openslide_t *osr,
                               &jp->header_stop_position,
                               comment_ptr, err)) {
       g_prefix_error(err, "Can't validate JPEG %d: ", i);
-      fclose(f);
+      _openslide_fclose(f);
       goto FAIL;
     }
     jp->tiles_across = jp->width / jp->tile_width;
@@ -1464,20 +1467,20 @@ static bool hamamatsu_vms_part2(openslide_t *osr,
 			  comment);
     }
 
-    if (fseeko(f, 0, SEEK_END)) {
+    if (_openslide_fseek(f, 0, SEEK_END)) {
       _openslide_io_error(err, "Can't seek to end of JPEG %d", i);
-      fclose(f);
+      _openslide_fclose(f);
       goto FAIL;
     }
-    jp->end_in_file = ftello(f);
+    jp->end_in_file = _openslide_ftell(f);
     if (jp->end_in_file == -1) {
       _openslide_io_error(err, "Can't read file size for JPEG %d", i);
-      fclose(f);
+      _openslide_fclose(f);
       goto FAIL;
     }
 
     // file is done now
-    fclose(f);
+    _openslide_fclose(f);
 
     // init MCU starts
     jp->mcu_starts = g_new(int64_t, jp->tile_count);
@@ -1597,7 +1600,7 @@ static bool ngr_read_tile(openslide_t *osr,
 
   if (!tiledata) {
     // read the tile data
-    FILE *f = _openslide_fopen(l->filename, err);
+    struct _openslide_file *f = _openslide_fopen(l->filename, err);
     if (!f) {
       return false;
     }
@@ -1607,9 +1610,9 @@ static bool ngr_read_tile(openslide_t *osr,
       (tile_y * NGR_TILE_HEIGHT * l->column_width * 6) +
       (tile_x * l->base.h * l->column_width * 6);
     //g_debug("tile_x: %"PRId64", tile_y: %"PRId64", seeking to %"PRId64, tile_x, tile_y, offset);
-    if (fseeko(f, offset, SEEK_SET)) {
+    if (_openslide_fseek(f, offset, SEEK_SET)) {
       _openslide_io_error(err, "Couldn't seek to tile offset");
-      fclose(f);
+      _openslide_fclose(f);
       return false;
     }
 
@@ -1617,14 +1620,14 @@ static bool ngr_read_tile(openslide_t *osr,
     int buf_size = tw * th * 6;
     uint16_t *buf = g_slice_alloc(buf_size);
 
-    if (fread(buf, buf_size, 1, f) != 1) {
+    if (_openslide_fread(f, buf, buf_size) != (size_t) buf_size) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Cannot read file %s", l->filename);
-      fclose(f);
+      _openslide_fclose(f);
       g_slice_free1(buf_size, buf);
       return false;
     }
-    fclose(f);
+    _openslide_fclose(f);
 
     // got the data, now convert to 8-bit xRGB
     tiledata = g_slice_alloc(tilesize);
@@ -1679,10 +1682,10 @@ static const struct _openslide_ops ngr_ops = {
   .destroy = ngr_destroy,
 };
 
-static int32_t read_le_int32_from_file(FILE *f) {
+static int32_t read_le_int32_from_file(struct _openslide_file *f) {
   int32_t i;
 
-  if (fread(&i, 4, 1, f) != 1) {
+  if (_openslide_fread(f, &i, 4) != 4) {
     return -1;
   }
 
@@ -1707,32 +1710,39 @@ static bool hamamatsu_vmu_part2(openslide_t *osr,
 
     l->filename = g_strdup(image_filenames[i]);
 
-    FILE *f;
+    struct _openslide_file *f;
     if ((f = _openslide_fopen(l->filename, err)) == NULL) {
       goto FAIL;
     }
 
     // validate magic
-    if ((fgetc(f) != 'G') || (fgetc(f) != 'N')) {
+    char buf[2];
+    if (_openslide_fread(f, buf, sizeof(buf)) != sizeof(buf)) {
+      g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                  "Couldn't read magic on NGR file, level %d", i);
+      _openslide_fclose(f);
+      goto FAIL;
+    }
+    if ((buf[0] != 'G') || (buf[1] != 'N')) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Bad magic on NGR file, level %d", i);
-      fclose(f);
+      _openslide_fclose(f);
       goto FAIL;
     }
 
     // read w, h, column width, headersize
-    if (fseeko(f, 4, SEEK_SET)) {
+    if (_openslide_fseek(f, 4, SEEK_SET)) {
       _openslide_io_error(err, "Couldn't seek to NGR header");
-      fclose(f);
+      _openslide_fclose(f);
       goto FAIL;
     }
     l->base.w = read_le_int32_from_file(f);
     l->base.h = read_le_int32_from_file(f);
     l->column_width = read_le_int32_from_file(f);
 
-    if (fseeko(f, 24, SEEK_SET)) {
+    if (_openslide_fseek(f, 24, SEEK_SET)) {
       _openslide_io_error(err, "Couldn't seek within NGR header");
-      fclose(f);
+      _openslide_fclose(f);
       goto FAIL;
     }
     l->start_in_file = read_le_int32_from_file(f);
@@ -1742,7 +1752,7 @@ static bool hamamatsu_vmu_part2(openslide_t *osr,
 	(l->column_width <= 0) || (l->start_in_file <= 0)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Couldn't read header, level %d", i);
-      fclose(f);
+      _openslide_fclose(f);
       goto FAIL;
     }
 
@@ -1751,7 +1761,7 @@ static bool hamamatsu_vmu_part2(openslide_t *osr,
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Width %"PRId64" not multiple of column width %d",
                   l->base.w, l->column_width);
-      fclose(f);
+      _openslide_fclose(f);
       goto FAIL;
     }
 
@@ -1767,7 +1777,7 @@ static bool hamamatsu_vmu_part2(openslide_t *osr,
     l->base.tile_w = l->column_width;
     l->base.tile_h = NGR_TILE_HEIGHT;
 
-    fclose(f);
+    _openslide_fclose(f);
   }
 
   // set osr data
@@ -2004,7 +2014,7 @@ static bool hamamatsu_vms_vmu_open(openslide_t *osr, const char *filename,
   // finalize depending on what format
   if (groupname == GROUP_VMS) {
     // open OptimisationFile
-    FILE *optimisation_file = NULL;
+    struct _openslide_file *optimisation_file = NULL;
     char *tmp = g_key_file_get_string(key_file,
 				      GROUP_VMS,
 				      KEY_OPTIMISATION_FILE,
@@ -2035,7 +2045,7 @@ static bool hamamatsu_vms_vmu_open(openslide_t *osr, const char *filename,
 
     // clean up
     if (optimisation_file) {
-      fclose(optimisation_file);
+      _openslide_fclose(optimisation_file);
     }
   } else if (groupname == GROUP_VMU) {
     // verify a few assumptions for VMU
@@ -2229,7 +2239,7 @@ static bool hamamatsu_ndpi_open(openslide_t *osr, const char *filename,
   bool restart_marker_scan = false;
 
   // open file
-  FILE *f = _openslide_fopen(filename, err);
+  struct _openslide_file *f = _openslide_fopen(filename, err);
   if (!f) {
     goto FAIL;
   }
@@ -2299,7 +2309,7 @@ static bool hamamatsu_ndpi_open(openslide_t *osr, const char *filename,
       int32_t jp_h = height; // overwritten if dimensions_valid
       int32_t jp_tw, jp_th;
       int64_t sof_position, header_stop_position;
-      if (fseeko(f, start_in_file, SEEK_SET)) {
+      if (_openslide_fseek(f, start_in_file, SEEK_SET)) {
         _openslide_io_error(err, "Couldn't seek to JPEG start");
         goto FAIL;
       }
@@ -2416,7 +2426,7 @@ static bool hamamatsu_ndpi_open(openslide_t *osr, const char *filename,
 FAIL:
   // free
   if (f) {
-    fclose(f);
+    _openslide_fclose(f);
   }
 
   // unwrap jpegs

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -915,7 +915,7 @@ static void *read_record_data(const char *path,
                               int64_t size, int64_t offset,
                               GError **err) {
   void *buffer = NULL;
-  FILE *f = _openslide_fopen(path, "rb", err);
+  FILE *f = _openslide_fopen(path, err);
   if (!f) {
     return NULL;
   }
@@ -1730,7 +1730,7 @@ static bool mirax_open(openslide_t *osr, const char *filename,
 
   // read indexfile
   tmp = g_build_filename(dirname, index_filename, NULL);
-  indexfile = _openslide_fopen(tmp, "rb", err);
+  indexfile = _openslide_fopen(tmp, err);
   g_free(tmp);
   tmp = NULL;
 

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -452,9 +452,8 @@ static bool read_nonhier_record(struct _openslide_file *f,
 				GError **err) {
   g_return_val_if_fail(recordno >= 0, false);
 
-  if (_openslide_fseek(f, nonhier_root_position, SEEK_SET) == -1) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Cannot seek to nonhier root");
+  if (!_openslide_fseek(f, nonhier_root_position, SEEK_SET, err)) {
+    g_prefix_error(err, "Cannot seek to nonhier root: ");
     return false;
   }
 
@@ -466,9 +465,8 @@ static bool read_nonhier_record(struct _openslide_file *f,
   }
 
   // seek to record pointer
-  if (_openslide_fseek(f, ptr + 4 * recordno, SEEK_SET) == -1) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Cannot seek to nonhier record pointer %d", recordno);
+  if (!_openslide_fseek(f, ptr + 4 * recordno, SEEK_SET, err)) {
+    g_prefix_error(err, "Cannot seek to nonhier record pointer %d: ", recordno);
     return false;
   }
 
@@ -481,9 +479,8 @@ static bool read_nonhier_record(struct _openslide_file *f,
   }
 
   // seek
-  if (_openslide_fseek(f, ptr, SEEK_SET) == -1) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Cannot seek to nonhier record %d", recordno);
+  if (!_openslide_fseek(f, ptr, SEEK_SET, err)) {
+    g_prefix_error(err, "Cannot seek to nonhier record %d: ", recordno);
     return false;
   }
 
@@ -503,9 +500,8 @@ static bool read_nonhier_record(struct _openslide_file *f,
   }
 
   // seek to offset
-  if (_openslide_fseek(f, ptr, SEEK_SET) == -1) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Can't seek to initial data page");
+  if (!_openslide_fseek(f, ptr, SEEK_SET, err)) {
+    g_prefix_error(err, "Can't seek to initial data page: ");
     return false;
   }
 
@@ -703,9 +699,8 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
 
     //    g_debug("reading zoom_level %d", zoom_level);
 
-    if (_openslide_fseek(f, seek_location, SEEK_SET) == -1) {
-      g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                  "Cannot seek to zoom level pointer %d", zoom_level);
+    if (!_openslide_fseek(f, seek_location, SEEK_SET, err)) {
+      g_prefix_error(err, "Cannot seek to zoom level pointer %d: ", zoom_level);
       goto DONE;
     }
 
@@ -715,9 +710,8 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
                   "Can't read zoom level pointer");
       goto DONE;
     }
-    if (_openslide_fseek(f, ptr, SEEK_SET) == -1) {
-      g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                  "Cannot seek to start of data pages");
+    if (!_openslide_fseek(f, ptr, SEEK_SET, err)) {
+      g_prefix_error(err, "Cannot seek to start of data pages: ");
       goto DONE;
     }
 
@@ -737,9 +731,8 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
     }
 
     // seek to offset
-    if (_openslide_fseek(f, ptr, SEEK_SET) == -1) {
-      g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                  "Can't seek to initial data page");
+    if (!_openslide_fseek(f, ptr, SEEK_SET, err)) {
+      g_prefix_error(err, "Can't seek to initial data page: ");
       goto DONE;
     }
 
@@ -921,9 +914,8 @@ static void *read_record_data(const char *path,
     return NULL;
   }
 
-  if (_openslide_fseek(f, offset, SEEK_SET) == -1) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Cannot seek data file");
+  if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
+    g_prefix_error(err, "Cannot seek data file: ");
     _openslide_fclose(f);
     return NULL;
   }
@@ -1067,7 +1059,10 @@ static bool process_indexfile(openslide_t *osr,
 
   int32_t *slide_positions = NULL;
 
-  _openslide_fseek(indexfile, 0, SEEK_SET);
+  if (!_openslide_fseek(indexfile, 0, SEEK_SET, err)) {
+    g_prefix_error(err, "Couldn't seek index file: ");
+    goto DONE;
+  }
 
   // save root positions
   const int64_t hier_root = strlen(INDEX_VERSION) + strlen(uuid);
@@ -1209,9 +1204,8 @@ static bool process_indexfile(openslide_t *osr,
   }
 
   // read hierarchical sections
-  if (_openslide_fseek(indexfile, hier_root, SEEK_SET) == -1) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Cannot seek to hier sections root");
+  if (!_openslide_fseek(indexfile, hier_root, SEEK_SET, err)) {
+    g_prefix_error(err, "Cannot seek to hier sections root: ");
     goto DONE;
   }
 

--- a/test/cases/mirax-index-bad-nonhier-table-base/config.yaml
+++ b/test/cases/mirax-index-bad-nonhier-table-base/config.yaml
@@ -1,7 +1,7 @@
 base: Mirax/CMU-1.zip
 # Unanchored regex: the error could have various prefixes depending on which
-# nonhier record is read first
-error: Cannot seek to nonhier record pointer [0-9]+$
+# nonhier record is read first, and suffixes depending on strerror
+error: "Cannot seek to nonhier record pointer [0-9]+:"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-index-hier-bad-initial-data-page-pointer/config.yaml
+++ b/test/cases/mirax-index-hier-bad-initial-data-page-pointer/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: ^Can't seek to initial data page$
+error: "^Can't seek to initial data page:"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-index-hier-bad-level-pointer/config.yaml
+++ b/test/cases/mirax-index-hier-bad-level-pointer/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: ^Cannot seek to start of data pages$
+error: "^Cannot seek to start of data pages:"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-index-negative-hier-root/config.yaml
+++ b/test/cases/mirax-index-negative-hier-root/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: ^Cannot seek to zoom level pointer 0$
+error: "^Cannot seek to zoom level pointer 0:"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-index-nonhier-bad-initial-data-page-pointer/config.yaml
+++ b/test/cases/mirax-index-nonhier-bad-initial-data-page-pointer/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: "^Cannot read macro associated image: Can't seek to initial data page$"
+error: "^Cannot read macro associated image: Can't seek to initial data page:"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-index-nonhier-bad-table-entry/config.yaml
+++ b/test/cases/mirax-index-nonhier-bad-table-entry/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: "^Cannot read macro associated image: Cannot seek to nonhier record 2$"
+error: "^Cannot read macro associated image: Cannot seek to nonhier record 2:"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-slidepos-bad-position/config.yaml
+++ b/test/cases/mirax-slidepos-bad-position/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: "^Cannot read slide position record: Cannot seek data file$"
+error: "^Cannot read slide position record: Cannot seek data file:"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax


### PR DESCRIPTION
This allows us to add some additional conveniences, such as `GError` returns and automatic retries for short reads.

This should affect all I/O initiated by OpenSlide, except for SQLite.