### PR TITLE
workflows: test on Debian stable, Ubuntu 20.04/22.04, CentOS Stream 8/9

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -23,54 +23,118 @@ jobs:
         include:
           - os: ubuntu-latest
             container: registry.fedoraproject.org/fedora:latest
+            extra: true
+          - os: ubuntu-latest
+            container: quay.io/centos/centos:stream8
+          # Use ubuntu-22.04 to get a newer Docker seccomp filter.  Otherwise
+          # "make check" fails with:
+          #     Spawning child failed: Failed to close file descriptor for child process (Operation not permitted)
+          - os: ubuntu-22.04
+            container: quay.io/centos/centos:stream9
+          - os: ubuntu-latest
+            container: debian:stable
+            ignore-fd-leaks: true
+          - os: ubuntu-20.04
+            ignore-fd-leaks: true
+          - os: ubuntu-22.04
           - os: macos-latest
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
-    - name: Install dependencies (Linux)
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-        # Actually a Fedora container
-        dnf install -y \
-          gcc make autoconf automake libtool pkg-config \
-          python3-requests python3-pyyaml \
-          zlib-devel \
-          libpng-devel \
-          libjpeg-turbo-devel \
-          libtiff-devel \
-          openjpeg2-devel \
-          gdk-pixbuf2-modules gdk-pixbuf2-devel \
-          libxml2-devel \
-          sqlite-devel \
-          cairo-devel \
-          glib2-devel \
-          doxygen \
-          xdelta libjpeg-turbo-utils
     # Quick way to get Python 3 on macOS
     - name: Set up Python (macOS)
       uses: actions/setup-python@v2
       if: ${{ matrix.os == 'macos-latest' }}
-    - name: Install dependencies (macOS)
-      if: ${{ matrix.os == 'macos-latest' }}
+    - name: Install dependencies
       run: |
-        brew install \
-          gcc make autoconf automake libtool pkg-config \
-          zlib \
-          libpng \
-          jpeg-turbo \
-          libtiff \
-          openjpeg \
-          gdk-pixbuf \
-          libxml2 \
-          sqlite \
-          cairo \
-          glib \
-          xdelta
-        python -m pip install --upgrade pip
-        pip install requests PyYAML
+        case "${{ matrix.os }}" in
+        macos-latest)
+            brew install \
+                gcc make autoconf automake libtool pkg-config \
+                zlib \
+                libpng \
+                jpeg-turbo \
+                libtiff \
+                openjpeg \
+                gdk-pixbuf \
+                libxml2 \
+                sqlite \
+                cairo \
+                glib \
+                xdelta
+            python -m pip install --upgrade pip
+            pip install requests PyYAML
+            ;;
+        ubuntu-*)
+            case "${{ matrix.container }}" in
+            *fedora*|*centos*)
+                pyver=3
+                . /etc/os-release
+                case "$VERSION_ID" in
+                8)
+                    dnf config-manager --set-enabled powertools
+                    pyver=38
+                    python=python38
+                    ;;
+                9)
+                    dnf install -y 'dnf-command(config-manager)'
+                    dnf config-manager --set-enabled crb
+                    dnf copr enable -y bgilbert/xdelta
+                    ;;
+                esac
+
+                dnf install -y \
+                    gcc make autoconf automake libtool pkg-config \
+                    $python python${pyver}-requests python${pyver}-pyyaml \
+                    zlib-devel \
+                    libpng-devel \
+                    libjpeg-turbo-devel \
+                    libtiff-devel \
+                    openjpeg2-devel \
+                    gdk-pixbuf2-modules gdk-pixbuf2-devel \
+                    libxml2-devel \
+                    sqlite-devel \
+                    cairo-devel \
+                    glib2-devel \
+                    doxygen \
+                    xdelta libjpeg-turbo-utils
+                ;;
+            *debian*|"")
+                if [ -n "${{ matrix.container }}" ]; then
+                    # Debian container
+                    jpeg=libjpeg-dev
+                else
+                    # Ubuntu, on host
+                    jpeg=libjpeg-turbo8-dev
+                    sudo=sudo
+                fi
+                $sudo apt-get update
+                $sudo apt-get -y install \
+                    gcc make autoconf automake libtool pkg-config \
+                    python3-requests python3-yaml \
+                    zlib1g-dev \
+                    libpng-dev \
+                    $jpeg \
+                    libtiff-dev \
+                    libopenjp2-7-dev \
+                    libgdk-pixbuf2.0-dev \
+                    libxml2-dev \
+                    libsqlite3-dev \
+                    libcairo2-dev \
+                    libglib2.0-dev \
+                    doxygen \
+                    xdelta3 libjpeg-turbo-progs
+                ;;
+            esac
+        esac
     - name: Build
       run: |
         autoreconf -i
+        if [ -n "${{ matrix.ignore-fd-leaks }}" ]; then
+            # Some distro versions have leaky libraries
+            echo "Disabling file descriptor leak check"
+            export CPPFLAGS="-DNONATOMIC_CLOEXEC"
+        fi
         ./configure
         make -j4 CFLAGS="-O2 -g -Werror"
     - name: Check
@@ -83,7 +147,7 @@ jobs:
         key: pristine
         path: test/_slidedata/pristine
     - name: Check for overlarge tests
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: matrix.extra
       run: |
         # We don't want to allow arbitrarily large binary diffs into the
         # repo, where they'll live in the Git history forever.  At the time
@@ -108,7 +172,7 @@ jobs:
       continue-on-error: true
       run: cd test && ./driver run
     - name: Check exports
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: matrix.extra
       run: cd test && ./driver exports
 
   windows_setup:

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -26,7 +26,7 @@ jobs:
           - os: macos-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install dependencies (Linux)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
@@ -148,7 +148,7 @@ jobs:
     container: registry.fedoraproject.org/fedora:latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install tools
       run: dnf install -y doxygen
     - name: Build

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -18,6 +18,7 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+    continue-on-error: ${{ matrix.failing || false }}
     strategy:
       matrix:
         include:
@@ -38,6 +39,7 @@ jobs:
             ignore-fd-leaks: true
           - os: ubuntu-22.04
           - os: macos-latest
+            failing: true
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
@@ -168,8 +170,6 @@ jobs:
         ./driver unfreeze
         ./driver unpack nonfrozen
     - name: Test
-      # Temporarily, until macOS is fixed
-      continue-on-error: true
       run: cd test && ./driver run
     - name: Check exports
       if: matrix.extra

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,6 @@ AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
 
 # Checks for programs.
-AM_PROG_CC_C_O
 AC_PROG_CC
 
 # Largefile

--- a/src/openslide-file.c
+++ b/src/openslide-file.c
@@ -45,7 +45,10 @@ struct _openslide_file {
 #undef fclose
 #undef g_file_test
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(FILE, fclose)
+static void wrap_fclose(FILE *fp) {
+  fclose(fp);
+}
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FILE, wrap_fclose)
 
 static void io_error(GError **err, const char *fmt, ...) G_GNUC_PRINTF(2, 3);
 static void io_error(GError **err, const char *fmt, ...) {


### PR DESCRIPTION
Test on a variety of distros that we want to keep working.

Notably, we're not testing Debian oldstable, Ubuntu 18.04, and CentOS 7, which in practice means that we're dropping support for them.  The current Debian oldstable will go EOL next month.  Ubuntu 18.04 has not been the current LTS release for two years, and likewise RHEL 8 was released in 2019.  While it's good to preserve some compatibility with LTS distros, we shouldn't maintain very old compatibility constraints forever, and this seems like a good compromise.

Also move the `continue-on-error` flag to job level.  The unconditional `continue-on-error` on `./driver run` caused that step to misleadingly report green, even on OSes where it was failing unexpectedly.  Move the flag to the job level for macOS, which will cause the job to be red but non-fatal.

On CentOS Stream 9, install xdelta from a Copr for now, until it's [available in EPEL 9](https://bugzilla.redhat.com/2110358).