### PR TITLE
Minor fixes/cleanups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -116,7 +116,7 @@ CLEANFILES += test/driver
 EXTRA_DIST += test/driver.in
 
 test_try_open_CPPFLAGS = $(COMMON_CPPFLAGS)
-test_try_open_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
+test_try_open_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS) -Wno-deprecated-declarations
 test_try_open_LDADD = $(COMMON_LDADD)
 
 test_parallel_CPPFLAGS = $(COMMON_CPPFLAGS)

--- a/src/openslide-vendor-leica.c
+++ b/src/openslide-vendor-leica.c
@@ -396,7 +396,7 @@ static struct collection *parse_xml_description(const char *xml,
   // parse the xml
   xmlDoc *doc = _openslide_xml_parse(xml, err);
   if (doc == NULL) {
-    return false;
+    return NULL;
   }
 
   // create XPATH context to query the document

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -290,12 +290,12 @@ static xmlNode *get_initial_xml_iscan(xmlDoc *doc, GError **err) {
     }
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Couldn't find iScan element in initial XML");
-    return false;
+    return NULL;
 
   } else {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Unrecognized root element in initial XML");
-    return false;
+    return NULL;
   }
 }
 

--- a/test/query.c
+++ b/test/query.c
@@ -19,12 +19,13 @@
  *
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <glib.h>
 #include "openslide.h"
 #include "openslide-common.h"
 
-static gboolean query_vendor = FALSE;
+static gboolean query_vendor = false;
 
 static GOptionEntry options[] = {
   {"vendor", 'n', 0, G_OPTION_ARG_NONE, &query_vendor,

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -21,6 +21,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -37,7 +38,7 @@ static gchar **prop_checks;
 static gchar **region_checks;
 static gboolean time_check;
 
-static gboolean have_error = FALSE;
+static bool have_error = false;
 
 static void fail(const char *str, ...) {
   va_list ap;
@@ -47,7 +48,7 @@ static void fail(const char *str, ...) {
     vfprintf(stderr, str, ap);
     fprintf(stderr, "\n");
     va_end(ap);
-    have_error = TRUE;
+    have_error = true;
   }
 }
 
@@ -55,7 +56,7 @@ static void print_log(const gchar *domain G_GNUC_UNUSED,
                       GLogLevelFlags level G_GNUC_UNUSED,
                       const gchar *message, void *data G_GNUC_UNUSED) {
   fprintf(stderr, "[log] %s\n", message);
-  have_error = TRUE;
+  have_error = true;
 }
 
 static void check_error(openslide_t *osr) {
@@ -248,7 +249,7 @@ int main(int argc, char **argv) {
     }
   } else if (!have_error) {
     // openslide_open returned NULL but logged nothing
-    have_error = TRUE;
+    have_error = true;
   }
 
   if (osr != NULL) {
@@ -267,7 +268,7 @@ int main(int argc, char **argv) {
       if (path != NULL) {
         // leaked
         fprintf(stderr, "Leaked file descriptor to %s\n", path);
-        have_error = TRUE;
+        have_error = true;
         g_free(path);
       }
     }

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -215,6 +215,7 @@ int main(int argc, char **argv) {
       print_log, NULL);
 
   const char *vendor = openslide_detect_vendor(filename);
+  bool can_open = openslide_can_open(filename);
   openslide_t *osr = openslide_open(filename);
 
   // Check vendor if requested
@@ -229,6 +230,13 @@ int main(int argc, char **argv) {
            vendor ? vendor : "NULL",
            expected_vendor ? expected_vendor : "NULL");
     }
+  }
+
+  // Check can_open
+  bool did_open = osr && openslide_get_error(osr) == NULL;
+  if (can_open != did_open) {
+    fail("openslide_can_open returned %d but openslide_open %s",
+         can_open, did_open ? "succeeded" : "failed");
   }
 
   // Check for open errors

--- a/tools/openslide-quickhash1sum.c
+++ b/tools/openslide-quickhash1sum.c
@@ -19,18 +19,19 @@
  *
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <glib.h>
 #include "openslide.h"
 #include "openslide-common.h"
 
-static gboolean process(const char *file) {
+static bool process(const char *file) {
   openslide_t *osr = openslide_open(file);
   if (osr == NULL) {
     fprintf(stderr, "%s: %s: Not a file that OpenSlide can recognize\n",
 	    g_get_prgname(), file);
     fflush(stderr);
-    return FALSE;
+    return false;
   }
 
   const char *err = openslide_get_error(osr);
@@ -38,7 +39,7 @@ static gboolean process(const char *file) {
     fprintf(stderr, "%s: %s: %s\n", g_get_prgname(), file, err);
     fflush(stderr);
     openslide_close(osr);
-    return FALSE;
+    return false;
   }
 
   const char *hash = openslide_get_property_value(osr,
@@ -50,11 +51,11 @@ static gboolean process(const char *file) {
             file);
     fflush(stderr);
     openslide_close(osr);
-    return FALSE;
+    return false;
   }
 
   openslide_close(osr);
-  return TRUE;
+  return true;
 }
 
 

--- a/tools/openslide-quickhash1sum.c
+++ b/tools/openslide-quickhash1sum.c
@@ -42,8 +42,8 @@ static bool process(const char *file) {
     return false;
   }
 
-  const char *hash = openslide_get_property_value(osr,
-        "openslide.quickhash-1");
+  const char *hash =
+    openslide_get_property_value(osr, OPENSLIDE_PROPERTY_NAME_QUICKHASH1);
   if (hash != NULL) {
     printf("%s  %s\n", hash, file);
   } else {

--- a/tools/openslide-show-properties.c
+++ b/tools/openslide-show-properties.c
@@ -19,18 +19,19 @@
  *
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <glib.h>
 #include "openslide.h"
 #include "openslide-common.h"
 
-static gboolean process(const char *file, int successes, int total) {
+static bool process(const char *file, int successes, int total) {
   openslide_t *osr = openslide_open(file);
   if (osr == NULL) {
     fprintf(stderr, "%s: %s: Not a file that OpenSlide can recognize\n",
 	    g_get_prgname(), file);
     fflush(stderr);
-    return FALSE;
+    return false;
   }
 
   const char *err = openslide_get_error(osr);
@@ -38,7 +39,7 @@ static gboolean process(const char *file, int successes, int total) {
     fprintf(stderr, "%s: %s: %s\n", g_get_prgname(), file, err);
     fflush(stderr);
     openslide_close(osr);
-    return FALSE;
+    return false;
   }
 
   // print header
@@ -61,7 +62,7 @@ static gboolean process(const char *file, int successes, int total) {
   }
 
   openslide_close(osr);
-  return TRUE;
+  return true;
 }
 
 

--- a/tools/openslide-write-png.c
+++ b/tools/openslide-write-png.c
@@ -88,9 +88,9 @@ static void write_png(openslide_t *osr, FILE *f,
   png_text text_ptr[1];
   memset(text_ptr, 0, sizeof text_ptr);
   text_ptr[0].compression = PNG_TEXT_COMPRESSION_NONE;
-  char *key = strdup(SOFTWARE);
+  char *key = g_strdup(SOFTWARE);
   text_ptr[0].key = key;
-  char *text = strdup(OPENSLIDE);
+  char *text = g_strdup(OPENSLIDE);
   text_ptr[0].text = text;
   text_ptr[0].text_length = strlen(text);
 

--- a/tools/openslide-write-png.c
+++ b/tools/openslide-write-png.c
@@ -45,6 +45,7 @@ static const char OPENSLIDE[] = "OpenSlide <https://openslide.org/>";
     fail(#i " must be positive");	\
   }
 
+static void fail(const char *format, ...) G_GNUC_NORETURN;
 static void fail(const char *format, ...) {
   va_list ap;
 
@@ -97,8 +98,8 @@ static void write_png(openslide_t *osr, FILE *f,
   png_set_text(png_ptr, info_ptr, text_ptr, 1);
 
   // background
-  const char *bgcolor = openslide_get_property_value(osr,
-						     OPENSLIDE_PROPERTY_NAME_BACKGROUND_COLOR);
+  const char *bgcolor =
+    openslide_get_property_value(osr, OPENSLIDE_PROPERTY_NAME_BACKGROUND_COLOR);
   if (bgcolor) {
     int r, g, b;
     sscanf(bgcolor, "%2x%2x%2x", &r, &g, &b);
@@ -223,8 +224,7 @@ int main (int argc, char **argv) {
   // set up output file
   FILE *png = fopen(output, "wb");
   if (!png) {
-    fail("Can't open %s for writing: %s", output,
-	 strerror(errno));
+    fail("Can't open %s for writing: %s", output, strerror(errno));
   }
 
   write_png(osr, png, x, y, level, width, height);


### PR DESCRIPTION
- Test `openslide_can_open()`
- Fix some incorrect return types on error
- Replace remaining uses of `TRUE`/`FALSE` with `true`/`false`
- Stop mixing allocators in `openslide-write-png`
- Minor tools cleanups