### PR TITLE
Migrate most of OpenSlide to `g_autoptr`

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -129,6 +129,12 @@ jobs:
                 ;;
             esac
         esac
+    - name: Check for uninitialized g_auto variables
+      run: |
+        if git grep -En 'g_auto\(|g_autoptr\(|g_autofree ' | grep -v = ; then
+            echo "Found g_auto* declarations without initializers"
+            exit 1
+        fi
     - name: Build
       run: |
         autoreconf -i

--- a/common/openslide-common-cmdline.c
+++ b/common/openslide-common-cmdline.c
@@ -88,9 +88,8 @@ void common_parse_commandline(const struct common_usage_info *info,
                               int *argc, char ***argv) {
   GError *err = NULL;
 
-  GOptionContext *octx = make_option_context(info);
+  g_autoptr(GOptionContext) octx = make_option_context(info);
   common_parse_options(octx, argc, argv, &err);
-  g_option_context_free(octx);
 
   if (err) {
     fprintf(stderr, "%s: %s\n\n", g_get_prgname(), err->message);
@@ -116,12 +115,10 @@ void common_parse_commandline(const struct common_usage_info *info,
 }
 
 void common_usage(const struct common_usage_info *info) {
-  GOptionContext *octx = make_option_context(info);
+  g_autoptr(GOptionContext) octx = make_option_context(info);
 
-  gchar *help = g_option_context_get_help(octx, TRUE, NULL);
+  g_autofree gchar *help = g_option_context_get_help(octx, true, NULL);
   fprintf(stderr, "%s", help);
-  g_free(help);
 
-  g_option_context_free(octx);
   exit(2);
 }

--- a/common/openslide-common.h
+++ b/common/openslide-common.h
@@ -25,6 +25,10 @@
 #include <stdbool.h>
 #include <glib.h>
 
+#ifdef OPENSLIDE_PUBLIC
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(openslide_t, openslide_close)
+#endif
+
 // cmdline
 
 struct common_usage_info {

--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -177,19 +177,16 @@ bool _openslide_gdkpixbuf_read(const char *format,
                                uint32_t *dest,
                                int32_t w, int32_t h,
                                GError **err) {
-  struct _openslide_file *f = _openslide_fopen(filename, err);
+  g_autoptr(_openslide_file) f = _openslide_fopen(filename, err);
   if (!f) {
     return false;
   }
   if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
     g_prefix_error(err, "Couldn't fseek %s: ", filename);
-    _openslide_fclose(f);
     return false;
   }
-  bool ret = gdkpixbuf_read(format, file_read_callback, f, length,
-                            dest, w, h, err);
-  _openslide_fclose(f);
-  return ret;
+  return gdkpixbuf_read(format, file_read_callback, f, length,
+                        dest, w, h, err);
 }
 
 struct mem {

--- a/src/openslide-decode-jp2k.c
+++ b/src/openslide-decode-jp2k.c
@@ -29,6 +29,10 @@
 
 #include <openjpeg.h>
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(opj_codec_t, opj_destroy_codec)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(opj_image_t, opj_image_destroy)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(opj_stream_t, opj_stream_destroy)
+
 struct buffer_state {
   const uint8_t *data;
   int32_t offset;
@@ -171,13 +175,12 @@ static void warning_callback(const char *msg G_GNUC_UNUSED,
 static void error_callback(const char *msg, void *data) {
   GError **err = (GError **) data;
   if (err && !*err) {
-    char *detail = g_strdup(msg);
+    g_autofree char *detail = g_strdup(msg);
     g_strchomp(detail);
     // OpenJPEG can produce obscure error messages, so make sure to
     // indicate where they came from
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "OpenJPEG error: %s", detail);
-    g_free(detail);
   }
 }
 
@@ -219,17 +222,13 @@ bool _openslide_jp2k_decode_buffer(uint32_t *dest,
                                    const void *data, int32_t datalen,
                                    enum _openslide_jp2k_colorspace space,
                                    GError **err) {
-  opj_image_t *image = NULL;
-  GError *tmp_err = NULL;
-  bool success = false;
-
   g_assert(data != NULL);
   g_assert(datalen >= 0);
 
   // init stream
   // avoid tracking stream offset (and implementing skip callback) by having
   // OpenJPEG read the whole buffer at once
-  opj_stream_t *stream = opj_stream_create(datalen, true);
+  g_autoptr(opj_stream_t) stream = opj_stream_create(datalen, true);
   struct buffer_state state = {
     .data = data,
     .length = datalen,
@@ -241,17 +240,19 @@ bool _openslide_jp2k_decode_buffer(uint32_t *dest,
   opj_stream_set_seek_function(stream, seek_callback);
 
   // init codec
-  opj_codec_t *codec = opj_create_decompress(OPJ_CODEC_J2K);
+  g_autoptr(opj_codec_t) codec = opj_create_decompress(OPJ_CODEC_J2K);
   opj_dparameters_t parameters;
   opj_set_default_decoder_parameters(&parameters);
   opj_setup_decoder(codec, &parameters);
 
   // enable error handlers
   // note: don't use info_handler, it outputs lots of junk
+  GError *tmp_err = NULL;
   opj_set_warning_handler(codec, warning_callback, &tmp_err);
   opj_set_error_handler(codec, error_callback, &tmp_err);
 
   // read header
+  g_autoptr(opj_image_t) image = NULL;
   if (!opj_read_header(stream, codec, &image)) {
     if (tmp_err) {
       g_propagate_error(err, tmp_err);
@@ -259,7 +260,7 @@ bool _openslide_jp2k_decode_buffer(uint32_t *dest,
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "opj_read_header() failed");
     }
-    goto DONE;
+    return false;
   }
   g_clear_error(&tmp_err);  // clear any spurious message
 
@@ -269,12 +270,12 @@ bool _openslide_jp2k_decode_buffer(uint32_t *dest,
                 "Dimensional mismatch reading JP2K, "
                 "expected %dx%d, got %ux%u",
                 w, h, image->x1, image->y1);
-    goto DONE;
+    return false;
   }
   if (image->numcomps != 3) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Expected 3 image components, found %u", image->numcomps);
-    goto DONE;
+    return false;
   }
   // TODO more checks?
 
@@ -286,18 +287,12 @@ bool _openslide_jp2k_decode_buffer(uint32_t *dest,
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "opj_decode() failed");
     }
-    goto DONE;
+    return false;
   }
   g_clear_error(&tmp_err);  // clear any spurious message
 
   // copy pixels
   unpack_argb(space, image->comps, dest, w, h);
 
-  success = true;
-
-DONE:
-  opj_image_destroy(image);
-  opj_destroy_codec(codec);
-  opj_stream_destroy(stream);
-  return success;
+  return true;
 }

--- a/src/openslide-decode-jpeg.c
+++ b/src/openslide-decode-jpeg.c
@@ -314,20 +314,16 @@ bool _openslide_jpeg_read_dimensions(const char *filename,
                                      int64_t offset,
                                      int32_t *w, int32_t *h,
                                      GError **err) {
-  struct _openslide_file *f = _openslide_fopen(filename, err);
+  g_autoptr(_openslide_file) f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return false;
   }
   if (offset && !_openslide_fseek(f, offset, SEEK_SET, err)) {
     g_prefix_error(err, "Cannot seek to offset: ");
-    _openslide_fclose(f);
     return false;
   }
 
-  bool success = jpeg_get_dimensions(f, NULL, 0, w, h, err);
-
-  _openslide_fclose(f);
-  return success;
+  return jpeg_get_dimensions(f, NULL, 0, w, h, err);
 }
 
 bool _openslide_jpeg_decode_buffer_dimensions(const void *buf, uint32_t len,
@@ -383,20 +379,16 @@ bool _openslide_jpeg_read(const char *filename,
                           GError **err) {
   //g_debug("read JPEG: %s %"PRId64, filename, offset);
 
-  struct _openslide_file *f = _openslide_fopen(filename, err);
+  g_autoptr(_openslide_file) f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return false;
   }
   if (offset && !_openslide_fseek(f, offset, SEEK_SET, err)) {
     g_prefix_error(err, "Cannot seek to offset: ");
-    _openslide_fclose(f);
     return false;
   }
 
-  bool success = jpeg_decode(f, NULL, 0, dest, false, w, h, err);
-
-  _openslide_fclose(f);
-  return success;
+  return jpeg_decode(f, NULL, 0, dest, false, w, h, err);
 }
 
 bool _openslide_jpeg_decode_buffer(const void *buf, uint32_t len,

--- a/src/openslide-decode-jpeg.h
+++ b/src/openslide-decode-jpeg.h
@@ -98,4 +98,8 @@ void _openslide_jpeg_propagate_error(GError **err,
 
 void _openslide_jpeg_decompress_destroy(struct _openslide_jpeg_decompress *dc);
 
+typedef struct _openslide_jpeg_decompress _openslide_jpeg_decompress;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_jpeg_decompress,
+                              _openslide_jpeg_decompress_destroy)
+
 #endif

--- a/src/openslide-decode-png.c
+++ b/src/openslide-decode-png.c
@@ -175,18 +175,15 @@ bool _openslide_png_read(const char *filename,
                          uint32_t *dest,
                          int64_t w, int64_t h,
                          GError **err) {
-  struct _openslide_file *f = _openslide_fopen(filename, err);
+  g_autoptr(_openslide_file) f = _openslide_fopen(filename, err);
   if (!f) {
     return false;
   }
   if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
     g_prefix_error(err, "Couldn't fseek %s: ", filename);
-    _openslide_fclose(f);
     return false;
   }
-  bool ret = png_read(file_read_callback, f, dest, w, h, err);
-  _openslide_fclose(f);
-  return ret;
+  return png_read(file_read_callback, f, dest, w, h, err);
 }
 
 struct mem {

--- a/src/openslide-decode-sqlite.c
+++ b/src/openslide-decode-sqlite.c
@@ -116,6 +116,11 @@ bool _openslide_sqlite_step(sqlite3_stmt *stmt, GError **err) {
   }
 }
 
+// wrapper that returns void for g_autoptr
+void _openslide_sqlite_finalize(sqlite3_stmt *stmt) {
+  sqlite3_finalize(stmt);
+}
+
 // only legal if an error occurred
 void _openslide_sqlite_propagate_error(sqlite3 *db, GError **err) {
   g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,

--- a/src/openslide-decode-sqlite.h
+++ b/src/openslide-decode-sqlite.h
@@ -32,8 +32,12 @@ sqlite3 *_openslide_sqlite_open(const char *filename, GError **err);
 sqlite3_stmt *_openslide_sqlite_prepare(sqlite3 *db, const char *sql,
                                         GError **err);
 bool _openslide_sqlite_step(sqlite3_stmt *stmt, GError **err);
+void _openslide_sqlite_finalize(sqlite3_stmt *stmt);
 void _openslide_sqlite_propagate_error(sqlite3 *db, GError **err);
 void _openslide_sqlite_propagate_stmt_error(sqlite3_stmt *stmt, GError **err);
 void _openslide_sqlite_close(sqlite3 *db);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(sqlite3, _openslide_sqlite_close)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(sqlite3_stmt, _openslide_sqlite_finalize)
 
 #endif

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -579,7 +579,9 @@ static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
   // check magic
   // TODO: remove if libtiff gets private error/warning callbacks
   if (buf[0] != buf[1]) {
-    goto NOT_TIFF;
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Not a TIFF file: %s", tc->filename);
+    return NULL;
   }
   uint16_t version;
   switch (buf[0]) {
@@ -592,10 +594,14 @@ static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
     version = (buf[3] << 8) | buf[2];
     break;
   default:
-    goto NOT_TIFF;
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Not a TIFF file: %s", tc->filename);
+    return NULL;
   }
   if (version != 42 && version != 43) {
-    goto NOT_TIFF;
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Not a TIFF file: %s", tc->filename);
+    return NULL;
   }
 
   // allocate
@@ -614,11 +620,6 @@ static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
     tiff_do_close(hdl);
   }
   return tiff;
-
-NOT_TIFF:
-  g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-              "Not a TIFF file: %s", tc->filename);
-  return NULL;
 }
 #define TIFFClientOpen _OPENSLIDE_POISON(_openslide_tiffcache_get)
 

--- a/src/openslide-decode-tiff.h
+++ b/src/openslide-decode-tiff.h
@@ -97,4 +97,8 @@ void _openslide_tiffcache_put(struct _openslide_tiffcache *tc, TIFF *tiff);
 
 void _openslide_tiffcache_destroy(struct _openslide_tiffcache *tc);
 
+typedef struct _openslide_tiffcache _openslide_tiffcache;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_tiffcache,
+                              _openslide_tiffcache_destroy)
+
 #endif

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -548,7 +548,7 @@ FAIL:
 
 struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
                                                        GError **err) {
-  struct _openslide_tifflike *tl = NULL;
+  g_autoptr(_openslide_tifflike) tl = NULL;
   GHashTable *loop_detector = NULL;
 
   // open file
@@ -688,10 +688,9 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
 
   g_hash_table_unref(loop_detector);
   _openslide_fclose(f);
-  return tl;
+  return g_steal_pointer(&tl);
 
 FAIL:
-  _openslide_tifflike_destroy(tl);
   if (loop_detector) {
     g_hash_table_unref(loop_detector);
   }

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -184,7 +184,7 @@ static uint64_t fix_offset_ndpi(uint64_t diroff, uint64_t offset) {
     if (!OUT) {								\
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,		\
                   "Cannot allocate TIFF value array");			\
-      goto FAIL;							\
+      return false;							\
     }									\
   } while (0)
 
@@ -315,9 +315,6 @@ static bool set_item_values(struct tiff_item *item,
   // record that we've set all values
   item->offset = NO_OFFSET;
   return true;
-
-FAIL:
-  return false;
 }
 
 static bool populate_item(struct _openslide_tifflike *tl,

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -320,18 +320,15 @@ static bool set_item_values(struct tiff_item *item,
 static bool populate_item(struct _openslide_tifflike *tl,
                           struct tiff_item *item,
                           GError **err) {
-  void *buf = NULL;
-  bool success = false;
-
-  g_mutex_lock(&tl->value_lock);
+  g_autoptr(GMutexLocker) locker G_GNUC_UNUSED =
+    g_mutex_locker_new(&tl->value_lock);
   if (item->offset == NO_OFFSET) {
-    g_mutex_unlock(&tl->value_lock);
     return true;
   }
 
-  struct _openslide_file *f = _openslide_fopen(tl->filename, err);
+  g_autoptr(_openslide_file) f = _openslide_fopen(tl->filename, err);
   if (!f) {
-    goto FAIL;
+    return false;
   }
 
   uint64_t count = item->count;
@@ -339,38 +336,30 @@ static bool populate_item(struct _openslide_tifflike *tl,
   g_assert(value_size);
   ssize_t len = value_size * count;
 
-  buf = g_try_malloc(len);
+  g_autofree void *buf = g_try_malloc(len);
   if (buf == NULL) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Cannot allocate TIFF value");
-    goto FAIL;
+    return false;
   }
 
   //g_debug("reading tiff value: len: %"PRId64", offset %"PRIu64, len, item->offset);
   if (!_openslide_fseek(f, item->offset, SEEK_SET, err)) {
     g_prefix_error(err, "Couldn't seek to read TIFF value: ");
-    goto FAIL;
+    return false;
   }
   if (_openslide_fread(f, buf, len) != (size_t) len) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Couldn't read TIFF value");
-    goto FAIL;
+    return false;
   }
 
   fix_byte_order(buf, value_size, count, tl->big_endian);
   if (!set_item_values(item, buf, err)) {
-    goto FAIL;
+    return false;
   }
 
-  success = true;
-
-FAIL:
-  g_mutex_unlock(&tl->value_lock);
-  g_free(buf);
-  if (f) {
-    _openslide_fclose(f);
-  }
-  return success;
+  return true;
 }
 
 static void tiff_directory_destroy(struct tiff_directory *d) {
@@ -380,6 +369,9 @@ static void tiff_directory_destroy(struct tiff_directory *d) {
   g_hash_table_unref(d->items);
   g_slice_free(struct tiff_directory, d);
 }
+
+typedef struct tiff_directory tiff_directory;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(tiff_directory, tiff_directory_destroy)
 
 static void tiff_item_destroy(gpointer data) {
   struct tiff_item *item = data;
@@ -401,15 +393,13 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
                                              GError **err) {
   int64_t off = *diroff;
   *diroff = 0;
-  struct tiff_directory *d = NULL;
-  bool ok = true;
 
   //  g_debug("diroff: %"PRId64, off);
 
   if (off <= 0) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Bad offset");
-    goto FAIL;
+    return NULL;
   }
 
   // loop detection
@@ -417,7 +407,7 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
     // loop
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Loop detected");
-    goto FAIL;
+    return NULL;
   }
   int64_t *key = g_slice_new(int64_t);
   *key = off;
@@ -426,22 +416,23 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
   // no loop, let's seek
   if (!_openslide_fseek(f, off, SEEK_SET, err)) {
     g_prefix_error(err, "Cannot seek to offset: ");
-    goto FAIL;
+    return NULL;
   }
 
   // read directory count
+  bool ok = true;
   uint64_t dircount = read_uint(f, bigtiff ? 8 : 2, big_endian, &ok);
   if (!ok) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Cannot read dircount");
-    goto FAIL;
+    return NULL;
   }
 
   //  g_debug("dircount: %"PRIu64, dircount);
 
 
   // initial checks passed, initialize the directory
-  d = g_slice_new0(struct tiff_directory);
+  g_autoptr(tiff_directory) d = g_slice_new0(struct tiff_directory);
   d->items = g_hash_table_new_full(g_direct_hash, g_direct_equal,
                                    NULL, tiff_item_destroy);
   d->offset = off;
@@ -455,7 +446,7 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
     if (!ok) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Cannot read tag, type, and count");
-      goto FAIL;
+      return NULL;
     }
 
     //    g_debug(" tag: %d, type: %d, count: %"PRId64, tag, type, count);
@@ -471,14 +462,14 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
     if (!value_size) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Unknown type encountered: %d", type);
-      goto FAIL;
+      return NULL;
     }
 
     // check for overflow
     if (count > SSIZE_MAX / value_size) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Value count too large");
-      goto FAIL;
+      return NULL;
     }
 
     // read in the value/offset
@@ -486,7 +477,7 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
     if (_openslide_fread(f, value, sizeof(value)) != sizeof(value)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Cannot read value/offset");
-      goto FAIL;
+      return NULL;
     }
 
     // does value/offset contain the value?
@@ -494,7 +485,7 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
       // yes
       fix_byte_order(value, value_size, count, big_endian);
       if (!set_item_values(item, value, err)) {
-        goto FAIL;
+        return NULL;
       }
 
     } else {
@@ -530,28 +521,20 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
   if (!ok) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Cannot read next directory offset");
-    goto FAIL;
+    return NULL;
   }
   *diroff = nextdiroff;
 
   // success
-  return d;
-
-
-FAIL:
-  tiff_directory_destroy(d);
-  return NULL;
+  return g_steal_pointer(&d);
 }
 
 struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
                                                        GError **err) {
-  g_autoptr(_openslide_tifflike) tl = NULL;
-  GHashTable *loop_detector = NULL;
-
   // open file
-  struct _openslide_file *f = _openslide_fopen(filename, err);
+  g_autoptr(_openslide_file) f = _openslide_fopen(filename, err);
   if (!f) {
-    goto FAIL;
+    return NULL;
   }
 
   // read and check magic
@@ -559,12 +542,12 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   if (_openslide_fread(f, &magic, sizeof magic) != sizeof magic) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Can't read TIFF magic number");
-    goto FAIL;
+    return NULL;
   }
   if (magic != TIFF_BIGENDIAN && magic != TIFF_LITTLEENDIAN) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Unrecognized TIFF magic number");
-    goto FAIL;
+    return NULL;
   }
   bool big_endian = (magic == TIFF_BIGENDIAN);
 
@@ -586,7 +569,7 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   if (!ok) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Can't read TIFF header");
-    goto FAIL;
+    return NULL;
   }
 
   //  g_debug("version: %d", version);
@@ -596,26 +579,25 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
     if (offset_size != 8 || pad != 0) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Unexpected value in BigTIFF header");
-      goto FAIL;
+      return NULL;
     }
   } else if (version != TIFF_VERSION_CLASSIC) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Unrecognized TIFF version");
-    goto FAIL;
+    return NULL;
   }
 
   // allocate struct
-  tl = g_slice_new0(struct _openslide_tifflike);
+  g_autoptr(_openslide_tifflike) tl = g_slice_new0(struct _openslide_tifflike);
   tl->filename = g_strdup(filename);
   tl->big_endian = big_endian;
   tl->directories = g_ptr_array_new();
   g_mutex_init(&tl->value_lock);
 
   // initialize directory reading
-  loop_detector = g_hash_table_new_full(_openslide_int64_hash,
-                                        _openslide_int64_equal,
-                                        _openslide_int64_free,
-                                        NULL);
+  g_autoptr(GHashTable) loop_detector =
+    g_hash_table_new_full(_openslide_int64_hash, _openslide_int64_equal,
+                          _openslide_int64_free, NULL);
   struct tiff_directory *first_dir = NULL;
 
   // NDPI needs special quirks, since it is classic TIFF pretending to be
@@ -666,7 +648,7 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
 
     // was the directory successfully read?
     if (d == NULL) {
-      goto FAIL;
+      return NULL;
     }
 
     // store result
@@ -680,21 +662,10 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   if (tl->directories->len == 0) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "TIFF contains no directories");
-    goto FAIL;
+    return NULL;
   }
 
-  g_hash_table_unref(loop_detector);
-  _openslide_fclose(f);
   return g_steal_pointer(&tl);
-
-FAIL:
-  if (loop_detector) {
-    g_hash_table_unref(loop_detector);
-  }
-  if (f) {
-    _openslide_fclose(f);
-  }
-  return NULL;
 }
 
 
@@ -809,12 +780,11 @@ static int tag_compare(gconstpointer a, gconstpointer b) {
 static void print_directory(struct _openslide_tifflike *tl,
                             int64_t dir) {
   struct tiff_directory *d = tl->directories->pdata[dir];
-  GList *keys = g_hash_table_get_keys(d->items);
+  g_autoptr(GList) keys = g_hash_table_get_keys(d->items);
   keys = g_list_sort(keys, tag_compare);
   for (GList *el = keys; el; el = el->next) {
     print_tag(tl, dir, GPOINTER_TO_INT(el->data));
   }
-  g_list_free(keys);
 
   printf("\n");
 }

--- a/src/openslide-decode-tifflike.h
+++ b/src/openslide-decode-tifflike.h
@@ -37,6 +37,9 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
 
 void _openslide_tifflike_destroy(struct _openslide_tifflike *tl);
 
+typedef struct _openslide_tifflike _openslide_tifflike;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_tifflike, _openslide_tifflike_destroy)
+
 bool _openslide_tifflike_init_properties_and_hash(openslide_t *osr,
                                                   struct _openslide_tifflike *tl,
                                                   struct _openslide_hash *quickhash1,

--- a/src/openslide-decode-xml.c
+++ b/src/openslide-decode-xml.c
@@ -58,7 +58,7 @@ bool _openslide_xml_has_default_namespace(xmlDoc *doc, const char *ns) {
 
 int64_t _openslide_xml_parse_int_attr(xmlNode *node, const char *name,
                                       GError **err) {
-  xmlChar *value = xmlGetProp(node, BAD_CAST name);
+  g_autoptr(xmlChar) value = xmlGetProp(node, BAD_CAST name);
   if (value == NULL) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "No integer attribute \"%s\"", name);
@@ -70,17 +70,15 @@ int64_t _openslide_xml_parse_int_attr(xmlNode *node, const char *name,
   if (value[0] == 0 || endptr[0] != 0) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Invalid integer attribute \"%s\"", name);
-    xmlFree(value);
     return -1;
   }
 
-  xmlFree(value);
   return result;
 }
 
 double _openslide_xml_parse_double_attr(xmlNode *node, const char *name,
                                         GError **err) {
-  xmlChar *value = xmlGetProp(node, BAD_CAST name);
+  g_autoptr(xmlChar) value = xmlGetProp(node, BAD_CAST name);
   if (value == NULL) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "No floating-point attribute \"%s\"", name);
@@ -91,10 +89,8 @@ double _openslide_xml_parse_double_attr(xmlNode *node, const char *name,
   if (isnan(result)) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Invalid floating-point attribute \"%s\"", name);
-    // fall through
+    return NAN;
   }
-
-  xmlFree(value);
   return result;
 }
 
@@ -118,38 +114,34 @@ xmlXPathContext *_openslide_xml_xpath_create(xmlDoc *doc) {
 // return NULL if no matches
 xmlXPathObject *_openslide_xml_xpath_eval(xmlXPathContext *ctx,
                                           const char *xpath) {
-  xmlXPathObject *result = xmlXPathEvalExpression(BAD_CAST xpath, ctx);
+  g_autoptr(xmlXPathObject) result =
+    xmlXPathEvalExpression(BAD_CAST xpath, ctx);
   if (result && (result->nodesetval == NULL ||
                  result->nodesetval->nodeNr == 0)) {
-    xmlXPathFreeObject(result);
     return NULL;
   }
-  return result;
+  return g_steal_pointer(&result);
 }
 
 // return NULL unless exactly one match
 xmlNode *_openslide_xml_xpath_get_node(xmlXPathContext *ctx,
                                        const char *xpath) {
-  xmlXPathObject *result = _openslide_xml_xpath_eval(ctx, xpath);
-  xmlNode *obj = NULL;
+  g_autoptr(xmlXPathObject) result = _openslide_xml_xpath_eval(ctx, xpath);
   if (result && result->nodesetval->nodeNr == 1) {
-    obj = result->nodesetval->nodeTab[0];
+    return result->nodesetval->nodeTab[0];
   }
-  xmlXPathFreeObject(result);
-  return obj;
+  return NULL;
 }
 
 char *_openslide_xml_xpath_get_string(xmlXPathContext *ctx,
                                       const char *xpath) {
-  xmlXPathObject *result = xmlXPathEvalExpression(BAD_CAST xpath, ctx);
-  char *str = NULL;
+  g_autoptr(xmlXPathObject) result =
+    xmlXPathEvalExpression(BAD_CAST xpath, ctx);
   if (result && result->nodesetval && result->nodesetval->nodeNr) {
-    xmlChar *xmlstr = xmlXPathCastToString(result);
-    str = g_strdup((char *) xmlstr);
-    xmlFree(xmlstr);
+    g_autoptr(xmlChar) xmlstr = xmlXPathCastToString(result);
+    return g_strdup((char *) xmlstr);
   }
-  xmlXPathFreeObject(result);
-  return str;
+  return NULL;
 }
 
 void _openslide_xml_set_prop_from_xpath(openslide_t *osr,

--- a/src/openslide-decode-xml.h
+++ b/src/openslide-decode-xml.h
@@ -33,6 +33,7 @@
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(xmlChar, xmlFree)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(xmlDoc, xmlFreeDoc)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(xmlXPathContext, xmlXPathFreeContext)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(xmlXPathObject, xmlXPathFreeObject)
 
 xmlDoc *_openslide_xml_parse(const char *xml, GError **err);

--- a/src/openslide-decode-xml.h
+++ b/src/openslide-decode-xml.h
@@ -31,7 +31,9 @@
 
 /* libxml support code */
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(xmlChar, xmlFree)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(xmlDoc, xmlFreeDoc)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(xmlXPathObject, xmlXPathFreeObject)
 
 xmlDoc *_openslide_xml_parse(const char *xml, GError **err);
 

--- a/src/openslide-grid.c
+++ b/src/openslide-grid.c
@@ -158,6 +158,47 @@ struct range_tile {
   double h;
 };
 
+struct cairo_state {
+  cairo_t *cr;
+};
+
+struct cairo_matrix {
+  cairo_t *cr;
+  cairo_matrix_t matrix;
+};
+
+// returns by value!
+static struct cairo_state state_save(cairo_t *cr) {
+  struct cairo_state s = {
+    .cr = cr,
+  };
+  cairo_save(cr);
+  return s;
+}
+
+static void state_restore(struct cairo_state *s) {
+  cairo_restore(s->cr);
+}
+
+typedef struct cairo_state cairo_state;
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(cairo_state, state_restore)
+
+// returns by value!
+static struct cairo_matrix matrix_save(cairo_t *cr) {
+  struct cairo_matrix m = {
+    .cr = cr,
+  };
+  cairo_get_matrix(cr, &m.matrix);
+  return m;
+}
+
+static void matrix_restore(struct cairo_matrix *m) {
+  cairo_set_matrix(m->cr, &m->matrix);
+}
+
+typedef struct cairo_matrix cairo_matrix;
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(cairo_matrix, matrix_restore)
+
 static void compute_region(struct _openslide_grid *grid,
                            double x, double y,
                            int32_t w, int32_t h,
@@ -202,8 +243,7 @@ static bool read_tiles(cairo_t *cr,
   //g_debug("start: %"PRId64" %"PRId64, region->start_tile_x, region->start_tile_y);
   //g_debug("end: %"PRId64" %"PRId64, region->end_tile_x, region->end_tile_y);
 
-  cairo_matrix_t matrix;
-  cairo_get_matrix(cr, &matrix);
+  g_auto(cairo_matrix) matrix = matrix_save(cr);
 
   int64_t tile_y = region->end_tile_y - 1;
 
@@ -217,13 +257,10 @@ static bool read_tiles(cairo_t *cr,
                             grid->tile_advance_x) - region->offset_x;
       //      g_debug("read_tiles %"PRId64" %"PRId64, tile_x, tile_y);
       cairo_translate(cr, translate_x, translate_y);
-      bool success = callback(grid, region, cr,
-                              level, tile_x, tile_y,
-                              arg, err);
-      cairo_set_matrix(cr, &matrix);
-      if (!success) {
+      if (!callback(grid, region, cr, level, tile_x, tile_y, arg, err)) {
         return false;
       }
+      matrix_restore(&matrix);
 
       tile_x--;
     }
@@ -238,7 +275,7 @@ static void label_tile(cairo_t *cr,
                        double r, double g, double b, double a,
                        double w, double h,
                        const char *coordinates) {
-  cairo_save(cr);
+  g_auto(cairo_state) state G_GNUC_UNUSED = state_save(cr);
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
 
   cairo_set_source_rgba(cr, r, g, b, a);
@@ -252,8 +289,6 @@ static void label_tile(cairo_t *cr,
                 (w - extents.width) / 2,
                 (h + extents.height) / 2);
   cairo_show_text(cr, coordinates);
-
-  cairo_restore(cr);
 }
 
 
@@ -280,12 +315,11 @@ static bool simple_read_tile(struct _openslide_grid *_grid,
     return false;
   }
   if (_openslide_debug(OPENSLIDE_DEBUG_TILES)) {
-    char *coordinates = g_strdup_printf("%"PRId64", %"PRId64,
-                                        tile_col, tile_row);
+    g_autofree char *coordinates =
+      g_strdup_printf("%"PRId64", %"PRId64, tile_col, tile_row);
     label_tile(cr, COLOR_TILE,
                grid->base.tile_advance_x, grid->base.tile_advance_y,
                coordinates);
-    g_free(coordinates);
   }
   return true;
 }
@@ -311,8 +345,7 @@ static bool simple_paint_region(struct _openslide_grid *_grid,
   }
 
   // save
-  cairo_matrix_t matrix;
-  cairo_get_matrix(cr, &matrix);
+  g_auto(cairo_matrix) matrix G_GNUC_UNUSED = matrix_save(cr);
 
   // bound on left/top
   int64_t skipped_tiles_x = -MIN(region.start_tile_x, 0);
@@ -328,13 +361,7 @@ static bool simple_paint_region(struct _openslide_grid *_grid,
   region.end_tile_y = MIN(region.end_tile_y, grid->tiles_down);
 
   // read
-  bool result = read_tiles(cr, level, _grid, &region,
-                           simple_read_tile, arg, err);
-
-  // restore
-  cairo_set_matrix(cr, &matrix);
-
-  return result;
+  return read_tiles(cr, level, _grid, &region, simple_read_tile, arg, err);
 }
 
 static void simple_destroy(struct _openslide_grid *_grid) {
@@ -436,20 +463,19 @@ static bool tilemap_read_tile(struct _openslide_grid *_grid,
 
   //g_debug("tilemap read_tile: %"PRId64" %"PRId64", offset: %g %g, dim: %g %g", tile_col, tile_row, tile->offset_x, tile->offset_y, tile->w, tile->h);
 
-  cairo_matrix_t matrix;
-  cairo_get_matrix(cr, &matrix);
+  g_auto(cairo_matrix) matrix G_GNUC_UNUSED = matrix_save(cr);
   cairo_translate(cr, tile->offset_x, tile->offset_y);
-  bool success = grid->read_tile(grid->base.osr, cr, level,
-                                 tile->col, tile->row, tile->data,
-                                 arg, err);
-  if (success && _openslide_debug(OPENSLIDE_DEBUG_TILES)) {
-    char *coordinates = g_strdup_printf("%"PRId64", %"PRId64,
-                                        tile_col, tile_row);
-    label_tile(cr, COLOR_TILE, tile->w, tile->h, coordinates);
-    g_free(coordinates);
+  if (!grid->read_tile(grid->base.osr, cr, level,
+                       tile->col, tile->row, tile->data,
+                       arg, err)) {
+    return false;
   }
-  cairo_set_matrix(cr, &matrix);
-  return success;
+  if (_openslide_debug(OPENSLIDE_DEBUG_TILES)) {
+    g_autofree char *coordinates =
+      g_strdup_printf("%"PRId64", %"PRId64, tile_col, tile_row);
+    label_tile(cr, COLOR_TILE, tile->w, tile->h, coordinates);
+  }
+  return true;
 }
 
 static bool tilemap_paint_region(struct _openslide_grid *_grid,
@@ -469,8 +495,7 @@ static bool tilemap_paint_region(struct _openslide_grid *_grid,
   //g_debug("start tile: %"PRId64" %"PRId64", end tile: %"PRId64" %"PRId64, start_tile_x, start_tile_y, end_tile_x, end_tile_y);
 
   // save
-  cairo_matrix_t matrix;
-  cairo_get_matrix(cr, &matrix);
+  g_auto(cairo_matrix) matrix G_GNUC_UNUSED = matrix_save(cr);
 
   // accommodate extra tiles being drawn
   region.start_tile_x -= grid->extra_tiles_left;
@@ -482,13 +507,7 @@ static bool tilemap_paint_region(struct _openslide_grid *_grid,
                   -grid->extra_tiles_top * grid->base.tile_advance_y);
 
   // read
-  bool result = read_tiles(cr, level, _grid, &region,
-                           tilemap_read_tile, arg, err);
-
-  // restore
-  cairo_set_matrix(cr, &matrix);
-
-  return result;
+  return read_tiles(cr, level, _grid, &region, tilemap_read_tile, arg, err);
 }
 
 static void tilemap_destroy(struct _openslide_grid *_grid) {
@@ -647,18 +666,16 @@ static bool range_paint_region(struct _openslide_grid *_grid,
                                int32_t w, int32_t h,
                                GError **err) {
   struct range_grid *grid = (struct range_grid *) _grid;
-  GList *tiles = NULL;
-  bool result = false;
 
   // ensure _openslide_grid_range_finish_adding_tiles() was called
   g_assert(grid->bins_runtime);
 
   // save
-  cairo_matrix_t matrix;
-  cairo_get_matrix(cr, &matrix);
+  g_auto(cairo_matrix) matrix = matrix_save(cr);
 
   // accumulate relevant tiles
   struct range_bin_address addr;
+  g_autoptr(GList) tiles = NULL;
   for (addr.row = y / grid->bin_height;
        addr.row < (int64_t) (y + h + grid->bin_height - 1) / grid->bin_height;
        addr.row++) {
@@ -682,16 +699,15 @@ static bool range_paint_region(struct _openslide_grid *_grid,
         }
       }
       if (_openslide_debug(OPENSLIDE_DEBUG_TILES)) {
-        char *coordinates = g_strdup_printf("%"PRId64", %"PRId64,
-                                            addr.col, addr.row);
+        g_autofree char *coordinates =
+          g_strdup_printf("%"PRId64", %"PRId64, addr.col, addr.row);
         cairo_translate(cr,
                         addr.col * grid->bin_width - x,
                         addr.row * grid->bin_height - y);
         label_tile(cr, COLOR_BIN,
                    grid->bin_width, grid->bin_height,
                    coordinates);
-        cairo_set_matrix(cr, &matrix);
-        g_free(coordinates);
+        matrix_restore(&matrix);
       }
     }
   }
@@ -711,26 +727,20 @@ static bool range_paint_region(struct _openslide_grid *_grid,
     // draw
     //g_debug("tile x %g y %g", tile->x, tile->y);
     cairo_translate(cr, tile->x - x, tile->y - y);
-    bool success = grid->read_tile(grid->base.osr, cr, level,
-                                   tile->id, tile->data,
-                                   arg, err);
-    if (success && _openslide_debug(OPENSLIDE_DEBUG_TILES)) {
-      char *coordinates = g_strdup_printf("%"PRId64, tile->id);
+    if (!grid->read_tile(grid->base.osr, cr, level,
+                         tile->id, tile->data,
+                         arg, err)) {
+      return false;
+    }
+    if (_openslide_debug(OPENSLIDE_DEBUG_TILES)) {
+      g_autofree char *coordinates = g_strdup_printf("%"PRId64, tile->id);
       label_tile(cr, COLOR_TILE, tile->w, tile->h, coordinates);
-      g_free(coordinates);
     }
-    cairo_set_matrix(cr, &matrix);
-    if (!success) {
-      goto DONE;
-    }
+    matrix_restore(&matrix);
   }
 
   // success
-  result = true;
-
-DONE:
-  g_list_free(tiles);
-  return result;
+  return true;
 }
 
 static void range_destroy(struct _openslide_grid *_grid) {
@@ -901,16 +911,15 @@ void _openslide_grid_draw_tile_info(cairo_t *cr, const char *fmt, ...) {
     return;
   }
 
-  cairo_save(cr);
+  g_auto(cairo_state) state G_GNUC_UNUSED = state_save(cr);
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
   cairo_set_source_rgba(cr, 0.6, 0, 0, 1);
 
   va_list ap;
   va_start(ap, fmt);
-  char *str = g_strdup_vprintf(fmt, ap);
-  char **lines = g_strsplit(str, "\n", 0);
+  g_autofree char *str = g_strdup_vprintf(fmt, ap);
+  g_auto(GStrv) lines = g_strsplit(str, "\n", 0);
   int count = g_strv_length(lines);
-  g_free(str);
   va_end(ap);
 
   cairo_font_extents_t extents;
@@ -919,7 +928,4 @@ void _openslide_grid_draw_tile_info(cairo_t *cr, const char *fmt, ...) {
     cairo_move_to(cr, 5, i * extents.height + extents.ascent + 5);
     cairo_show_text(cr, lines[i]);
   }
-
-  g_strfreev(lines);
-  cairo_restore(cr);
 }

--- a/src/openslide-hash.c
+++ b/src/openslide-hash.c
@@ -63,9 +63,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
 			       const char *filename,
 			       int64_t offset, int64_t size,
 			       GError **err) {
-  bool success = false;
-
-  struct _openslide_file *f = _openslide_fopen(filename, err);
+  g_autoptr(_openslide_file) f = _openslide_fopen(filename, err);
   if (f == NULL) {
     return false;
   }
@@ -75,7 +73,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
     int64_t len = _openslide_fsize(f, err);
     if (len == -1) {
       g_prefix_error(err, "Couldn't get size of %s: ", filename);
-      goto DONE;
+      return false;
     }
     size = len - offset;
   }
@@ -85,7 +83,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
   if (offset != 0) {
     if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
       g_prefix_error(err, "Can't seek in %s: ", filename);
-      goto DONE;
+      return false;
     }
   }
 
@@ -97,7 +95,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
     if (bytes_read != bytes_to_read) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Can't read from %s", filename);
-      goto DONE;
+      return false;
     }
 
     //    g_debug("hash '%s' %"PRId64" %d", filename, offset + (size - bytes_left), bytes_to_read);
@@ -107,11 +105,7 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
     _openslide_hash_data(hash, buf, bytes_read);
   }
 
-  success = true;
-
-DONE:
-  _openslide_fclose(f);
-  return success;
+  return true;
 }
 
 // Invalidate this hash.  Use if this slide is unhashable for some reason.

--- a/src/openslide-hash.h
+++ b/src/openslide-hash.h
@@ -56,4 +56,7 @@ const char *_openslide_hash_get_string(struct _openslide_hash *hash);
 // destructor
 void _openslide_hash_destroy(struct _openslide_hash *hash);
 
+typedef struct _openslide_hash _openslide_hash;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_hash, _openslide_hash_destroy)
+
 #endif

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -34,6 +34,7 @@
 
 #include <cairo.h>
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(cairo_t, cairo_destroy)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(cairo_surface_t, cairo_surface_destroy)
 
 /* the associated image structure */

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -305,6 +305,10 @@ void *_openslide_cache_get(struct _openslide_cache_binding *cb,
 // value unref
 void _openslide_cache_entry_unref(struct _openslide_cache_entry *entry);
 
+typedef struct _openslide_cache_entry _openslide_cache_entry;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_cache_entry,
+                              _openslide_cache_entry_unref)
+
 
 /* Internal error propagation */
 enum OpenSlideError {

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -36,6 +36,7 @@
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(cairo_t, cairo_destroy)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(cairo_surface_t, cairo_surface_destroy)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(openslide_t, openslide_close)
 
 /* the associated image structure */
 struct _openslide_associated_image {

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -297,13 +297,12 @@ bool _openslide_clip_tile(uint32_t *tiledata,
     return true;
   }
 
-  cairo_surface_t *surface =
+  g_autoptr(cairo_surface_t) surface =
     cairo_image_surface_create_for_data((unsigned char *) tiledata,
                                         CAIRO_FORMAT_ARGB32,
                                         tile_w, tile_h,
                                         tile_w * 4);
-  cairo_t *cr = cairo_create(surface);
-  cairo_surface_destroy(surface);
+  g_autoptr(cairo_t) cr = cairo_create(surface);
 
   cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
 
@@ -313,10 +312,7 @@ bool _openslide_clip_tile(uint32_t *tiledata,
   cairo_rectangle(cr, 0, clip_h, tile_w, tile_h - clip_h);
   cairo_fill(cr);
 
-  bool success = _openslide_check_cairo_status(cr, err);
-  cairo_destroy(cr);
-
-  return success;
+  return _openslide_check_cairo_status(cr, err);
 }
 
 // note: g_getenv() is not reentrant

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -91,46 +91,43 @@ static bool render_missing_tile(struct level *l,
                                 uint32_t *dest,
                                 int64_t tile_col, int64_t tile_row,
                                 GError **err) {
-  bool success = true;
-
   int64_t tw = l->tiffl.tile_w;
   int64_t th = l->tiffl.tile_h;
 
   // always fill with transparent (needed for SATURATE)
   memset(dest, 0, tw * th * 4);
 
-  if (l->prev) {
-    // recurse into previous level
-    double relative_ds = l->prev->base.downsample / l->base.downsample;
-
-    cairo_surface_t *surface =
-      cairo_image_surface_create_for_data((unsigned char *) dest,
-                                          CAIRO_FORMAT_ARGB32,
-                                          tw, th, tw * 4);
-    cairo_t *cr = cairo_create(surface);
-    cairo_surface_destroy(surface);
-    cairo_set_operator(cr, CAIRO_OPERATOR_SATURATE);
-    cairo_translate(cr, -1, -1);
-    cairo_scale(cr, relative_ds, relative_ds);
-
-    // For the usual case that we are on a tile boundary in the previous
-    // level, extend the region by one pixel in each direction to ensure we
-    // paint the surrounding tiles.  This reduces the visible seam that
-    // would otherwise occur with non-integer downsamples.
-    success = _openslide_grid_paint_region(l->prev->grid, cr, tiff,
-                                           (tile_col * tw - 1) / relative_ds,
-                                           (tile_row * th - 1) / relative_ds,
-                                           (struct _openslide_level *) l->prev,
-                                           ceil((tw + 2) / relative_ds),
-                                           ceil((th + 2) / relative_ds),
-                                           err);
-    if (success) {
-      success = _openslide_check_cairo_status(cr, err);
-    }
-    cairo_destroy(cr);
+  if (l->prev == NULL) {
+    // no previous levels; nothing to do
+    return true;
   }
 
-  return success;
+  // recurse into previous level
+  double relative_ds = l->prev->base.downsample / l->base.downsample;
+
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) dest,
+                                        CAIRO_FORMAT_ARGB32,
+                                        tw, th, tw * 4);
+  g_autoptr(cairo_t) cr = cairo_create(surface);
+  cairo_set_operator(cr, CAIRO_OPERATOR_SATURATE);
+  cairo_translate(cr, -1, -1);
+  cairo_scale(cr, relative_ds, relative_ds);
+
+  // For the usual case that we are on a tile boundary in the previous
+  // level, extend the region by one pixel in each direction to ensure we
+  // paint the surrounding tiles.  This reduces the visible seam that
+  // would otherwise occur with non-integer downsamples.
+  if (!_openslide_grid_paint_region(l->prev->grid, cr, tiff,
+                                    (tile_col * tw - 1) / relative_ds,
+                                    (tile_row * th - 1) / relative_ds,
+                                    (struct _openslide_level *) l->prev,
+                                    ceil((tw + 2) / relative_ds),
+                                    ceil((th + 2) / relative_ds),
+                                    err)) {
+    return false;
+  }
+  return _openslide_check_cairo_status(cr, err);
 }
 
 static bool decode_tile(struct level *l,
@@ -228,12 +225,11 @@ static bool read_tile(openslide_t *osr,
   }
 
   // draw it
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-								 CAIRO_FORMAT_ARGB32,
-								 tw, th,
-								 tw * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                        CAIRO_FORMAT_ARGB32,
+                                        tw, th, tw * 4);
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return true;

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -413,7 +413,7 @@ static bool aperio_open(openslide_t *osr,
   int32_t level_count = 0;
 
   // open TIFF
-  struct _openslide_tiffcache *tc = _openslide_tiffcache_create(filename);
+  g_autoptr(_openslide_tiffcache) tc = _openslide_tiffcache_create(filename);
   TIFF *tiff = _openslide_tiffcache_get(tc, err);
   if (!tiff) {
     goto FAIL;
@@ -580,14 +580,13 @@ static bool aperio_open(openslide_t *osr,
 
   // put TIFF handle and store tiffcache reference
   _openslide_tiffcache_put(tc, tiff);
-  data->tc = tc;
+  data->tc = g_steal_pointer(&tc);
 
   return true;
 
 FAIL:
   destroy_data(data, levels, level_count);
   _openslide_tiffcache_put(tc, tiff);
-  _openslide_tiffcache_destroy(tc);
   return false;
 }
 

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -202,7 +202,7 @@ static bool read_tile(openslide_t *osr,
   int64_t th = tiffl->tile_h;
 
   // cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             level, tile_col, tile_row,
                                             &cache_entry);
@@ -235,9 +235,6 @@ static bool read_tile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return true;
 }

--- a/src/openslide-vendor-generic-tiff.c
+++ b/src/openslide-vendor-generic-tiff.c
@@ -104,12 +104,11 @@ static bool read_tile(openslide_t *osr,
   }
 
   // draw it
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-                                                                 CAIRO_FORMAT_ARGB32,
-                                                                 tw, th,
-                                                                 tw * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                        CAIRO_FORMAT_ARGB32,
+                                        tw, th, tw * 4);
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return true;

--- a/src/openslide-vendor-generic-tiff.c
+++ b/src/openslide-vendor-generic-tiff.c
@@ -184,7 +184,7 @@ static bool generic_tiff_open(openslide_t *osr,
   GPtrArray *level_array = g_ptr_array_new();
 
   // open TIFF
-  struct _openslide_tiffcache *tc = _openslide_tiffcache_create(filename);
+  g_autoptr(_openslide_tiffcache) tc = _openslide_tiffcache_create(filename);
   TIFF *tiff = _openslide_tiffcache_get(tc, err);
   if (!tiff) {
     goto FAIL;
@@ -276,7 +276,7 @@ static bool generic_tiff_open(openslide_t *osr,
 
   // put TIFF handle and store tiffcache reference
   _openslide_tiffcache_put(tc, tiff);
-  data->tc = tc;
+  data->tc = g_steal_pointer(&tc);
 
   return true;
 
@@ -292,7 +292,6 @@ static bool generic_tiff_open(openslide_t *osr,
   }
   // free TIFF
   _openslide_tiffcache_put(tc, tiff);
-  _openslide_tiffcache_destroy(tc);
   return false;
 }
 

--- a/src/openslide-vendor-generic-tiff.c
+++ b/src/openslide-vendor-generic-tiff.c
@@ -76,7 +76,7 @@ static bool read_tile(openslide_t *osr,
   int64_t th = tiffl->tile_h;
 
   // cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             level, tile_col, tile_row,
                                             &cache_entry);
@@ -111,9 +111,6 @@ static bool read_tile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return true;
 }

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -696,7 +696,7 @@ static bool read_jpeg_tile(openslide_t *osr,
   //g_debug("hamamatsu read_tile: jpeg %d %d, local %d %d, tile %d, dim %d %d", jpeg_col, jpeg_row, local_tile_col, local_tile_row, tileno, tw, th);
 
   // get the jpeg data, possibly from cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             level, tile_col, tile_row,
                                             &cache_entry);
@@ -728,9 +728,6 @@ static bool read_jpeg_tile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return true;
 }
@@ -1604,7 +1601,7 @@ static bool ngr_read_tile(openslide_t *osr,
   int64_t tw = l->column_width;
   int64_t th = MIN(NGR_TILE_HEIGHT, l->base.h - tile_y * NGR_TILE_HEIGHT);
   int tilesize = tw * th * 4;
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   // look up tile in cache
   uint32_t *tiledata = _openslide_cache_get(osr->cache, level, tile_x, tile_y,
                                             &cache_entry);
@@ -1667,9 +1664,6 @@ static bool ngr_read_tile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return true;
 }

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -719,13 +719,12 @@ static bool read_jpeg_tile(openslide_t *osr,
   }
 
   // draw it
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-								 CAIRO_FORMAT_RGB24,
-								 tw, th,
-								 tw * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                        CAIRO_FORMAT_RGB24,
+                                        tw, th, tw * 4);
 
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return true;
@@ -1650,12 +1649,11 @@ static bool ngr_read_tile(openslide_t *osr,
   }
 
   // draw it
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-                                                                 CAIRO_FORMAT_RGB24,
-                                                                 tw, th,
-                                                                 tw * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                         CAIRO_FORMAT_RGB24,
+                                         tw, th, tw * 4);
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return true;

--- a/src/openslide-vendor-leica.c
+++ b/src/openslide-vendor-leica.c
@@ -802,7 +802,7 @@ static bool leica_open(openslide_t *osr, const char *filename,
   GPtrArray *level_array = g_ptr_array_new();
 
   // open TIFF
-  struct _openslide_tiffcache *tc = _openslide_tiffcache_create(filename);
+  g_autoptr(_openslide_tiffcache) tc = _openslide_tiffcache_create(filename);
   TIFF *tiff = _openslide_tiffcache_get(tc, err);
   if (!tiff) {
     goto FAIL;
@@ -879,7 +879,7 @@ static bool leica_open(openslide_t *osr, const char *filename,
 
   // put TIFF handle and store tiffcache reference
   _openslide_tiffcache_put(tc, tiff);
-  data->tc = tc;
+  data->tc = g_steal_pointer(&tc);
 
   return true;
 
@@ -893,7 +893,6 @@ FAIL:
   }
   // free TIFF
   _openslide_tiffcache_put(tc, tiff);
-  _openslide_tiffcache_destroy(tc);
   return false;
 }
 

--- a/src/openslide-vendor-leica.c
+++ b/src/openslide-vendor-leica.c
@@ -157,7 +157,7 @@ static bool read_tile(openslide_t *osr,
   int64_t th = tiffl->tile_h;
 
   // cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             args->area, tile_col, tile_row,
                                             &cache_entry);
@@ -193,9 +193,6 @@ static bool read_tile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return true;
 }

--- a/src/openslide-vendor-leica.c
+++ b/src/openslide-vendor-leica.c
@@ -186,12 +186,11 @@ static bool read_tile(openslide_t *osr,
   }
 
   // draw it
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-                                                                 CAIRO_FORMAT_ARGB32,
-                                                                 tw, th,
-                                                                 tw * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                        CAIRO_FORMAT_ARGB32,
+                                        tw, th, tw * 4);
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return true;

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -274,7 +274,7 @@ static bool read_tile(openslide_t *osr,
   //g_debug("mirax read_tile: src: %g %g, dim: %d %d, tile dim: %g %g, region %g %g %g %g", tile->src_x, tile->src_y, l->image_width, l->image_height, l->tile_w, l->tile_h, x, y, w, h);
 
   // get the image data, possibly from cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             level,
                                             tile->image->imageno,
@@ -325,9 +325,6 @@ static bool read_tile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return success;
 }

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -295,10 +295,10 @@ static bool read_tile(openslide_t *osr,
   }
 
   // draw it
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-                                                                 CAIRO_FORMAT_RGB24,
-                                                                 iw, ih,
-                                                                 iw * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                        CAIRO_FORMAT_RGB24,
+                                        iw, ih, iw * 4);
 
   // if we are drawing a subregion of the tile, we must do an additional copy,
   // because cairo lacks source clipping
@@ -307,7 +307,7 @@ static bool read_tile(openslide_t *osr,
     cairo_surface_t *surface2 = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
                                                            ceil(l->tile_w),
                                                            ceil(l->tile_h));
-    cairo_t *cr2 = cairo_create(surface2);
+    g_autoptr(cairo_t) cr2 = cairo_create(surface2);
     cairo_set_source_surface(cr2, surface, -tile->src_x, -tile->src_y);
 
     // replace original image surface
@@ -319,11 +319,9 @@ static bool read_tile(openslide_t *osr,
                     ceil(l->tile_h));
     cairo_fill(cr2);
     success = _openslide_check_cairo_status(cr2, err);
-    cairo_destroy(cr2);
   }
 
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return success;

--- a/src/openslide-vendor-philips.c
+++ b/src/openslide-vendor-philips.c
@@ -107,7 +107,7 @@ static bool read_tile(openslide_t *osr,
   int64_t th = tiffl->tile_h;
 
   // cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             level, tile_col, tile_row,
                                             &cache_entry);
@@ -158,9 +158,6 @@ static bool read_tile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return true;
 }

--- a/src/openslide-vendor-philips.c
+++ b/src/openslide-vendor-philips.c
@@ -151,12 +151,11 @@ static bool read_tile(openslide_t *osr,
   }
 
   // draw it
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-                                                                 CAIRO_FORMAT_ARGB32,
-                                                                 tw, th,
-                                                                 tw * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                        CAIRO_FORMAT_ARGB32,
+                                        tw, th, tw * 4);
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return true;

--- a/src/openslide-vendor-philips.c
+++ b/src/openslide-vendor-philips.c
@@ -555,7 +555,7 @@ static bool philips_open(openslide_t *osr,
   bool success = false;
 
   // open TIFF
-  struct _openslide_tiffcache *tc = _openslide_tiffcache_create(filename);
+  g_autoptr(_openslide_tiffcache) tc = _openslide_tiffcache_create(filename);
   TIFF *tiff = _openslide_tiffcache_get(tc, err);
   if (!tiff) {
     goto FAIL;
@@ -712,7 +712,7 @@ static bool philips_open(openslide_t *osr,
 
   // put TIFF handle and store tiffcache reference
   _openslide_tiffcache_put(tc, tiff);
-  data->tc = tc;
+  data->tc = g_steal_pointer(&tc);
 
   // done
   success = true;
@@ -730,7 +730,6 @@ FAIL:
   }
   // free TIFF
   _openslide_tiffcache_put(tc, tiff);
-  _openslide_tiffcache_destroy(tc);
 
 DONE:
   // free XML

--- a/src/openslide-vendor-sakura.c
+++ b/src/openslide-vendor-sakura.c
@@ -372,7 +372,7 @@ static bool read_tile(openslide_t *osr,
   GError *tmp_err = NULL;
 
   // cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             level, tile_col, tile_row,
                                             &cache_entry);
@@ -419,9 +419,6 @@ static bool read_tile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return true;
 }

--- a/src/openslide-vendor-sakura.c
+++ b/src/openslide-vendor-sakura.c
@@ -386,12 +386,11 @@ static bool read_tile(openslide_t *osr,
   }
 
   // draw it
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-                                                                 CAIRO_FORMAT_ARGB32,
-                                                                 tile_size, tile_size,
-                                                                 tile_size * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                        CAIRO_FORMAT_ARGB32,
+                                        tile_size, tile_size, tile_size * 4);
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return true;

--- a/src/openslide-vendor-sakura.c
+++ b/src/openslide-vendor-sakura.c
@@ -3,6 +3,7 @@
  *
  *  Copyright (c) 2007-2015 Carnegie Mellon University
  *  Copyright (c) 2011 Google, Inc.
+ *  Copyright (c) 2022 Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -67,23 +68,23 @@ enum color_index {
   NUM_INDEXES = 3,
 };
 
-#define PREPARE_OR_FAIL(DEST, DB, SQL) do {				\
+#define PREPARE_OR_RETURN(DEST, DB, SQL, RET) do {			\
     DEST = _openslide_sqlite_prepare(DB, SQL, err);			\
     if (!DEST) {							\
-      goto FAIL;							\
+      return RET;							\
     }									\
   } while (0)
 
-#define BIND_TEXT_OR_FAIL(STMT, INDEX, STR) do {			\
+#define BIND_TEXT_OR_RETURN(STMT, INDEX, STR, RET) do {			\
     if (sqlite3_bind_text(STMT, INDEX, STR, -1, SQLITE_TRANSIENT)) {	\
       _openslide_sqlite_propagate_stmt_error(STMT, err);		\
-      goto FAIL;							\
+      return RET;							\
     }									\
   } while (0)
 
-#define STEP_OR_FAIL(STMT) do {						\
+#define STEP_OR_RETURN(STMT, RET) do {					\
     if (!_openslide_sqlite_step(STMT, err)) {				\
-      goto FAIL;							\
+      return RET;							\
     }									\
   } while (0)
 
@@ -106,34 +107,25 @@ struct associated_image {
 };
 
 static char *get_quoted_unique_table_name(sqlite3 *db, GError **err) {
-  sqlite3_stmt *stmt;
-  char *result = NULL;
-
-  PREPARE_OR_FAIL(stmt, db, "SELECT quote(TableName) FROM "
-                  "DataManagerSQLiteConfigXPO");
-  STEP_OR_FAIL(stmt);
-  result = g_strdup((const char *) sqlite3_column_text(stmt, 0));
+  g_autoptr(sqlite3_stmt) stmt = NULL;
+  PREPARE_OR_RETURN(stmt, db, "SELECT quote(TableName) FROM "
+                  "DataManagerSQLiteConfigXPO", NULL);
+  STEP_OR_RETURN(stmt, NULL);
+  g_autofree char *result =
+    g_strdup((const char *) sqlite3_column_text(stmt, 0));
 
   // we only expect to find one row
   if (sqlite3_step(stmt) != SQLITE_DONE) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Found > 1 unique tables");
-    g_free(result);
-    result = NULL;
+    return NULL;
   }
 
-FAIL:
-  sqlite3_finalize(stmt);
-  return result;
+  return g_steal_pointer(&result);
 }
 
 static bool sakura_detect(const char *filename,
                           struct _openslide_tifflike *tl, GError **err) {
-  sqlite3_stmt *stmt = NULL;
-  char *unique_table_name = NULL;
-  char *sql = NULL;
-  bool result = false;
-
   // reject TIFFs
   if (tl) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
@@ -142,37 +134,32 @@ static bool sakura_detect(const char *filename,
   }
 
   // open database
-  sqlite3 *db = _openslide_sqlite_open(filename, err);
+  g_autoptr(sqlite3) db = _openslide_sqlite_open(filename, err);
   if (!db) {
     return false;
   }
 
   // get name of unique table
-  unique_table_name = get_quoted_unique_table_name(db, err);
+  g_autofree char *unique_table_name = get_quoted_unique_table_name(db, err);
   if (!unique_table_name) {
-    goto FAIL;
+    return false;
   }
 
   // check ++MagicBytes from unique table
-  sql = g_strdup_printf("SELECT data FROM %s WHERE id = '++MagicBytes'",
-                        unique_table_name);
-  PREPARE_OR_FAIL(stmt, db, sql);
-  STEP_OR_FAIL(stmt);
+  g_autofree char *sql =
+    g_strdup_printf("SELECT data FROM %s WHERE id = '++MagicBytes'",
+                    unique_table_name);
+  g_autoptr(sqlite3_stmt) stmt = NULL;
+  PREPARE_OR_RETURN(stmt, db, sql, false);
+  STEP_OR_RETURN(stmt, false);
   const char *magic = (const char *) sqlite3_column_text(stmt, 0);
   if (strcmp(magic, MAGIC_BYTES)) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Magic number does not match");
-    goto FAIL;
+    return false;
   }
 
-  result = true;
-
-FAIL:
-  sqlite3_finalize(stmt);
-  g_free(sql);
-  g_free(unique_table_name);
-  _openslide_sqlite_close(db);
-  return result;
+  return true;
 }
 
 static void destroy_level(struct level *l) {
@@ -222,25 +209,21 @@ static bool parse_tileid(const char *tileid,
                          enum color_index *_color,
                          int32_t *_focal_plane,
                          GError **err) {
-  // T;x|y;downsample;color;0
-  gchar **fields = NULL;
-  gchar *synth_tileid = NULL;
-  bool success = false;
-
   // preliminary checks
   if (!g_str_has_prefix(tileid, "T;") || // not a tile
       g_str_has_suffix(tileid, "#")) {   // hash of a tile
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_NO_VALUE,
                 "Not a tile ID");
-    goto OUT;
+    return false;
   }
 
   // parse and check fields
-  fields = g_strsplit_set(tileid, ";|", 0);
+  // T;x|y;downsample;color;0
+  g_auto(GStrv) fields = g_strsplit_set(tileid, ";|", 0);
   if (g_strv_length(fields) != 6) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Bad field count in tile ID %s", tileid);
-    goto OUT;
+    return false;
   }
   int64_t x, y, downsample, color, focal_plane;
   if (!_parse_tileid_column(tileid, fields[1], &x, err) ||
@@ -248,20 +231,21 @@ static bool parse_tileid(const char *tileid,
       !_parse_tileid_column(tileid, fields[3], &downsample, err) ||
       !_parse_tileid_column(tileid, fields[4], &color, err) ||
       !_parse_tileid_column(tileid, fields[5], &focal_plane, err)) {
-    goto OUT;
+    return false;
   }
   if (downsample < 1 || color >= NUM_INDEXES) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Bad field value in tile ID %s", tileid);
-    goto OUT;
+    return false;
   }
 
   // verify round trip (no leading zeros, etc.)
-  synth_tileid = make_tileid(x, y, downsample, color, focal_plane);
+  g_autofree char *synth_tileid =
+    make_tileid(x, y, downsample, color, focal_plane);
   if (strcmp(tileid, synth_tileid)) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Couldn't round-trip tile ID %s", tileid);
-    goto OUT;
+    return false;
   }
 
   // commit
@@ -280,12 +264,7 @@ static bool parse_tileid(const char *tileid,
   if (_focal_plane) {
     *_focal_plane = focal_plane;
   }
-  success = true;
-
-OUT:
-  g_strfreev(fields);
-  g_free(synth_tileid);
-  return success;
+  return true;
 }
 
 static bool read_channel(uint8_t *channeldata,
@@ -297,25 +276,20 @@ static bool read_channel(uint8_t *channeldata,
                          sqlite3_stmt *stmt,
                          GError **err) {
   // compute tile id
-  char *tileid = make_tileid(tile_col * tile_size * downsample,
-                             tile_row * tile_size * downsample,
-                             downsample, color, focal_plane);
+  g_autofree char *tileid = make_tileid(tile_col * tile_size * downsample,
+                                        tile_row * tile_size * downsample,
+                                        downsample, color, focal_plane);
 
   // retrieve compressed tile
   sqlite3_reset(stmt);
-  BIND_TEXT_OR_FAIL(stmt, 1, tileid);
-  STEP_OR_FAIL(stmt);
+  BIND_TEXT_OR_RETURN(stmt, 1, tileid, false);
+  STEP_OR_RETURN(stmt, false);
   const void *buf = sqlite3_column_blob(stmt, 0);
   int buflen = sqlite3_column_bytes(stmt, 0);
-  g_free(tileid);
 
   // decompress
   return _openslide_jpeg_decode_buffer_gray(buf, buflen, channeldata,
                                             tile_size, tile_size, err);
-
-FAIL:
-  g_free(tileid);
-  return false;
 }
 
 static bool read_image(uint32_t *tiledata,
@@ -430,25 +404,19 @@ static bool paint_region(openslide_t *osr, cairo_t *cr,
                          GError **err) {
   struct sakura_ops_data *data = osr->data;
   struct level *l = (struct level *) level;
-  sqlite3_stmt *stmt = NULL;
-  bool success = false;
 
-  sqlite3 *db = _openslide_sqlite_open(data->filename, err);
+  g_autoptr(sqlite3) db = _openslide_sqlite_open(data->filename, err);
   if (!db) {
     return false;
   }
-  PREPARE_OR_FAIL(stmt, db, data->data_sql);
+  g_autoptr(sqlite3_stmt) stmt = NULL;
+  PREPARE_OR_RETURN(stmt, db, data->data_sql, false);
 
-  success = _openslide_grid_paint_region(l->grid, cr, stmt,
-                                         x / l->base.downsample,
-                                         y / l->base.downsample,
-                                         level, w, h,
-                                         err);
-
-FAIL:
-  sqlite3_finalize(stmt);
-  _openslide_sqlite_close(db);
-  return success;
+  return _openslide_grid_paint_region(l->grid, cr, stmt,
+                                      x / l->base.downsample,
+                                      y / l->base.downsample,
+                                      level, w, h,
+                                      err);
 }
 
 static const struct _openslide_ops sakura_ops = {
@@ -460,31 +428,25 @@ static bool get_associated_image_data(struct _openslide_associated_image *_img,
                                       uint32_t *dest,
                                       GError **err) {
   struct associated_image *img = (struct associated_image *) _img;
-  bool success = false;
 
   //g_debug("read Sakura associated image: %s", img->data_sql);
 
   // open DB handle
-  sqlite3 *db = _openslide_sqlite_open(img->filename, err);
+  g_autoptr(sqlite3) db = _openslide_sqlite_open(img->filename, err);
   if (!db) {
     return false;
   }
 
   // read data
-  sqlite3_stmt *stmt;
-  PREPARE_OR_FAIL(stmt, db, img->data_sql);
-  STEP_OR_FAIL(stmt);
+  g_autoptr(sqlite3_stmt) stmt = NULL;
+  PREPARE_OR_RETURN(stmt, db, img->data_sql, false);
+  STEP_OR_RETURN(stmt, false);
   const void *buf = sqlite3_column_blob(stmt, 0);
   int buflen = sqlite3_column_bytes(stmt, 0);
 
   // decode it
-  success = _openslide_jpeg_decode_buffer(buf, buflen, dest,
-                                          img->base.w, img->base.h, err);
-
-FAIL:
-  sqlite3_finalize(stmt);
-  _openslide_sqlite_close(db);
-  return success;
+  return _openslide_jpeg_decode_buffer(buf, buflen, dest,
+                                       img->base.w, img->base.h, err);
 }
 
 static void destroy_associated_image(struct _openslide_associated_image *_img) {
@@ -506,26 +468,24 @@ static bool add_associated_image(openslide_t *osr,
                                  const char *name,
                                  const char *data_sql,
                                  GError **err) {
-  bool success = false;
-
   // read data
-  sqlite3_stmt *stmt;
-  PREPARE_OR_FAIL(stmt, db, data_sql);
-  STEP_OR_FAIL(stmt);
+  g_autoptr(sqlite3_stmt) stmt = NULL;
+  PREPARE_OR_RETURN(stmt, db, data_sql, false);
+  STEP_OR_RETURN(stmt, false);
   const void *buf = sqlite3_column_blob(stmt, 0);
   int buflen = sqlite3_column_bytes(stmt, 0);
 
   // read dimensions from JPEG header
   int32_t w, h;
   if (!_openslide_jpeg_decode_buffer_dimensions(buf, buflen, &w, &h, err)) {
-    goto FAIL;
+    return false;
   }
 
   // ensure there is only one row
   if (sqlite3_step(stmt) != SQLITE_DONE) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Query returned multiple rows: %s", data_sql);
-    goto FAIL;
+    return false;
   }
 
   // create struct
@@ -539,11 +499,7 @@ static bool add_associated_image(openslide_t *osr,
   // add it
   g_hash_table_insert(osr->associated_images, g_strdup(name), img);
 
-  success = true;
-
-FAIL:
-  sqlite3_finalize(stmt);
-  return success;
+  return true;
 }
 
 static gint compare_downsamples(const void *a, const void *b) {
@@ -563,17 +519,13 @@ static bool read_header(sqlite3 *db, const char *unique_table_name,
                         int64_t *image_width, int64_t *image_height,
                         int32_t *_tile_size, int32_t *_focal_planes,
                         GError **err) {
-  GInputStream *strm = NULL;
-  GDataInputStream *dstrm = NULL;
-  GError *tmp_err = NULL;
-  bool success = false;
-
   // load header
-  char *sql = g_strdup_printf("SELECT data FROM %s WHERE id = 'Header'",
-                              unique_table_name);
-  sqlite3_stmt *stmt;
-  PREPARE_OR_FAIL(stmt, db, sql);
-  STEP_OR_FAIL(stmt);
+  g_autofree char *sql =
+    g_strdup_printf("SELECT data FROM %s WHERE id = 'Header'",
+                    unique_table_name);
+  g_autoptr(sqlite3_stmt) stmt = NULL;
+  PREPARE_OR_RETURN(stmt, db, sql, false);
+  STEP_OR_RETURN(stmt, false);
   const void *buf = sqlite3_column_blob(stmt, 0);
   const int buflen = sqlite3_column_bytes(stmt, 0);
   if (!buf) {
@@ -581,40 +533,42 @@ static bool read_header(sqlite3 *db, const char *unique_table_name,
   }
 
   // create data stream
-  strm = g_memory_input_stream_new_from_data(buf, buflen, NULL);
-  dstrm = g_data_input_stream_new(strm);
+  g_autoptr(GInputStream) strm =
+    g_memory_input_stream_new_from_data(buf, buflen, NULL);
+  g_autoptr(GDataInputStream) dstrm = g_data_input_stream_new(strm);
   g_data_input_stream_set_byte_order(dstrm,
                                      G_DATA_STREAM_BYTE_ORDER_LITTLE_ENDIAN);
 
   // read fields
+  GError *tmp_err = NULL;
   uint32_t tile_size = g_data_input_stream_read_uint32(dstrm, NULL, &tmp_err);
   if (tmp_err) {
     g_propagate_error(err, tmp_err);
-    goto FAIL;
+    return false;
   }
   if (tile_size == 0 || tile_size > INT32_MAX) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Invalid tile size: %u", tile_size);
-    goto FAIL;
+    return false;
   }
   uint32_t w = g_data_input_stream_read_uint32(dstrm, NULL, &tmp_err);
   if (tmp_err) {
     g_propagate_error(err, tmp_err);
-    goto FAIL;
+    return false;
   }
   uint32_t h = g_data_input_stream_read_uint32(dstrm, NULL, &tmp_err);
   if (tmp_err) {
     g_propagate_error(err, tmp_err);
-    goto FAIL;
+    return false;
   }
   if (!g_seekable_seek(G_SEEKABLE(dstrm), 16, G_SEEK_SET, NULL, err)) {
-    goto FAIL;
+    return false;
   }
   uint32_t focal_planes = g_data_input_stream_read_uint32(dstrm, NULL,
                                                           &tmp_err);
   if (tmp_err) {
     g_propagate_error(err, tmp_err);
-    goto FAIL;
+    return false;
   }
 
   // commit
@@ -622,111 +576,101 @@ static bool read_header(sqlite3 *db, const char *unique_table_name,
   *image_height = h;
   *_tile_size = tile_size;
   *_focal_planes = focal_planes;
-  success = true;
-
-FAIL:
-  if (dstrm) {
-    g_object_unref(dstrm);
-  }
-  if (strm) {
-    g_object_unref(strm);
-  }
-  sqlite3_finalize(stmt);
-  g_free(sql);
-  return success;
+  return true;
 }
 
 static void add_properties(openslide_t *osr,
                            sqlite3 *db,
                            const char *unique_table_name) {
-  // build unified query
-  GString *query = g_string_new("SELECT ");
-  for (uint32_t i = 0; i < G_N_ELEMENTS(property_table); i++) {
-    const struct property *prop = &property_table[i];
-    g_string_append_printf(query, "%s%s.%s",
-                           i ? ", " : "",
-                           prop->table,
-                           prop->column);
-  }
-  g_string_append(query, " FROM SVSlideDataXPO JOIN SVHRScanDataXPO ON "
-                  "SVHRScanDataXPO.ParentSlide == SVSlideDataXPO.OID");
-  char *sql = g_string_free(query, false);
-  //g_debug("%s", sql);
-
-  // execute it
-  sqlite3_stmt *stmt = _openslide_sqlite_prepare(db, sql, NULL);
-  if (stmt && sqlite3_step(stmt) == SQLITE_ROW) {
-    // add properties
+  {
+    // build unified query
+    GString *query = g_string_new("SELECT ");
     for (uint32_t i = 0; i < G_N_ELEMENTS(property_table); i++) {
       const struct property *prop = &property_table[i];
-      switch (prop->type) {
-      case SQLITE_TEXT: {
-        const char *value = (const char *) sqlite3_column_text(stmt, i);
-        if (value[0]) {
+      g_string_append_printf(query, "%s%s.%s",
+                             i ? ", " : "",
+                             prop->table,
+                             prop->column);
+    }
+    g_string_append(query, " FROM SVSlideDataXPO JOIN SVHRScanDataXPO ON "
+                    "SVHRScanDataXPO.ParentSlide == SVSlideDataXPO.OID");
+    g_autofree char *sql = g_string_free(query, false);
+    //g_debug("%s", sql);
+
+    // execute it
+    g_autoptr(sqlite3_stmt) stmt = _openslide_sqlite_prepare(db, sql, NULL);
+    if (stmt && sqlite3_step(stmt) == SQLITE_ROW) {
+      // add properties
+      for (uint32_t i = 0; i < G_N_ELEMENTS(property_table); i++) {
+        const struct property *prop = &property_table[i];
+        switch (prop->type) {
+        case SQLITE_TEXT: {
+          const char *value = (const char *) sqlite3_column_text(stmt, i);
+          if (value[0]) {
+            g_hash_table_insert(osr->properties,
+                                g_strdup_printf("sakura.%s", prop->column),
+                                g_strdup(value));
+          }
+          break;
+        }
+        case SQLITE_FLOAT: {
+          // convert to text ourselves to ensure full precision
+          double value = sqlite3_column_double(stmt, i);
           g_hash_table_insert(osr->properties,
                               g_strdup_printf("sakura.%s", prop->column),
-                              g_strdup(value));
+                              _openslide_format_double(value));
+          break;
         }
-        break;
-      }
-      case SQLITE_FLOAT: {
-        // convert to text ourselves to ensure full precision
-        double value = sqlite3_column_double(stmt, i);
-        g_hash_table_insert(osr->properties,
-                            g_strdup_printf("sakura.%s", prop->column),
-                            _openslide_format_double(value));
-        break;
-      }
-      default:
-        g_assert_not_reached();
+        default:
+          g_assert_not_reached();
+        }
       }
     }
   }
-  sqlite3_finalize(stmt);
-  g_free(sql);
 
-  // set MPP and objective power
-  stmt = _openslide_sqlite_prepare(db, "SELECT ResolutionMmPerPix FROM "
-                                   "SVHRScanDataXPO JOIN SVSlideDataXPO ON "
-                                   "SVHRScanDataXPO.ParentSlide = "
-                                   "SVSlideDataXPO.OID", NULL);
-  if (stmt && sqlite3_step(stmt) == SQLITE_ROW) {
-    double mmpp = sqlite3_column_double(stmt, 0);
-    g_hash_table_insert(osr->properties,
-                        g_strdup(OPENSLIDE_PROPERTY_NAME_MPP_X),
-                        _openslide_format_double(mmpp * 1000));
-    g_hash_table_insert(osr->properties,
-                        g_strdup(OPENSLIDE_PROPERTY_NAME_MPP_Y),
-                        _openslide_format_double(mmpp * 1000));
+  {
+    // set MPP and objective power
+    g_autoptr(sqlite3_stmt) stmt =
+      _openslide_sqlite_prepare(db, "SELECT ResolutionMmPerPix FROM "
+                                    "SVHRScanDataXPO JOIN SVSlideDataXPO ON "
+                                    "SVHRScanDataXPO.ParentSlide = "
+                                    "SVSlideDataXPO.OID", NULL);
+    if (stmt && sqlite3_step(stmt) == SQLITE_ROW) {
+      double mmpp = sqlite3_column_double(stmt, 0);
+      g_hash_table_insert(osr->properties,
+                          g_strdup(OPENSLIDE_PROPERTY_NAME_MPP_X),
+                          _openslide_format_double(mmpp * 1000));
+      g_hash_table_insert(osr->properties,
+                          g_strdup(OPENSLIDE_PROPERTY_NAME_MPP_Y),
+                          _openslide_format_double(mmpp * 1000));
+    }
+    _openslide_duplicate_double_prop(osr, "sakura.NominalLensMagnification",
+                                     OPENSLIDE_PROPERTY_NAME_OBJECTIVE_POWER);
   }
-  sqlite3_finalize(stmt);
-  _openslide_duplicate_double_prop(osr, "sakura.NominalLensMagnification",
-                                   OPENSLIDE_PROPERTY_NAME_OBJECTIVE_POWER);
 
-  // add version property
-  sql = g_strdup_printf("SELECT data FROM %s WHERE id = '++VersionBytes'",
-                        unique_table_name);
-  stmt = _openslide_sqlite_prepare(db, sql, NULL);
-  if (stmt && sqlite3_step(stmt) == SQLITE_ROW) {
-    const char *version = (const char *) sqlite3_column_text(stmt, 0);
-    g_hash_table_insert(osr->properties,
-                        g_strdup("sakura.VersionBytes"),
-                        g_strdup(version));
+  {
+    // add version property
+    g_autofree char *sql =
+      g_strdup_printf("SELECT data FROM %s WHERE id = '++VersionBytes'",
+                      unique_table_name);
+    g_autoptr(sqlite3_stmt) stmt = _openslide_sqlite_prepare(db, sql, NULL);
+    if (stmt && sqlite3_step(stmt) == SQLITE_ROW) {
+      const char *version = (const char *) sqlite3_column_text(stmt, 0);
+      g_hash_table_insert(osr->properties,
+                          g_strdup("sakura.VersionBytes"),
+                          g_strdup(version));
+    }
   }
-  sqlite3_finalize(stmt);
-  g_free(sql);
 }
 
 static bool hash_columns(struct _openslide_hash *quickhash1,
                          sqlite3 *db,
                          const char *sql,
                          GError **err) {
-  bool success = false;
-
   //g_debug("%s", sql);
 
-  sqlite3_stmt *stmt;
-  PREPARE_OR_FAIL(stmt, db, sql);
+  g_autoptr(sqlite3_stmt) stmt = NULL;
+  PREPARE_OR_RETURN(stmt, db, sql, false);
   int ret;
   while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
     for (int i = 0; i < sqlite3_column_count(stmt); i++) {
@@ -740,14 +684,10 @@ static bool hash_columns(struct _openslide_hash *quickhash1,
   }
   if (ret != SQLITE_DONE) {
     _openslide_sqlite_propagate_error(db, err);
-    goto FAIL;
+    return false;
   }
 
-  success = true;
-
-FAIL:
-  sqlite3_finalize(stmt);
-  return success;
+  return true;
 }
 
 static gint compare_tileids(const void *a, const void *b,
@@ -760,22 +700,20 @@ static bool hash_tiles(struct _openslide_hash *quickhash1,
                        const char *unique_table_name,
                        GQueue *tileids,
                        GError **err) {
-  bool success = false;
-
   // sort tile IDs
   g_queue_sort(tileids, compare_tileids, NULL);
 
   // prepare query
-  char *sql = g_strdup_printf("SELECT data from %s WHERE id = ?",
-                              unique_table_name);
-  sqlite3_stmt *stmt;
-  PREPARE_OR_FAIL(stmt, db, sql);
+  g_autofree char *sql = g_strdup_printf("SELECT data from %s WHERE id = ?",
+                                         unique_table_name);
+  g_autoptr(sqlite3_stmt) stmt = NULL;
+  PREPARE_OR_RETURN(stmt, db, sql, false);
 
   // hash tiles
   for (GList *cur = tileids->head; cur; cur = cur->next) {
     sqlite3_reset(stmt);
-    BIND_TEXT_OR_FAIL(stmt, 1, cur->data);
-    STEP_OR_FAIL(stmt);
+    BIND_TEXT_OR_RETURN(stmt, 1, cur->data, false);
+    STEP_OR_RETURN(stmt, false);
     const void *data = sqlite3_column_blob(stmt, 0);
     int datalen = sqlite3_column_bytes(stmt, 0);
 
@@ -783,12 +721,7 @@ static bool hash_tiles(struct _openslide_hash *quickhash1,
     _openslide_hash_data(quickhash1, data, datalen);
   }
 
-  success = true;
-
-FAIL:
-  sqlite3_finalize(stmt);
-  g_free(sql);
-  return success;
+  return true;
 }
 
 static void compute_quickhash1(struct _openslide_hash *quickhash1,
@@ -798,31 +731,29 @@ static void compute_quickhash1(struct _openslide_hash *quickhash1,
   if (!hash_columns(quickhash1, db, "SELECT SlideId, Date, Creator, "
                     "Description, Keywords FROM SVSlideDataXPO "
                     "ORDER BY OID", NULL)) {
-    goto FAIL;
+    _openslide_hash_disable(quickhash1);
+    return;
   }
   if (!hash_columns(quickhash1, db, "SELECT ScanId, Date, Name, Description "
                     "FROM SVHRScanDataXPO ORDER BY OID", NULL)) {
-    goto FAIL;
+    _openslide_hash_disable(quickhash1);
+    return;
   }
 
   // header blob
-  char *sql = g_strdup_printf("SELECT data FROM %s WHERE id = 'Header' "
-                              "ORDER BY rowid", unique_table_name);
-  bool success = hash_columns(quickhash1, db, sql, NULL);
-  g_free(sql);
-  if (!success) {
-    goto FAIL;
+  g_autofree char *sql =
+    g_strdup_printf("SELECT data FROM %s WHERE id = 'Header' ORDER BY rowid",
+                    unique_table_name);
+  if (!hash_columns(quickhash1, db, sql, NULL)) {
+    _openslide_hash_disable(quickhash1);
+    return;
   }
 
   // tiles in lowest-resolution level
   if (!hash_tiles(quickhash1, db, unique_table_name, tileids, NULL)) {
-    goto FAIL;
+    _openslide_hash_disable(quickhash1);
+    return;
   }
-
-  return;
-
-FAIL:
-  _openslide_hash_disable(quickhash1);
 }
 
 static void clear_tileids(GQueue *tileids) {
@@ -832,32 +763,26 @@ static void clear_tileids(GQueue *tileids) {
   }
 }
 
+static void free_tileid_queue(GQueue *tileids) {
+  g_queue_free_full(tileids, g_free);
+}
+
+typedef GQueue tileid_queue;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(tileid_queue, free_tileid_queue)
+
 static bool sakura_open(openslide_t *osr, const char *filename,
                         struct _openslide_tifflike *tl G_GNUC_UNUSED,
                         struct _openslide_hash *quickhash1, GError **err) {
-  struct level **levels = NULL;
-  int32_t level_count = 0;
-  char *unique_table_name = NULL;
-  char *sql = NULL;
-  sqlite3_stmt *stmt = NULL;
-  GHashTable *level_hash =
-    g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free,
-                          (GDestroyNotify) destroy_level);
-  GQueue *quickhash_tileids = g_queue_new();
-  int64_t quickhash_downsample = 0;
-  bool success = false;
-  GError *tmp_err = NULL;
-
   // open database
-  sqlite3 *db = _openslide_sqlite_open(filename, err);
+  g_autoptr(sqlite3) db = _openslide_sqlite_open(filename, err);
   if (!db) {
-    goto FAIL;
+    return false;
   }
 
   // get unique table name
-  unique_table_name = get_quoted_unique_table_name(db, err);
+  g_autofree char *unique_table_name = get_quoted_unique_table_name(db, err);
   if (!unique_table_name) {
-    goto FAIL;
+    return false;
   }
 
   // read header
@@ -869,7 +794,7 @@ static bool sakura_open(openslide_t *osr, const char *filename,
   if (!read_header(db, unique_table_name,
                    &image_width, &image_height,
                    &tile_size, &focal_planes, err)) {
-    goto FAIL;
+    return false;
   }
 
   // select middle focal plane
@@ -877,13 +802,21 @@ static bool sakura_open(openslide_t *osr, const char *filename,
   //g_debug("Using focal plane %d", chosen_focal_plane);
 
   // create levels; gather tileids for top level
-  sql = g_strdup_printf("SELECT id FROM %s", unique_table_name);
-  PREPARE_OR_FAIL(stmt, db, sql);
+  g_autoptr(GHashTable) level_hash =
+    g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free,
+                          (GDestroyNotify) destroy_level);
+  g_autoptr(tileid_queue) quickhash_tileids = g_queue_new();
+  int64_t quickhash_downsample = 0;
+  g_autofree char *sql =
+    g_strdup_printf("SELECT id FROM %s", unique_table_name);
+  g_autoptr(sqlite3_stmt) stmt = NULL;
+  PREPARE_OR_RETURN(stmt, db, sql, false);
   int ret;
   while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
     const char *tileid = (const char *) sqlite3_column_text(stmt, 0);
     int64_t downsample;
     int32_t focal_plane;
+    GError *tmp_err = NULL;
     if (!parse_tileid(tileid, NULL, NULL, &downsample, NULL, &focal_plane,
                       &tmp_err)) {
       if (g_error_matches(tmp_err, OPENSLIDE_ERROR,
@@ -893,7 +826,7 @@ static bool sakura_open(openslide_t *osr, const char *filename,
         continue;
       } else {
         g_propagate_error(err, tmp_err);
-        goto FAIL;
+        return false;
       }
     }
 
@@ -904,7 +837,7 @@ static bool sakura_open(openslide_t *osr, const char *filename,
       if (downsample <= 0 || (downsample & (downsample - 1))) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Invalid downsample %"PRId64, downsample);
-        goto FAIL;
+        return false;
       }
 
       l = g_slice_new0(struct level);
@@ -937,21 +870,18 @@ static bool sakura_open(openslide_t *osr, const char *filename,
   }
   if (ret != SQLITE_DONE) {
     _openslide_sqlite_propagate_error(db, err);
-    goto FAIL;
+    return false;
   }
-  sqlite3_finalize(stmt);
-  stmt = NULL;
-  g_free(sql);
-  sql = NULL;
 
   // move levels to level array
-  level_count = g_hash_table_size(level_hash);
+  int32_t level_count = g_hash_table_size(level_hash);
   if (level_count == 0) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Couldn't find any tiles");
-    goto FAIL;
+    return false;
   }
-  levels = g_new(struct level *, level_count);
+  // not autoptr; we can't fail after this
+  struct level **levels = g_new(struct level *, level_count);
   GList *keys = g_hash_table_get_keys(level_hash);
   keys = g_list_sort(keys, compare_downsamples);
   int32_t i = 0;
@@ -959,10 +889,9 @@ static bool sakura_open(openslide_t *osr, const char *filename,
     levels[i] = g_hash_table_lookup(level_hash, cur->data);
     g_assert(levels[i]);
     g_hash_table_steal(level_hash, cur->data);
-    g_free(cur->data);
     i++;
   }
-  g_list_free(keys);
+  g_list_free_full(keys, g_free);
 
   // add properties
   add_properties(osr, db, unique_table_name);
@@ -1001,24 +930,7 @@ static bool sakura_open(openslide_t *osr, const char *filename,
   osr->data = data;
   osr->ops = &sakura_ops;
 
-  success = true;
-
-FAIL:
-  if (!success) {
-    for (int32_t i = 0; i < level_count; i++) {
-      destroy_level(levels[i]);
-    }
-    g_free(levels);
-  }
-
-  sqlite3_finalize(stmt);
-  _openslide_sqlite_close(db);
-  clear_tileids(quickhash_tileids);
-  g_queue_free(quickhash_tileids);
-  g_hash_table_destroy(level_hash);
-  g_free(sql);
-  g_free(unique_table_name);
-  return success;
+  return true;
 }
 
 const struct _openslide_format _openslide_format_sakura = {

--- a/src/openslide-vendor-synthetic.c
+++ b/src/openslide-vendor-synthetic.c
@@ -250,7 +250,7 @@ static bool read_tile(openslide_t *osr G_GNUC_UNUSED,
   const struct synthetic_item *item = tile;
 
   // cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             level, tile_col, tile_row,
                                             &cache_entry);
@@ -274,9 +274,6 @@ static bool read_tile(openslide_t *osr G_GNUC_UNUSED,
                                         IMAGE_PIXELS * 4);
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return true;
 }

--- a/src/openslide-vendor-trestle.c
+++ b/src/openslide-vendor-trestle.c
@@ -123,12 +123,11 @@ static bool read_tile(openslide_t *osr,
   }
 
   // draw it
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-                                                                 CAIRO_FORMAT_ARGB32,
-                                                                 tw, th,
-                                                                 tw * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                        CAIRO_FORMAT_ARGB32,
+                                        tw, th, tw * 4);
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return true;

--- a/src/openslide-vendor-trestle.c
+++ b/src/openslide-vendor-trestle.c
@@ -95,7 +95,7 @@ static bool read_tile(openslide_t *osr,
   int64_t th = tiffl->tile_h;
 
   // cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             level, tile_col, tile_row,
                                             &cache_entry);
@@ -130,9 +130,6 @@ static bool read_tile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return true;
 }

--- a/src/openslide-vendor-trestle.c
+++ b/src/openslide-vendor-trestle.c
@@ -300,7 +300,7 @@ static bool trestle_open(openslide_t *osr, const char *filename,
   int32_t level_count = 0;
 
   // open TIFF
-  struct _openslide_tiffcache *tc = _openslide_tiffcache_create(filename);
+  g_autoptr(_openslide_tiffcache) tc = _openslide_tiffcache_create(filename);
   TIFF *tiff = _openslide_tiffcache_get(tc, err);
   if (!tiff) {
     goto FAIL;
@@ -429,7 +429,7 @@ static bool trestle_open(openslide_t *osr, const char *filename,
 
   // put TIFF handle and store tiffcache reference
   _openslide_tiffcache_put(tc, tiff);
-  data->tc = tc;
+  data->tc = g_steal_pointer(&tc);
 
   return true;
 
@@ -437,7 +437,6 @@ FAIL:
   destroy_data(data, levels, level_count);
   g_free(overlaps);
   _openslide_tiffcache_put(tc, tiff);
-  _openslide_tiffcache_destroy(tc);
   return false;
 }
 

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -336,17 +336,20 @@ static bool ventana_detect(const char *filename G_GNUC_UNUSED,
   return true;
 }
 
+static void area_free(struct area *area) {
+  for (int64_t j = 0; j < area->tile_count; j++) {
+    g_slice_free(struct tile, area->tiles[j]);
+  }
+  g_free(area->tiles);
+  g_slice_free(struct area, area);
+}
+
 static void bif_free(struct bif *bif) {
   if (!bif) {
     return;
   }
   for (int32_t i = 0; i < bif->num_areas; i++) {
-    struct area *area = bif->areas[i];
-    for (int64_t j = 0; j < area->tile_count; j++) {
-      g_slice_free(struct tile, area->tiles[j]);
-    }
-    g_free(area->tiles);
-    g_slice_free(struct area, area);
+    area_free(bif->areas[i]);
   }
   g_free(bif->areas);
   g_slice_free(struct bif, bif);

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -169,7 +169,7 @@ static bool read_subtile(openslide_t *osr,
   double subtile_y = subtile_row % l->subtiles_per_tile * subtile_h;
 
   // get tile data, possibly from cache
-  struct _openslide_cache_entry *cache_entry;
+  g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   uint32_t *tiledata = _openslide_cache_get(osr->cache,
                                             level, tile_col, tile_row,
                                             &cache_entry);
@@ -226,9 +226,6 @@ static bool read_subtile(openslide_t *osr,
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_surface_destroy(surface);
   cairo_paint(cr);
-
-  // done with the cache entry, release it
-  _openslide_cache_entry_unref(cache_entry);
 
   return success;
 }

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -198,10 +198,10 @@ static bool read_subtile(openslide_t *osr,
   }
 
   // draw
-  cairo_surface_t *surface = cairo_image_surface_create_for_data((unsigned char *) tiledata,
-                                                                 CAIRO_FORMAT_ARGB32,
-                                                                 tw, th,
-                                                                 tw * 4);
+  g_autoptr(cairo_surface_t) surface =
+    cairo_image_surface_create_for_data((unsigned char *) tiledata,
+                                        CAIRO_FORMAT_ARGB32,
+                                        tw, th, tw * 4);
 
   // if we are drawing a subtile, we must do an additional copy,
   // because cairo lacks source clipping
@@ -209,7 +209,7 @@ static bool read_subtile(openslide_t *osr,
     cairo_surface_t *surface2 = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
                                                            ceil(subtile_w),
                                                            ceil(subtile_h));
-    cairo_t *cr2 = cairo_create(surface2);
+    g_autoptr(cairo_t) cr2 = cairo_create(surface2);
     cairo_set_source_surface(cr2, surface, -subtile_x, -subtile_y);
 
     // replace original image surface
@@ -221,11 +221,9 @@ static bool read_subtile(openslide_t *osr,
                     ceil(subtile_h));
     cairo_fill(cr2);
     success = _openslide_check_cairo_status(cr2, err);
-    cairo_destroy(cr2);
   }
 
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_surface_destroy(surface);
   cairo_paint(cr);
 
   return success;

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -787,7 +787,7 @@ static bool ventana_open(openslide_t *osr, const char *filename,
   GError *tmp_err = NULL;
 
   // open TIFF
-  struct _openslide_tiffcache *tc = _openslide_tiffcache_create(filename);
+  g_autoptr(_openslide_tiffcache) tc = _openslide_tiffcache_create(filename);
   TIFF *tiff = _openslide_tiffcache_get(tc, err);
   if (!tiff) {
     goto FAIL;
@@ -1008,7 +1008,7 @@ static bool ventana_open(openslide_t *osr, const char *filename,
 
   // put TIFF handle and store tiffcache reference
   _openslide_tiffcache_put(tc, tiff);
-  data->tc = tc;
+  data->tc = g_steal_pointer(&tc);
 
   return true;
 
@@ -1026,7 +1026,6 @@ FAIL:
   }
   // free TIFF
   _openslide_tiffcache_put(tc, tiff);
-  _openslide_tiffcache_destroy(tc);
   return false;
 }
 

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -527,7 +527,7 @@ static bool read_region_area(openslide_t *osr,
                              int64_t w, int64_t h,
                              GError **err) {
   // create the cairo surface for the dest
-  cairo_surface_t *surface;
+  g_autoptr(cairo_surface_t) surface = NULL;
   if (dest) {
     surface =
       cairo_image_surface_create_for_data((unsigned char *) dest,
@@ -539,22 +539,18 @@ static bool read_region_area(openslide_t *osr,
   }
 
   // create the cairo context
-  cairo_t *cr = cairo_create(surface);
-  cairo_surface_destroy(surface);
+  g_autoptr(cairo_t) cr = cairo_create(surface);
 
   // paint
   if (!read_region(osr, cr, x, y, level, w, h, err)) {
-    cairo_destroy(cr);
     return false;
   }
 
   // done
   if (!_openslide_check_cairo_status(cr, err)) {
-    cairo_destroy(cr);
     return false;
   }
 
-  cairo_destroy(cr);
   return true;
 }
 

--- a/test/parallel.c
+++ b/test/parallel.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
   int priming = 5 * threads;
   int64_t w, h;
   openslide_get_level0_dimensions(state.osr, &w, &h);
-  GTimer *timer = g_timer_new();
+  g_autoptr(GTimer) timer = g_timer_new();
   for (int64_t y = 0; y < h; y += TILE_SIZE) {
     for (int64_t x = 0; x < w; x += TILE_SIZE) {
       if (priming) {

--- a/test/profile.c
+++ b/test/profile.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
   const char *path = argv[1];
   int level = atoi(argv[2]);
 
-  openslide_t *osr = openslide_open(path);
+  g_autoptr(openslide_t) osr = openslide_open(path);
   if (!osr) {
     common_fail("Couldn't open %s", path);
   }
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
 
   w = MIN(w, MAXWIDTH);
   h = MIN(h, MAXHEIGHT);
-  uint32_t *buf = g_new(uint32_t, BUFWIDTH * BUFHEIGHT);
+  g_autofree uint32_t *buf = g_new(uint32_t, BUFWIDTH * BUFHEIGHT);
 
   printf("Reading (%"PRId64", %"PRId64") in level %d for "
          "%"PRId64" x %"PRId64"\n\n", x, y, level, w, h);
@@ -103,9 +103,6 @@ int main(int argc, char **argv) {
   if (err) {
     common_fail("Read failed: %s", err);
   }
-
-  g_free(buf);
-  openslide_close(osr);
 
   return 0;
 }

--- a/test/query.c
+++ b/test/query.c
@@ -37,16 +37,14 @@ int main(int argc, char **argv) {
   GError *tmp_err = NULL;
 
   // Parse arguments
-  GOptionContext *ctx =
+  g_autoptr(GOptionContext) ctx =
     g_option_context_new("SLIDE - retrieve information about a slide file");
   g_option_context_add_main_entries(ctx, options, NULL);
   if (!common_parse_options(ctx, &argc, &argv, &tmp_err)) {
     fprintf(stderr, "%s\n", tmp_err->message);
     g_clear_error(&tmp_err);
-    g_option_context_free(ctx);
     return 2;
   }
-  g_option_context_free(ctx);
   if (argc != 2) {
     fprintf(stderr, "No slide specified\n");
     return 2;

--- a/test/synth.c
+++ b/test/synth.c
@@ -27,6 +27,8 @@
 #include <glib.h>
 #include <openslide.h>
 
+#include "openslide-common.h"
+
 int main(int argc, char **argv) {
   if (argc < 2 || !g_str_equal(argv[1], "child")) {
     putenv("OPENSLIDE_DEBUG=synthetic");
@@ -49,7 +51,7 @@ int main(int argc, char **argv) {
   }
 
   // open
-  openslide_t *osr = openslide_open("");
+  g_autoptr(openslide_t) osr = openslide_open("");
   if (osr == NULL) {
     fprintf(stderr, "Couldn't open synthetic slide\n");
     return 1;
@@ -57,7 +59,6 @@ int main(int argc, char **argv) {
   const char *err = openslide_get_error(osr);
   if (err != NULL) {
     fprintf(stderr, "Opening synthetic slide: %s\n", err);
-    openslide_close(osr);
     return 1;
   }
 
@@ -67,7 +68,6 @@ int main(int argc, char **argv) {
   err = openslide_get_error(osr);
   if (err != NULL) {
     fprintf(stderr, "Reading region: %s\n", err);
-    openslide_close(osr);
     return 1;
   }
 
@@ -81,6 +81,5 @@ int main(int argc, char **argv) {
     }
   }
 
-  openslide_close(osr);
   return 0;
 }

--- a/tools/openslide-quickhash1sum.c
+++ b/tools/openslide-quickhash1sum.c
@@ -26,7 +26,7 @@
 #include "openslide-common.h"
 
 static bool process(const char *file) {
-  openslide_t *osr = openslide_open(file);
+  g_autoptr(openslide_t) osr = openslide_open(file);
   if (osr == NULL) {
     fprintf(stderr, "%s: %s: Not a file that OpenSlide can recognize\n",
 	    g_get_prgname(), file);
@@ -38,23 +38,19 @@ static bool process(const char *file) {
   if (err) {
     fprintf(stderr, "%s: %s: %s\n", g_get_prgname(), file, err);
     fflush(stderr);
-    openslide_close(osr);
     return false;
   }
 
   const char *hash =
     openslide_get_property_value(osr, OPENSLIDE_PROPERTY_NAME_QUICKHASH1);
-  if (hash != NULL) {
-    printf("%s  %s\n", hash, file);
-  } else {
+  if (hash == NULL) {
     fprintf(stderr, "%s: %s: No quickhash-1 available\n", g_get_prgname(),
             file);
     fflush(stderr);
-    openslide_close(osr);
     return false;
   }
 
-  openslide_close(osr);
+  printf("%s  %s\n", hash, file);
   return true;
 }
 

--- a/tools/openslide-show-properties.c
+++ b/tools/openslide-show-properties.c
@@ -26,7 +26,7 @@
 #include "openslide-common.h"
 
 static bool process(const char *file, int successes, int total) {
-  openslide_t *osr = openslide_open(file);
+  g_autoptr(openslide_t) osr = openslide_open(file);
   if (osr == NULL) {
     fprintf(stderr, "%s: %s: Not a file that OpenSlide can recognize\n",
 	    g_get_prgname(), file);
@@ -38,7 +38,6 @@ static bool process(const char *file, int successes, int total) {
   if (err) {
     fprintf(stderr, "%s: %s: %s\n", g_get_prgname(), file, err);
     fflush(stderr);
-    openslide_close(osr);
     return false;
   }
 
@@ -61,7 +60,6 @@ static bool process(const char *file, int successes, int total) {
     property_names++;
   }
 
-  openslide_close(osr);
   return true;
 }
 

--- a/tools/openslide-write-png.c
+++ b/tools/openslide-write-png.c
@@ -89,9 +89,9 @@ static void write_png(openslide_t *osr, FILE *f,
   png_text text_ptr[1];
   memset(text_ptr, 0, sizeof text_ptr);
   text_ptr[0].compression = PNG_TEXT_COMPRESSION_NONE;
-  char *key = g_strdup(SOFTWARE);
+  g_autofree char *key = g_strdup(SOFTWARE);
   text_ptr[0].key = key;
-  char *text = g_strdup(OPENSLIDE);
+  g_autofree char *text = g_strdup(OPENSLIDE);
   text_ptr[0].text = text;
   text_ptr[0].text_length = strlen(text);
 
@@ -111,7 +111,7 @@ static void write_png(openslide_t *osr, FILE *f,
   // start writing
   png_write_info(png_ptr, info_ptr);
 
-  uint32_t *dest = g_malloc(w * 4);
+  g_autofree uint32_t *dest = g_malloc(w * 4);
   int32_t lines_to_draw = h;
   double ds = openslide_get_level_downsample(osr, level);
   int32_t yy = y / ds;
@@ -165,9 +165,6 @@ static void write_png(openslide_t *osr, FILE *f,
   }
 
   // end
-  g_free(dest);
-  g_free(key);
-  g_free(text);
   png_write_end(png_ptr, info_ptr);
   png_destroy_write_struct(&png_ptr, &info_ptr);
 }
@@ -194,7 +191,7 @@ int main (int argc, char **argv) {
   const char *output = argv[7];
 
   // open slide
-  openslide_t *osr = openslide_open(slide);
+  g_autoptr(openslide_t) osr = openslide_open(slide);
 
   // check errors
   if (osr == NULL) {
@@ -230,7 +227,6 @@ int main (int argc, char **argv) {
   write_png(osr, png, x, y, level, width, height);
 
   fclose(png);
-  openslide_close(osr);
 
   return 0;
 }


### PR DESCRIPTION
`g_autoptr()` and friends (`g_auto()`, `g_autofree`) allow defining a variable that automatically frees its contents when it goes out of scope.  This greatly reduces the manual allocation tracking that has to be done in error paths (either by manually backing out allocations or by jumping to a common cleanup label), which should help make OpenSlide more maintainable.

Migrate core library code, tools, and tests to `g_autoptr()` and `g_autofree`.  Also migrate the `sakura` vendor driver and certain functions in other drivers.  The remaining drivers will be converted in a followup PR.

For https://github.com/openslide/openslide/issues/310.  Documentation in https://github.com/openslide/openslide.github.io/pull/26.