### PR TITLE
Migrate vendor drivers to `g_autoptr`

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -41,8 +41,6 @@ jobs:
           - os: macos-latest
             failing: true
     steps:
-    - name: Check out repo
-      uses: actions/checkout@v3
     # Quick way to get Python 3 on macOS
     - name: Set up Python (macOS)
       uses: actions/setup-python@v2
@@ -83,6 +81,9 @@ jobs:
                     dnf config-manager --set-enabled crb
                     dnf copr enable -y bgilbert/xdelta
                     ;;
+                *)
+                    extra=git-core
+                    ;;
                 esac
 
                 dnf install -y \
@@ -99,7 +100,7 @@ jobs:
                     cairo-devel \
                     glib2-devel \
                     doxygen \
-                    xdelta libjpeg-turbo-utils
+                    xdelta libjpeg-turbo-utils $extra
                 ;;
             *debian*|"")
                 if [ -n "${{ matrix.container }}" ]; then
@@ -129,8 +130,12 @@ jobs:
                 ;;
             esac
         esac
+    - name: Check out repo
+      uses: actions/checkout@v3
     - name: Check for uninitialized g_auto variables
+      if: matrix.extra
       run: |
+        git config --global --add safe.directory $GITHUB_WORKSPACE
         if git grep -En 'g_auto\(|g_autoptr\(|g_autofree ' | grep -v = ; then
             echo "Found g_auto* declarations without initializers"
             exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,24 @@ PKG_CHECK_MODULES(VALGRIND, [valgrind], [
 
 gl_VISIBILITY
 
+# glib only offers autoptr macros when the compiler supports them
+AC_MSG_CHECKING([compiler support for cleanup attribute])
+saved_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS $GLIB2_CFLAGS"
+AC_COMPILE_IFELSE([
+  AC_LANG_PROGRAM([
+    #include <glib.h>
+    #ifndef G_DEFINE_AUTOPTR_CLEANUP_FUNC
+    #error Cleanup functions not available
+    #endif
+  ])
+], [
+  AC_MSG_RESULT([yes])
+], [
+  AC_MSG_FAILURE([glib2 reports compiler does not support cleanup attribute])
+])
+CFLAGS="$saved_CFLAGS"
+
 # CLOEXEC
 AC_MSG_CHECKING([fopen() close-on-exec flag])
 AS_CASE([$host_os],

--- a/misc/make-vmu.py
+++ b/misc/make-vmu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 #
 #  OpenSlide, a library for reading whole slide image files
 #
@@ -24,16 +24,15 @@
 # to fool OpenSlide.
 #
 
-
 from configparser import RawConfigParser
-from fractions import gcd
+from math import gcd
 from openslide import OpenSlide
 import struct
 import sys
 
 BUF_HEIGHT = 512
 
-class VmuLevel(object):
+class VmuLevel:
     def __init__(self, osr, level):
         self._osr = osr
         self.level = level
@@ -42,9 +41,9 @@ class VmuLevel(object):
         self.downsample = osr.level_downsamples[level]
 
     def save(self, path):
-        with open(path, 'w') as fh:
+        with open(path, 'wb') as fh:
             # Header
-            fh.write(struct.pack('<2c2x3i8xi4x', 'G', 'N', self.width,
+            fh.write(struct.pack('<2c2x3i8xi4x', b'G', b'N', self.width,
                     self.height, self.column_width, 32))
 
             # Body
@@ -73,7 +72,7 @@ def make_vmu(in_path, out_base):
         l0 = VmuLevel(osr, 0)
         l1 = VmuLevel(osr, osr.get_best_level_for_downsample(32))
         for i, l in enumerate([l0, l1]):
-            print(('Level %d: %d pixels/column' % (i, l.column_width)))
+            print(f'Level {i}: {l.column_width} pixels/column')
         l0.save(path_0)
         l1.save(path_1)
 
@@ -89,7 +88,7 @@ def make_vmu(in_path, out_base):
     c = RawConfigParser()
     c.optionxform = str
     c.add_section(section)
-    for k, v in list(conf.items()):
+    for k, v in conf.items():
         c.set(section, k, v)
     with open(path_conf, 'w') as fh:
         c.write(fh)
@@ -97,6 +96,6 @@ def make_vmu(in_path, out_base):
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print(('Usage: %s infile outbase' % sys.argv[0]))
+        print(f'Usage: {sys.argv[0]} infile outbase')
         sys.exit(1)
     make_vmu(sys.argv[1], sys.argv[2])

--- a/misc/make-vmu.py
+++ b/misc/make-vmu.py
@@ -24,8 +24,8 @@
 # to fool OpenSlide.
 #
 
-from __future__ import division
-from ConfigParser import RawConfigParser
+
+from configparser import RawConfigParser
 from fractions import gcd
 from openslide import OpenSlide
 import struct
@@ -48,17 +48,17 @@ class VmuLevel(object):
                     self.height, self.column_width, 32))
 
             # Body
-            for col in xrange(self.width // self.column_width):
+            for col in range(self.width // self.column_width):
                 # BUF_HEIGHT rows at a time
-                for i in xrange((self.height + BUF_HEIGHT - 1) // BUF_HEIGHT):
+                for i in range((self.height + BUF_HEIGHT - 1) // BUF_HEIGHT):
                     rows = min(BUF_HEIGHT, self.height - i * BUF_HEIGHT)
                     img = self._osr.read_region(
                             (int(col * self.column_width * self.downsample),
                             int(i * BUF_HEIGHT * self.downsample)),
                             self.level,
                             (self.column_width, rows)).load()
-                    for y in xrange(rows):
-                        for x in xrange(self.column_width):
+                    for y in range(rows):
+                        for x in range(self.column_width):
                             pix = [v << 4 for v in img[x, y]]
                             # FIXME: ignores alpha
                             fh.write(struct.pack('<3h', *pix[0:3]))
@@ -73,7 +73,7 @@ def make_vmu(in_path, out_base):
         l0 = VmuLevel(osr, 0)
         l1 = VmuLevel(osr, osr.get_best_level_for_downsample(32))
         for i, l in enumerate([l0, l1]):
-            print 'Level %d: %d pixels/column' % (i, l.column_width)
+            print(('Level %d: %d pixels/column' % (i, l.column_width)))
         l0.save(path_0)
         l1.save(path_1)
 
@@ -89,7 +89,7 @@ def make_vmu(in_path, out_base):
     c = RawConfigParser()
     c.optionxform = str
     c.add_section(section)
-    for k, v in conf.iteritems():
+    for k, v in list(conf.items()):
         c.set(section, k, v)
     with open(path_conf, 'w') as fh:
         c.write(fh)
@@ -97,6 +97,6 @@ def make_vmu(in_path, out_base):
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print 'Usage: %s infile outbase' % sys.argv[0]
+        print(('Usage: %s infile outbase' % sys.argv[0]))
         sys.exit(1)
     make_vmu(sys.argv[1], sys.argv[2])

--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -3,6 +3,7 @@
  *
  *  Copyright (c) 2007-2014 Carnegie Mellon University
  *  Copyright (c) 2011 Google, Inc.
+ *  Copyright (c) 2022 Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -38,11 +39,12 @@
 
 #define BUFSIZE (64 << 10)
 
-struct load_state {
+struct gdkpixbuf_ctx {
+  GdkPixbufLoader *loader;
   int32_t w;
   int32_t h;
   GdkPixbuf *pixbuf;  // NULL until validated, then a borrowed ref
-  GError *err;
+  GError *err;        // from area_prepared
 };
 
 // Validate image size and format.  There's no point connecting to the
@@ -50,9 +52,9 @@ struct load_state {
 // after every BUFSIZE bytes, and we'll likely receive both signals while
 // processing the first buffer.
 static void area_prepared(GdkPixbufLoader *loader, void *data) {
-  struct load_state *state = data;
+  struct gdkpixbuf_ctx *ctx = data;
 
-  if (state->err) {
+  if (ctx->err) {
     return;
   }
 
@@ -65,76 +67,112 @@ static void area_prepared(GdkPixbufLoader *loader, void *data) {
       gdk_pixbuf_get_bits_per_sample(pixbuf) != 8 ||
       gdk_pixbuf_get_has_alpha(pixbuf) ||
       gdk_pixbuf_get_n_channels(pixbuf) != 3) {
-    g_set_error(&state->err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+    g_set_error(&ctx->err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Unsupported pixbuf parameters");
     return;
   }
   int w = gdk_pixbuf_get_width(pixbuf);
   int h = gdk_pixbuf_get_height(pixbuf);
-  if (w != state->w || h != state->h) {
-    g_set_error(&state->err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+  if (w != ctx->w || h != ctx->h) {
+    g_set_error(&ctx->err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Dimensional mismatch reading pixbuf: "
-                "expected %dx%d, found %dx%d", state->w, state->h, w, h);
+                "expected %dx%d, found %dx%d", ctx->w, ctx->h, w, h);
     return;
   }
 
   // commit
-  state->pixbuf = pixbuf;
+  ctx->pixbuf = pixbuf;
+}
+
+static void gdkpixbuf_ctx_free(struct gdkpixbuf_ctx *ctx) {
+  if (ctx->loader) {
+    gdk_pixbuf_loader_close(ctx->loader, NULL);
+    g_object_unref(ctx->loader);
+  }
+  g_clear_error(&ctx->err);
+  g_slice_free(struct gdkpixbuf_ctx, ctx);
+}
+
+typedef struct gdkpixbuf_ctx gdkpixbuf_ctx;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(gdkpixbuf_ctx, gdkpixbuf_ctx_free)
+
+// Fix up an existing gdk-pixbuf error in *err, or possibly propagate a new
+// one.  Return false in the latter case.  Unlike the typical GError rules,
+// *err may be non-NULL.
+static bool gdkpixbuf_ctx_check_error(struct gdkpixbuf_ctx *ctx,
+                                      GError **err) {
+  g_prefix_error(err, "gdk-pixbuf error: ");
+  if (ctx->err) {
+    // error from area_prepared takes precedence
+    g_clear_error(err);
+    g_propagate_error(err, g_steal_pointer(&ctx->err));
+    return false;
+  }
+  return true;
+}
+
+static struct gdkpixbuf_ctx *gdkpixbuf_ctx_new(const char *format,
+                                               int32_t w, int32_t h,
+                                               GError **err) {
+  g_autoptr(gdkpixbuf_ctx) ctx = g_slice_new0(struct gdkpixbuf_ctx);
+  ctx->w = w;
+  ctx->h = h;
+
+  ctx->loader = gdk_pixbuf_loader_new_with_type(format, err);
+  if (!ctx->loader) {
+    return NULL;
+  }
+  g_signal_connect(ctx->loader,
+                   "area-prepared", G_CALLBACK(area_prepared), ctx);
+
+  return g_steal_pointer(&ctx);
 }
 
 static bool gdkpixbuf_read(const char *format,
                            size_t (*read_callback)(void *out, void *in, size_t size),
                            void *callback_data,
-                           int64_t length,
+                           uint64_t length,
                            uint32_t *dest,
                            int32_t w, int32_t h,
                            GError **err) {
-  GdkPixbufLoader *loader = NULL;
-  uint8_t *buf = g_slice_alloc(BUFSIZE);
-  bool success = false;
-  struct load_state state = {
-    .w = w,
-    .h = h,
-  };
-
   // create loader
-  loader = gdk_pixbuf_loader_new_with_type(format, err);
-  if (!loader) {
-    goto DONE;
+  g_autoptr(gdkpixbuf_ctx) ctx = gdkpixbuf_ctx_new(format, w, h, err);
+  if (!ctx) {
+    return false;
   }
-  g_signal_connect(loader, "area-prepared", G_CALLBACK(area_prepared), &state);
 
   // read data
+  g_auto(_openslide_slice) box = _openslide_slice_alloc(BUFSIZE);
   while (length) {
-    size_t count = read_callback(buf, callback_data, MIN(length, BUFSIZE));
+    size_t count = read_callback(box.p, callback_data, MIN(length, box.len));
     if (!count) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Short read loading pixbuf");
-      goto DONE;
+      return false;
     }
-    if (!gdk_pixbuf_loader_write(loader, buf, count, err)) {
-      g_prefix_error(err, "gdk-pixbuf error: ");
-      goto DONE;
+    if (!gdk_pixbuf_loader_write(ctx->loader, box.p, count, err)) {
+      gdkpixbuf_ctx_check_error(ctx, err);
+      return false;
     }
-    if (state.err) {
-      goto DONE;
+    if (!gdkpixbuf_ctx_check_error(ctx, err)) {
+      return false;
     }
     length -= count;
   }
 
   // finish load
-  if (!gdk_pixbuf_loader_close(loader, err)) {
-    g_prefix_error(err, "gdk-pixbuf error: ");
-    goto DONE;
+  if (!gdk_pixbuf_loader_close(ctx->loader, err)) {
+    gdkpixbuf_ctx_check_error(ctx, err);
+    return false;
   }
-  if (state.err) {
-    goto DONE;
+  if (!gdkpixbuf_ctx_check_error(ctx, err)) {
+    return false;
   }
-  g_assert(state.pixbuf);
+  g_assert(ctx->pixbuf);
 
   // copy pixels
-  uint8_t *pixels = gdk_pixbuf_get_pixels(state.pixbuf);
-  int rowstride = gdk_pixbuf_get_rowstride(state.pixbuf);
+  uint8_t *pixels = gdk_pixbuf_get_pixels(ctx->pixbuf);
+  int rowstride = gdk_pixbuf_get_rowstride(ctx->pixbuf);
   for (int32_t y = 0; y < h; y++) {
     for (int32_t x = 0; x < w; x++) {
       dest[y * w + x] = 0xFF000000 |                              // A
@@ -144,26 +182,7 @@ static bool gdkpixbuf_read(const char *format,
     }
   }
 
-  success = true;
-
-DONE:
-  // clean up
-  if (loader) {
-    gdk_pixbuf_loader_close(loader, NULL);
-    g_object_unref(loader);
-  }
-  g_slice_free1(BUFSIZE, buf);
-
-  // now that the loader is closed, we know state.err won't be set
-  // behind our back
-  if (state.err) {
-    // signal handler validation errors override GdkPixbuf errors
-    g_clear_error(err);
-    g_propagate_error(err, state.err);
-    // signal handler errors should have been noticed before falling through
-    g_assert(!success);
-  }
-  return success;
+  return true;
 }
 
 static size_t file_read_callback(void *out, void *in, size_t size) {

--- a/src/openslide-decode-png.c
+++ b/src/openslide-decode-png.c
@@ -3,6 +3,7 @@
  *
  *  Copyright (c) 2007-2013 Carnegie Mellon University
  *  Copyright (c) 2011 Google, Inc.
+ *  Copyright (c) 2022 Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -32,7 +33,11 @@
 #include <setjmp.h>
 #include <stdio.h>
 
-struct png_error_ctx {
+struct png_ctx {
+  png_struct *png;
+  png_info *info;
+  png_byte **rows;
+  int64_t h;
   jmp_buf env;
   GError *err;
 };
@@ -43,124 +48,140 @@ static void warning_callback(png_struct *png G_GNUC_UNUSED,
 }
 
 static void error_callback(png_struct *png, const char *message) {
-  struct png_error_ctx *ectx = png_get_error_ptr(png);
-  g_set_error(&ectx->err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+  struct png_ctx *ctx = png_get_error_ptr(png);
+  g_set_error(&ctx->err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
               "PNG error: %s", message);
-  longjmp(ectx->env, 1);
+  longjmp(ctx->env, 1);
+}
+
+static void png_ctx_free(struct png_ctx *ctx) {
+  png_destroy_read_struct(&ctx->png, &ctx->info, NULL);
+  g_slice_free1(ctx->h * sizeof(*ctx->rows), ctx->rows);
+  g_slice_free(struct png_ctx, ctx);
+}
+
+typedef struct png_ctx png_ctx;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(png_ctx, png_ctx_free)
+
+// We want to avoid inlining this to avoid compiler setjmp clobber warnings
+// in the caller.  We won't have G_GNUC_NO_INLINE until glib 2.58, so use
+// the raw attribute syntax for now.
+static struct png_ctx * __attribute__((noinline)) png_ctx_new(uint32_t *dest,
+                                                              int64_t w,
+                                                              int64_t h,
+                                                              GError **err) {
+  g_autoptr(png_ctx) ctx = g_slice_new0(struct png_ctx);
+
+  // allocate row pointers
+  ctx->rows = g_slice_alloc(h * sizeof(*ctx->rows));
+  ctx->h = h;
+  for (int64_t y = 0; y < h; y++) {
+    ctx->rows[y] = (png_byte *) &dest[y * w];
+  }
+
+  // init libpng
+  ctx->png = png_create_read_struct(PNG_LIBPNG_VER_STRING, ctx,
+                                    error_callback, warning_callback);
+  if (!ctx->png) {
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Couldn't initialize libpng");
+    return NULL;
+  }
+  ctx->info = png_create_info_struct(ctx->png);
+  if (!ctx->info) {
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Couldn't initialize PNG info");
+    return NULL;
+  }
+
+  return g_steal_pointer(&ctx);
 }
 
 static bool png_read(png_rw_ptr read_callback, void *callback_data,
                      uint32_t *dest, int64_t w, int64_t h,
                      GError **err) {
-  png_struct *png = NULL;
-  png_info *info = NULL;
-  volatile bool success = false;
-
-  // allocate error context
-  struct png_error_ctx *ectx = g_slice_new0(struct png_error_ctx);
-
-  // allocate row pointers
-  png_byte **rows = g_slice_alloc(h * sizeof(*rows));
-  for (int64_t y = 0; y < h; y++) {
-    rows[y] = (png_byte *) &dest[y * w];
+  // allocate context
+  g_autoptr(png_ctx) ctx = png_ctx_new(dest, w, h, err);
+  if (ctx == NULL) {
+    return false;
   }
 
-  // init libpng
-  png = png_create_read_struct(PNG_LIBPNG_VER_STRING, ectx,
-                               error_callback, warning_callback);
-  if (!png) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Couldn't initialize libpng");
-    goto DONE;
-  }
-  info = png_create_info_struct(png);
-  if (!info) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Couldn't initialize PNG info");
-    goto DONE;
-  }
-
-  if (!setjmp(ectx->env)) {
+  if (!setjmp(ctx->env)) {
     // We can't use png_init_io(): passing FILE * between libraries isn't
     // safe on Windows
-    png_set_read_fn(png, callback_data, read_callback);
+    png_set_read_fn(ctx->png, callback_data, read_callback);
 
     // read header
-    png_read_info(png, info);
-    int64_t width = png_get_image_width(png, info);
-    int64_t height = png_get_image_height(png, info);
+    png_read_info(ctx->png, ctx->info);
+    int64_t width = png_get_image_width(ctx->png, ctx->info);
+    int64_t height = png_get_image_height(ctx->png, ctx->info);
     if (width != w || height != h) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Dimensional mismatch reading PNG: "
                   "expected %"PRId64"x%"PRId64", found %"PRId64"x%"PRId64,
                   w, h, width, height);
-      goto DONE;
+      return false;
     }
 
     // downsample 16 bits/channel to 8
     #ifdef PNG_READ_SCALE_16_TO_8_SUPPORTED
-      png_set_scale_16(png);
+      png_set_scale_16(ctx->png);
     #else
       // less-accurate fallback
-      png_set_strip_16(png);
+      png_set_strip_16(ctx->png);
     #endif
     // expand to 24-bit RGB or 8-bit gray
-    png_set_expand(png);
+    png_set_expand(ctx->png);
     // expand gray to 24-bit RGB
-    png_set_gray_to_rgb(png);
+    png_set_gray_to_rgb(ctx->png);
     // libpng emits bytes, but we need words, so byte order matters
     if (G_BYTE_ORDER == G_LITTLE_ENDIAN) {
       // need BGRA
       // RGB -> BGR, RGBA -> BGRA
-      png_set_bgr(png);
+      png_set_bgr(ctx->png);
       // BGR -> BGRx (BGR + filler)
-      png_set_filler(png, 0xff, PNG_FILLER_AFTER);
+      png_set_filler(ctx->png, 0xff, PNG_FILLER_AFTER);
     } else {
       // need ARGB
       // RGBA -> ARGB
-      png_set_swap_alpha(png);
+      png_set_swap_alpha(ctx->png);
       // RGB -> xRGB (filler + RGB)
-      png_set_filler(png, 0xff, PNG_FILLER_BEFORE);
+      png_set_filler(ctx->png, 0xff, PNG_FILLER_BEFORE);
     }
 
     // check buffer size
-    png_read_update_info(png, info);
-    uint32_t rowbytes = png_get_rowbytes(png, info);
+    png_read_update_info(ctx->png, ctx->info);
+    uint32_t rowbytes = png_get_rowbytes(ctx->png, ctx->info);
     if (rowbytes != w * sizeof(*dest)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Unexpected bufsize %u for %"PRId64" pixels",
                   rowbytes, w);
-      goto DONE;
+      return false;
     }
 
     // alpha channel is not supported
     // When adding support for PNGs with alpha, we will need to premultiply
     // the RGB channels.  libpng >= 1.5.4 supports premultiplied alpha via
     // png_set_alpha_mode().
-    int color_type = png_get_color_type(png, info);
+    int color_type = png_get_color_type(ctx->png, ctx->info);
     if (color_type != PNG_COLOR_TYPE_RGB) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Unsupported color type %d", color_type);
-      goto DONE;
+      return false;
     }
 
     // read image
-    png_read_image(png, rows);
+    png_read_image(ctx->png, ctx->rows);
 
     // finish
-    png_read_end(png, NULL);
-
-    success = true;
+    png_read_end(ctx->png, NULL);
   } else {
     // setjmp returned again
-    g_propagate_error(err, ectx->err);
+    g_propagate_error(err, ctx->err);
+    return false;
   }
 
-DONE:
-  png_destroy_read_struct(&png, &info, NULL);
-  g_slice_free1(h * sizeof(*rows), rows);
-  g_slice_free(struct png_error_ctx, ectx);
-  return success;
+  return true;
 }
 
 static void file_read_callback(png_struct *png, png_byte *buf, png_size_t len) {

--- a/src/openslide-decode-tiff.h
+++ b/src/openslide-decode-tiff.h
@@ -47,6 +47,11 @@ struct _openslide_tiff_level {
 
 struct _openslide_tiffcache;
 
+struct _openslide_cached_tiff {
+  struct _openslide_tiffcache *tc;
+  TIFF *tiff;
+};
+
 bool _openslide_tiff_level_init(TIFF *tiff,
                                 tdir_t dir,
                                 struct _openslide_level *level,
@@ -91,14 +96,20 @@ bool _openslide_tiff_set_dir(TIFF *tiff,
    multithreaded access */
 struct _openslide_tiffcache *_openslide_tiffcache_create(const char *filename);
 
-TIFF *_openslide_tiffcache_get(struct _openslide_tiffcache *tc, GError **err);
+// result.tiff is NULL on error
+struct _openslide_cached_tiff _openslide_tiffcache_get(struct _openslide_tiffcache *tc,
+                                                       GError **err);
 
-void _openslide_tiffcache_put(struct _openslide_tiffcache *tc, TIFF *tiff);
+void _openslide_cached_tiff_put(struct _openslide_cached_tiff *ct);
 
 void _openslide_tiffcache_destroy(struct _openslide_tiffcache *tc);
 
 typedef struct _openslide_tiffcache _openslide_tiffcache;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_tiffcache,
                               _openslide_tiffcache_destroy)
+
+typedef struct _openslide_cached_tiff _openslide_cached_tiff;
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(_openslide_cached_tiff,
+                                 _openslide_cached_tiff_put)
 
 #endif

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -176,6 +176,22 @@ bool _openslide_clip_tile(uint32_t *tiledata,
                           GError **err);
 
 
+// Slice allocator wrapper for g_auto
+struct _openslide_slice {
+  void *p;
+  gsize len;
+};
+
+struct _openslide_slice _openslide_slice_alloc(gsize len);
+
+void *_openslide_slice_steal(struct _openslide_slice *box);
+
+void _openslide_slice_free(struct _openslide_slice *box);
+
+typedef struct _openslide_slice _openslide_slice;
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(_openslide_slice, _openslide_slice_free)
+
+
 // File handling
 struct _openslide_file;
 

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -2,7 +2,7 @@
  *  OpenSlide, a library for reading whole slide image files
  *
  *  Copyright (c) 2007-2015 Carnegie Mellon University
- *  Copyright (c) 2015 Benjamin Gilbert
+ *  Copyright (c) 2015-2022 Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -347,5 +347,26 @@ void _openslide_performance_warn_once(gint *warned_flag,
       g_logv(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, str, ap);
       va_end(ap);
     }
+  }
+}
+
+struct _openslide_slice _openslide_slice_alloc(gsize len) {
+  struct _openslide_slice box = {
+    .p = g_slice_alloc(len),
+    .len = len,
+  };
+  return box;
+}
+
+void *_openslide_slice_steal(struct _openslide_slice *box) {
+  void *p = box->p;
+  box->p = NULL;
+  return p;
+}
+
+void _openslide_slice_free(struct _openslide_slice *box) {
+  if (box && box->p) {
+    g_slice_free1(box->len, box->p);
+    box->p = NULL;
   }
 }

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -59,31 +59,23 @@ struct level {
   uint16_t compression;
 };
 
-static void destroy_data(struct aperio_ops_data *data,
-                         struct level **levels, int32_t level_count) {
-  if (data) {
-    _openslide_tiffcache_destroy(data->tc);
-    g_slice_free(struct aperio_ops_data, data);
+static void destroy_level(struct level *l) {
+  if (l->missing_tiles) {
+    g_hash_table_destroy(l->missing_tiles);
   }
-
-  if (levels) {
-    for (int32_t i = 0; i < level_count; i++) {
-      if (levels[i]) {
-        if (levels[i]->missing_tiles) {
-          g_hash_table_destroy(levels[i]->missing_tiles);
-        }
-        _openslide_grid_destroy(levels[i]->grid);
-        g_slice_free(struct level, levels[i]);
-      }
-    }
-    g_free(levels);
-  }
+  _openslide_grid_destroy(l->grid);
+  g_slice_free(struct level, l);
 }
 
 static void destroy(openslide_t *osr) {
+  for (int32_t i = 0; i < osr->level_count; i++) {
+    destroy_level((struct level *) osr->levels[i]);
+  }
+  g_free(osr->levels);
+
   struct aperio_ops_data *data = osr->data;
-  struct level **levels = (struct level **) osr->levels;
-  destroy_data(data, levels, osr->level_count);
+  _openslide_tiffcache_destroy(data->tc);
+  g_slice_free(struct aperio_ops_data, data);
 }
 
 static bool render_missing_tile(struct level *l,
@@ -162,26 +154,21 @@ static bool decode_tile(struct level *l,
   }
 
   // read raw tile
-  void *buf;
+  g_autofree void *buf = NULL;
   int32_t buflen;
   if (!_openslide_tiff_read_tile_data(tiffl, tiff,
                                       &buf, &buflen,
                                       tile_col, tile_row,
                                       err)) {
-    return false;  // ok, haven't allocated anything yet
+    return false;
   }
 
   // decompress
-  bool success = _openslide_jp2k_decode_buffer(dest,
-                                               tiffl->tile_w, tiffl->tile_h,
-                                               buf, buflen,
-                                               space,
-                                               err);
-
-  // clean up
-  g_free(buf);
-
-  return success;
+  return _openslide_jp2k_decode_buffer(dest,
+                                       tiffl->tile_w, tiffl->tile_h,
+                                       buf, buflen,
+                                       space,
+                                       err);
 }
 
 static bool read_tile(openslide_t *osr,
@@ -298,7 +285,7 @@ static void add_properties(openslide_t *osr, char **props) {
 
   // ignore first property in Aperio
   for(char **p = props + 1; *p != NULL; p++) {
-    char **pair = g_strsplit(*p, "=", 2);
+    g_auto(GStrv) pair = g_strsplit(*p, "=", 2);
 
     if (pair) {
       char *name = g_strstrip(pair[0]);
@@ -310,7 +297,6 @@ static void add_properties(openslide_t *osr, char **props) {
 			    g_strdup(value));
       }
     }
-    g_strfreev(pair);
   }
 
   _openslide_duplicate_int_prop(osr, "aperio.AppMag",
@@ -329,19 +315,18 @@ static bool add_associated_image(openslide_t *osr,
                                  struct _openslide_tiffcache *tc,
                                  TIFF *tiff,
                                  GError **err) {
-  char *name = NULL;
+  g_autofree char *name = NULL;
   if (name_if_available) {
     name = g_strdup(name_if_available);
   } else {
-    char *val;
-
     // get name
+    char *val;
     if (!TIFFGetField(tiff, TIFFTAG_IMAGEDESCRIPTION, &val)) {
       return true;
     }
 
     // parse ImageDescription, after newline up to first whitespace -> gives name
-    char **lines = g_strsplit_set(val, "\r\n", -1);
+    g_auto(GStrv) lines = g_strsplit_set(val, "\r\n", -1);
     if (!lines) {
       return true;
     }
@@ -349,25 +334,20 @@ static bool add_associated_image(openslide_t *osr,
     if (lines[0] && lines[1]) {
       char *line = lines[1];
 
-      char **names = g_strsplit(line, " ", -1);
+      g_auto(GStrv) names = g_strsplit(line, " ", -1);
       if (names && names[0]) {
 	name = g_strdup(names[0]);
       }
-      g_strfreev(names);
     }
-
-    g_strfreev(lines);
   }
 
   if (!name) {
     return true;
   }
 
-  bool result = _openslide_tiff_add_associated_image(osr, name, tc,
-                                                     TIFFCurrentDirectory(tiff),
-                                                     err);
-  g_free(name);
-  return result;
+  return _openslide_tiff_add_associated_image(osr, name, tc,
+                                              TIFFCurrentDirectory(tiff),
+                                              err);
 }
 
 static void propagate_missing_tile(void *key, void *value G_GNUC_UNUSED,
@@ -400,15 +380,11 @@ static bool aperio_open(openslide_t *osr,
                         const char *filename,
                         struct _openslide_tifflike *tl,
                         struct _openslide_hash *quickhash1, GError **err) {
-  struct aperio_ops_data *data = NULL;
-  struct level **levels = NULL;
-  int32_t level_count = 0;
-
   // open TIFF
   g_autoptr(_openslide_tiffcache) tc = _openslide_tiffcache_create(filename);
   g_auto(_openslide_cached_tiff) ct = _openslide_tiffcache_get(tc, err);
   if (!ct.tiff) {
-    goto FAIL;
+    return false;
   }
 
   /*
@@ -432,12 +408,9 @@ static bool aperio_open(openslide_t *osr,
    * always stripped.
    */
 
+  g_autoptr(GPtrArray) level_array =
+    g_ptr_array_new_with_free_func((GDestroyNotify) destroy_level);
   do {
-    // for aperio, the tiled directories are the ones we want
-    if (TIFFIsTiled(ct.tiff)) {
-      level_count++;
-    }
-
     // check depth
     uint32_t depth;
     if (TIFFGetField(ct.tiff, TIFFTAG_IMAGEDEPTH, &depth) &&
@@ -445,7 +418,7 @@ static bool aperio_open(openslide_t *osr,
       // we can't handle depth != 1
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Cannot handle ImageDepth=%d", depth);
-      goto FAIL;
+      return false;
     }
 
     // check compression
@@ -453,42 +426,33 @@ static bool aperio_open(openslide_t *osr,
     if (!TIFFGetField(ct.tiff, TIFFTAG_COMPRESSION, &compression)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Can't read compression scheme");
-      goto FAIL;
+      return false;
     }
     if ((compression != APERIO_COMPRESSION_JP2K_YCBCR) &&
         (compression != APERIO_COMPRESSION_JP2K_RGB) &&
         !TIFFIsCODECConfigured(compression)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Unsupported TIFF compression: %u", compression);
-      goto FAIL;
+      return false;
     }
-  } while (TIFFReadDirectory(ct.tiff));
 
-  // allocate private data
-  data = g_slice_new0(struct aperio_ops_data);
-
-  levels = g_new0(struct level *, level_count);
-  int32_t i = 0;
-  if (!_openslide_tiff_set_dir(ct.tiff, 0, err)) {
-    goto FAIL;
-  }
-  do {
     tdir_t dir = TIFFCurrentDirectory(ct.tiff);
+    // for aperio, the tiled directories are the ones we want
     if (TIFFIsTiled(ct.tiff)) {
       //g_debug("tiled directory: %d", dir);
       struct level *l = g_slice_new0(struct level);
       struct _openslide_tiff_level *tiffl = &l->tiffl;
-      if (i) {
-        l->prev = levels[i - 1];
+      if (level_array->len) {
+        l->prev = level_array->pdata[level_array->len - 1];
       }
-      levels[i++] = l;
+      g_ptr_array_add(level_array, l);
 
       if (!_openslide_tiff_level_init(ct.tiff,
                                       dir,
                                       (struct _openslide_level *) l,
                                       tiffl,
                                       err)) {
-        goto FAIL;
+        return false;
       }
 
       l->grid = _openslide_grid_create_simple(osr,
@@ -502,7 +466,7 @@ static bool aperio_open(openslide_t *osr,
       if (!TIFFGetField(ct.tiff, TIFFTAG_COMPRESSION, &l->compression)) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Can't read compression scheme");
-        goto FAIL;
+        return false;
       }
 
       // some Aperio slides have some zero-length tiles, apparently due to
@@ -511,7 +475,7 @@ static bool aperio_open(openslide_t *osr,
       if (!TIFFGetField(ct.tiff, TIFFTAG_TILEBYTECOUNTS, &tile_sizes)) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Cannot get tile sizes");
-        goto FAIL;
+        return false;
       }
       l->missing_tiles = g_hash_table_new_full(g_int64_hash, g_int64_equal,
                                                g_free, NULL);
@@ -527,7 +491,7 @@ static bool aperio_open(openslide_t *osr,
       // associated image
       const char *name = (dir == 1) ? "thumbnail" : NULL;
       if (!add_associated_image(osr, name, tc, ct.tiff, err)) {
-	goto FAIL;
+	return false;
       }
       //g_debug("associated image: %d", dir);
     }
@@ -535,49 +499,48 @@ static bool aperio_open(openslide_t *osr,
 
   // tiles concatenating a missing tile are sometimes corrupt, so we mark
   // them missing too
-  for (i = 0; i < level_count - 1; i++) {
-    g_hash_table_foreach(levels[i]->missing_tiles, propagate_missing_tile,
-                         levels[i + 1]);
+  for (guint i = 0; i < level_array->len - 1; i++) {
+    struct level *l = level_array->pdata[i];
+    g_hash_table_foreach(l->missing_tiles, propagate_missing_tile,
+                         level_array->pdata[i + 1]);
   }
 
   // read properties
   if (!_openslide_tiff_set_dir(ct.tiff, 0, err)) {
-    goto FAIL;
+    return false;
   }
   char *image_desc;
   if (!TIFFGetField(ct.tiff, TIFFTAG_IMAGEDESCRIPTION, &image_desc)) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Couldn't read ImageDescription field");
-    goto FAIL;
+    return false;
   }
-  char **props = g_strsplit(image_desc, "|", -1);
+  g_auto(GStrv) props = g_strsplit(image_desc, "|", -1);
   add_properties(osr, props);
-  g_strfreev(props);
 
   // set hash and properties
+  struct level *top_level = level_array->pdata[level_array->len - 1];
   if (!_openslide_tifflike_init_properties_and_hash(osr, tl, quickhash1,
-                                                    levels[level_count - 1]->tiffl.dir,
+                                                    top_level->tiffl.dir,
                                                     0,
                                                     err)) {
-    goto FAIL;
+    return false;
   }
+
+  // allocate private data
+  struct aperio_ops_data *data = g_slice_new0(struct aperio_ops_data);
+  data->tc = g_steal_pointer(&tc);
 
   // store osr data
   g_assert(osr->data == NULL);
   g_assert(osr->levels == NULL);
-  osr->levels = (struct _openslide_level **) levels;
-  osr->level_count = level_count;
+  osr->level_count = level_array->len;
+  osr->levels = (struct _openslide_level **)
+    g_ptr_array_free(g_steal_pointer(&level_array), false);
   osr->data = data;
   osr->ops = &aperio_ops;
 
-  // store tiffcache reference
-  data->tc = g_steal_pointer(&tc);
-
   return true;
-
-FAIL:
-  destroy_data(data, levels, level_count);
-  return false;
 }
 
 const struct _openslide_format _openslide_format_aperio = {

--- a/src/openslide-vendor-generic-tiff.c
+++ b/src/openslide-vendor-generic-tiff.c
@@ -81,23 +81,22 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    tiledata = g_slice_alloc(tw * th * 4);
+    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
-                                   tiledata, tile_col, tile_row,
+                                   box.p, tile_col, tile_row,
                                    err)) {
-      g_slice_free1(tw * th * 4, tiledata);
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_tiff_clip_tile(tiffl, tiledata,
+    if (!_openslide_tiff_clip_tile(tiffl, box.p,
                                    tile_col, tile_row,
                                    err)) {
-      g_slice_free1(tw * th * 4, tiledata);
       return false;
     }
 
     // put it in the cache
+    tiledata = _openslide_slice_steal(&box);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
                          tiledata, tw * th * 4,
                          &cache_entry);

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -1263,10 +1263,7 @@ static void create_scaled_jpeg_levels(openslide_t *osr,
       sd_l->tile_height = l->tile_height / scale_denom;
 
       int32_t num_jpegs = sd_l->jpegs_across * sd_l->jpegs_down;
-      sd_l->jpegs = g_new(struct jpeg *, num_jpegs);
-      for (int32_t j = 0; j < num_jpegs; j++) {
-        sd_l->jpegs[j] = l->jpegs[j];
-      }
+      sd_l->jpegs = g_memdup(l->jpegs, sizeof(struct jpeg *) * num_jpegs);
 
       // tile size hints
       sd_l->base.tile_w = sd_l->tile_width;

--- a/src/openslide-vendor-leica.c
+++ b/src/openslide-vendor-leica.c
@@ -162,23 +162,22 @@ static bool read_tile(openslide_t *osr,
                                             args->area, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    tiledata = g_slice_alloc(tw * th * 4);
+    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
     if (!_openslide_tiff_read_tile(tiffl, args->tiff,
-                                   tiledata, tile_col, tile_row,
+                                   box.p, tile_col, tile_row,
                                    err)) {
-      g_slice_free1(tw * th * 4, tiledata);
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_tiff_clip_tile(tiffl, tiledata,
+    if (!_openslide_tiff_clip_tile(tiffl, box.p,
                                    tile_col, tile_row,
                                    err)) {
-      g_slice_free1(tw * th * 4, tiledata);
       return false;
     }
 
     // put it in the cache
+    tiledata = _openslide_slice_steal(&box);
     _openslide_cache_put(osr->cache,
 			 args->area, tile_col, tile_row,
 			 tiledata, tw * th * 4,

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -100,7 +100,7 @@ static const char KEY_IMAGE_CONCAT_FACTOR[] = "IMAGE_CONCAT_FACTOR";
     TARGET = g_key_file_get_ ## TYPE(KEYFILE, GROUP, KEY, &tmp_err);	\
     if (tmp_err != NULL) {						\
       g_propagate_error(err, tmp_err);					\
-      goto FAIL;							\
+      return false;							\
     }									\
   } while(0)
 
@@ -109,7 +109,7 @@ static const char KEY_IMAGE_CONCAT_FACTOR[] = "IMAGE_CONCAT_FACTOR";
     if (!g_key_file_has_group(slidedat, GROUP)) {			\
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,		\
                   "Can't find %s group", GROUP);			\
-      goto FAIL;							\
+      return false;							\
     }									\
   } while(0)
 
@@ -117,7 +117,7 @@ static const char KEY_IMAGE_CONCAT_FACTOR[] = "IMAGE_CONCAT_FACTOR";
   do {								\
     if (TMP_ERR) {						\
       g_propagate_error(err, TMP_ERR);				\
-      goto FAIL;						\
+      return false;						\
     }								\
   } while(0)
 
@@ -126,7 +126,7 @@ static const char KEY_IMAGE_CONCAT_FACTOR[] = "IMAGE_CONCAT_FACTOR";
     if (N <= 0) {						\
       g_set_error(err, OPENSLIDE_ERROR,				\
                   OPENSLIDE_ERROR_FAILED, #N " <= 0: %d", N);	\
-      goto FAIL;						\
+      return false;						\
     }								\
   } while(0)
 
@@ -135,7 +135,7 @@ static const char KEY_IMAGE_CONCAT_FACTOR[] = "IMAGE_CONCAT_FACTOR";
     if (N < 0) {						\
       g_set_error(err, OPENSLIDE_ERROR,				\
                   OPENSLIDE_ERROR_FAILED, #N " < 0: %d", N);	\
-      goto FAIL;						\
+      return false;						\
     }								\
   } while(0)
 
@@ -161,7 +161,7 @@ struct slide_zoom_level_section {
   int image_h;
 };
 
-// see comments in _openslide_try_mirax()
+// see comments in mirax_open()
 struct slide_zoom_level_params {
   int image_concat;
   int tile_count_divisor;
@@ -208,6 +208,9 @@ static void image_unref(struct image *image) {
     g_slice_free(struct image, image);
   }
 }
+
+typedef struct image image;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(image, image_unref)
 
 static void tile_free(gpointer data) {
   struct tile *tile = data;
@@ -340,17 +343,18 @@ static bool paint_region(openslide_t *osr G_GNUC_UNUSED, cairo_t *cr,
                                       err);
 }
 
+static void destroy_level(struct level *l) {
+  _openslide_grid_destroy(l->grid);
+  g_slice_free(struct level, l);
+}
+
 static void destroy(openslide_t *osr) {
   struct mirax_ops_data *data = osr->data;
 
-  // each level in turn
+  // levels
   for (int32_t i = 0; i < osr->level_count; i++) {
-    struct level *l = (struct level *) osr->levels[i];
-    _openslide_grid_destroy(l->grid);
-    g_slice_free(struct level, l);
+    destroy_level((struct level *) osr->levels[i]);
   }
-
-  // the level array
   g_free(osr->levels);
 
   // the ops data
@@ -392,12 +396,11 @@ static bool mirax_detect(const char *filename, struct _openslide_tifflike *tl,
   }
 
   // verify slidedat exists
-  char *dirname = g_strndup(filename, strlen(filename) - strlen(MRXS_EXT));
-  char *slidedat_path = g_build_filename(dirname, SLIDEDAT_INI, NULL);
-  bool ok = _openslide_fexists(slidedat_path, &tmp_err);
-  g_free(slidedat_path);
-  g_free(dirname);
-  if (!ok) {
+  g_autofree char *dirname =
+    g_strndup(filename, strlen(filename) - strlen(MRXS_EXT));
+  g_autofree char *slidedat_path =
+    g_build_filename(dirname, SLIDEDAT_INI, NULL);
+  if (!_openslide_fexists(slidedat_path, &tmp_err)) {
     if (tmp_err != NULL) {
       g_propagate_prefixed_error(err, tmp_err, "Testing whether %s exists: ",
                                  SLIDEDAT_INI);
@@ -412,14 +415,13 @@ static bool mirax_detect(const char *filename, struct _openslide_tifflike *tl,
 }
 
 static char *read_string_from_file(struct _openslide_file *f, int len) {
-  char *str = g_malloc(len + 1);
+  g_autofree char *str = g_malloc(len + 1);
   str[len] = '\0';
 
   if (_openslide_fread(f, str, len) != (size_t) len) {
-    g_free(str);
     return NULL;
   }
-  return str;
+  return g_steal_pointer(&str);
 }
 
 static bool read_le_int32_from_file_with_result(struct _openslide_file *f,
@@ -559,7 +561,6 @@ static bool read_nonhier_record(struct _openslide_file *f,
   return true;
 }
 
-
 static void insert_tile(struct level *l,
                         const struct slide_zoom_level_params *lp,
                         struct image *image,
@@ -689,11 +690,9 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
 						   GError **err) {
   int32_t image_number = 0;
 
-  bool success = false;
-
   // used for storing which positions actually have data
-  GHashTable *active_positions = g_hash_table_new_full(g_int_hash, g_int_equal,
-						       g_free, NULL);
+  g_autoptr(GHashTable) active_positions =
+    g_hash_table_new_full(g_int_hash, g_int_equal, g_free, NULL);
 
   for (int zoom_level = 0; zoom_level < zoom_levels; zoom_level++) {
     struct level *l = levels[zoom_level];
@@ -705,25 +704,25 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
 
     if (!_openslide_fseek(f, seek_location, SEEK_SET, err)) {
       g_prefix_error(err, "Cannot seek to zoom level pointer %d: ", zoom_level);
-      goto DONE;
+      return false;
     }
 
     ptr = read_le_int32_from_file(f);
     if (ptr == -1) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Can't read zoom level pointer");
-      goto DONE;
+      return false;
     }
     if (!_openslide_fseek(f, ptr, SEEK_SET, err)) {
       g_prefix_error(err, "Cannot seek to start of data pages: ");
-      goto DONE;
+      return false;
     }
 
     // read initial 0
     if (read_le_int32_from_file(f) != 0) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Expected 0 value at beginning of data page");
-      goto DONE;
+      return false;
     }
 
     // read pointer
@@ -731,13 +730,13 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
     if (ptr == -1) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Can't read initial data page pointer");
-      goto DONE;
+      return false;
     }
 
     // seek to offset
     if (!_openslide_fseek(f, ptr, SEEK_SET, err)) {
       g_prefix_error(err, "Can't seek to initial data page: ");
-      goto DONE;
+      return false;
     }
 
     int32_t next_ptr;
@@ -747,7 +746,7 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
       if (page_len == -1) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Can't read page length");
-        goto DONE;
+        return false;
       }
 
       //    g_debug("page_len: %d", page_len);
@@ -757,7 +756,7 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
       if (next_ptr == -1) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Cannot read \"next\" pointer");
-        goto DONE;
+        return false;
       }
 
       // read all the data into the list
@@ -770,22 +769,22 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
 	if (image_index < 0) {
           g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                       "image_index < 0");
-          goto DONE;
+          return false;
 	}
 	if (offset < 0) {
           g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                       "offset < 0");
-          goto DONE;
+          return false;
 	}
 	if (length < 0) {
           g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                       "length < 0");
-          goto DONE;
+          return false;
 	}
 	if (fileno < 0) {
           g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                       "fileno < 0");
-          goto DONE;
+          return false;
 	}
 
 	// we have only encountered slides with exactly power-of-two scale
@@ -798,27 +797,27 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
           g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                       "y (%d) outside of bounds for zoom level (%d)",
                       y, zoom_level);
-          goto DONE;
+          return false;
 	}
 
 	if (x % lp->image_concat) {
           g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                       "x (%d) not correct multiple for zoom level (%d)",
                       x, zoom_level);
-          goto DONE;
+          return false;
 	}
 	if (y % lp->image_concat) {
           g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                       "y (%d) not correct multiple for zoom level (%d)",
                       y, zoom_level);
-          goto DONE;
+          return false;
 	}
 
 	// save filename
 	if (fileno >= datafile_count) {
           g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                       "Invalid fileno");
-          goto DONE;
+          return false;
 	}
 
 	// hash in the lowest-res images
@@ -826,12 +825,12 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
 	  if (!_openslide_hash_file_part(quickhash1, datafile_paths[fileno],
 	                                 offset, length, err)) {
             g_prefix_error(err, "Can't hash images: ");
-            goto DONE;
+            return false;
 	  }
 	}
 
 	// populate the image structure
-	struct image *image = g_slice_new0(struct image);
+	g_autoptr(image) image = g_slice_new0(struct image);
 	image->fileno = fileno;
 	image->start_in_file = offset;
 	image->length = length;
@@ -882,6 +881,7 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
 
 	    //g_debug("pos0: %d %d, pos: %g %g", pos0_x, pos0_y, pos_x, pos_y);
 
+            // increments image refcount
 	    insert_tile(l, lp,
                         image,
                         pos_x, pos_y,
@@ -891,9 +891,6 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
                         zoom_level);
 	  }
 	}
-
-	// drop initial reference, possibly free
-	image_unref(image);
       }
     } while (next_ptr != 0);
 
@@ -901,40 +898,30 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
     seek_location += 4;
   }
 
-  success = true;
-
- DONE:
-  g_hash_table_unref(active_positions);
-
-  return success;
+  return true;
 }
 
 static void *read_record_data(const char *path,
                               int64_t size, int64_t offset,
                               GError **err) {
-  void *buffer = NULL;
-  struct _openslide_file *f = _openslide_fopen(path, err);
+  g_autoptr(_openslide_file) f = _openslide_fopen(path, err);
   if (!f) {
     return NULL;
   }
 
   if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
     g_prefix_error(err, "Cannot seek data file: ");
-    _openslide_fclose(f);
     return NULL;
   }
 
-  buffer = g_malloc(size);
+  g_autofree void *buffer = g_malloc(size);
   if (_openslide_fread(f, buffer, size) != (size_t) size) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Error while reading data");
-    g_free(buffer);
-    _openslide_fclose(f);
     return NULL;
   }
 
-  _openslide_fclose(f);
-  return buffer;
+  return g_steal_pointer(&buffer);
 }
 
 static int32_t *read_slide_position_buffer(const void *buffer,
@@ -950,7 +937,7 @@ static int32_t *read_slide_position_buffer(const void *buffer,
 
   const char *p = buffer;
   int64_t count = buffer_size / SLIDE_POSITION_RECORD_SIZE;
-  int32_t *result = g_new(int32_t, count * 2);
+  g_autofree int32_t *result = g_new(int32_t, count * 2);
   int32_t x;
   int32_t y;
   char zz;
@@ -963,7 +950,6 @@ static int32_t *read_slide_position_buffer(const void *buffer,
     if (zz & 0xfe) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Unexpected flag value (%d)", zz);
-      g_free(result);
       return NULL;
     }
 
@@ -982,7 +968,7 @@ static int32_t *read_slide_position_buffer(const void *buffer,
     result[(i * 2) + 1] = y * level_0_image_concat;
   }
 
-  return result;
+  return g_steal_pointer(&result);
 }
 
 static enum image_format parse_image_format(const char *name, GError **err) {
@@ -1047,25 +1033,12 @@ static bool process_indexfile(openslide_t *osr,
 			      struct level **levels,
 			      struct _openslide_hash *quickhash1,
 			      GError **err) {
-  char *teststr = NULL;
-  bool match;
-
-  void *slide_position_buffer = NULL;
-  int slide_position_record = -1;
-
-  // init tmp parameters
-  int32_t ptr = -1;
-
   const int npositions = (images_x / image_divisions) * (images_y / image_divisions);
   const int slide_position_buffer_size = SLIDE_POSITION_RECORD_SIZE * npositions;
 
-  bool success = false;
-
-  int32_t *slide_positions = NULL;
-
   if (!_openslide_fseek(indexfile, 0, SEEK_SET, err)) {
     g_prefix_error(err, "Couldn't seek index file: ");
-    goto DONE;
+    return false;
   }
 
   // save root positions
@@ -1073,32 +1046,31 @@ static bool process_indexfile(openslide_t *osr,
   const int64_t nonhier_root = hier_root + 4;
 
   // verify version and uuid
-  teststr = read_string_from_file(indexfile, strlen(INDEX_VERSION));
-  match = (teststr != NULL) && (strcmp(teststr, INDEX_VERSION) == 0);
-  g_free(teststr);
-  if (!match) {
+  g_autofree char *found_ver =
+    read_string_from_file(indexfile, strlen(INDEX_VERSION));
+  if (!found_ver || strcmp(found_ver, INDEX_VERSION)) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Index.dat doesn't have expected version");
-    goto DONE;
+    return false;
   }
 
-  teststr = read_string_from_file(indexfile, strlen(uuid));
-  match = (teststr != NULL) && (strcmp(teststr, uuid) == 0);
-  g_free(teststr);
-  if (!match) {
+  g_autofree char *found_uuid = read_string_from_file(indexfile, strlen(uuid));
+  if (!found_uuid || strcmp(found_uuid, uuid)) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Index.dat doesn't have a matching slide identifier");
-    goto DONE;
+    return false;
   }
 
   // If we have individual slide positioning information as part of the
   // non-hier data, read the position information.
+  int slide_position_record;
   if (vimslide_position_record != -1) {
     slide_position_record = vimslide_position_record;
   } else {
     slide_position_record = stitching_position_record;
   }
 
+  g_autofree int32_t *slide_positions = NULL;
   if (slide_position_record != -1) {
     char *slide_position_path;
     int64_t slide_position_size;
@@ -1113,16 +1085,16 @@ static bool process_indexfile(openslide_t *osr,
 			     &slide_position_offset,
 			     err)) {
       g_prefix_error(err, "Cannot read slide position info: ");
-      goto DONE;
+      return false;
     }
 
-    slide_position_buffer = read_record_data(slide_position_path,
-                                             slide_position_size,
-                                             slide_position_offset,
-                                             err);
+    g_autofree void *slide_position_buffer =
+      read_record_data(slide_position_path,
+                       slide_position_size, slide_position_offset,
+                       err);
     if (!slide_position_buffer) {
       g_prefix_error(err, "Cannot read slide position record: ");
-      goto DONE;
+      return false;
     }
 
     if (slide_position_record == stitching_position_record) {
@@ -1132,20 +1104,16 @@ static bool process_indexfile(openslide_t *osr,
                                                      slide_position_size,
                                                      slide_position_buffer_size,
                                                      err);
-
-      g_free(slide_position_buffer); // free the compressed buffer
-
-      if (decompressed) {
-        slide_position_buffer = decompressed;
-      } else {
+      if (!decompressed) {
         g_prefix_error(err, "Error decompressing position buffer: ");
-        goto DONE;
+        return false;
       }
+      g_free(g_steal_pointer(&slide_position_buffer));
+      slide_position_buffer = decompressed;
     } else if (slide_position_buffer_size != slide_position_size) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Slide position file not of the expected size");
-      g_free(slide_position_buffer);
-      goto DONE;
+      return false;
     }
 
     // read in the slide positions
@@ -1153,11 +1121,8 @@ static bool process_indexfile(openslide_t *osr,
 					         slide_position_buffer_size,
 					         slide_zoom_level_params[0].image_concat,
 					         err);
-
-    g_free(slide_position_buffer);
-
     if (!slide_positions) {
-      goto DONE;
+      return false;
     }
   } else {
     // No position map available.  Fill in our own values based on the tile
@@ -1184,7 +1149,7 @@ static bool process_indexfile(openslide_t *osr,
                             "macro",
                             macro_record,
                             err)) {
-    goto DONE;
+    return false;
   }
   if (!add_associated_image(osr,
                             indexfile,
@@ -1194,7 +1159,7 @@ static bool process_indexfile(openslide_t *osr,
                             "label",
                             label_record,
                             err)) {
-    goto DONE;
+    return false;
   }
   if (!add_associated_image(osr,
                             indexfile,
@@ -1204,20 +1169,20 @@ static bool process_indexfile(openslide_t *osr,
                             "thumbnail",
                             thumbnail_record,
                             err)) {
-    goto DONE;
+    return false;
   }
 
   // read hierarchical sections
   if (!_openslide_fseek(indexfile, hier_root, SEEK_SET, err)) {
     g_prefix_error(err, "Cannot seek to hier sections root: ");
-    goto DONE;
+    return false;
   }
 
-  ptr = read_le_int32_from_file(indexfile);
+  int32_t ptr = read_le_int32_from_file(indexfile);
   if (ptr == -1) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Can't read initial pointer");
-    goto DONE;
+    return false;
   }
 
   // read these pages in
@@ -1234,42 +1199,33 @@ static bool process_indexfile(openslide_t *osr,
 					      slide_positions,
 					      quickhash1,
 					      err)) {
-    goto DONE;
+    return false;
   }
 
-  success = true;
-
- DONE:
-  // deallocate
-  g_free(slide_positions);
-
-  return success;
+  return true;
 }
 
 static void add_properties(openslide_t *osr, GKeyFile *kf) {
-  char **groups = g_key_file_get_groups(kf, NULL);
+  g_auto(GStrv) groups = g_key_file_get_groups(kf, NULL);
   if (groups == NULL) {
     return;
   }
 
   for (char **group = groups; *group != NULL; group++) {
-    char **keys = g_key_file_get_keys(kf, *group, NULL, NULL);
+    g_auto(GStrv) keys = g_key_file_get_keys(kf, *group, NULL, NULL);
     if (keys == NULL) {
       break;
     }
 
     for (char **key = keys; *key != NULL; key++) {
-      char *value = g_key_file_get_value(kf, *group, *key, NULL);
+      g_autofree char *value = g_key_file_get_value(kf, *group, *key, NULL);
       if (value) {
 	g_hash_table_insert(osr->properties,
 			    g_strdup_printf("mirax.%s.%s", *group, *key),
 			    g_strdup(value));
-	g_free(value);
       }
     }
-    g_strfreev(keys);
   }
-  g_strfreev(groups);
 }
 
 static int get_nonhier_name_offset_helper(GKeyFile *keyfile,
@@ -1279,28 +1235,23 @@ static int get_nonhier_name_offset_helper(GKeyFile *keyfile,
 					  int *name_count_out,
 					  int *name_index_out,
 					  GError **err) {
-  GError *tmp_err = NULL;
-
-  *name_count_out = 0;
-  *name_index_out = 0;
-
   int offset = 0;
   for (int i = 0; i < nonhier_count; i++) {
     *name_index_out = i;
 
     // look at a key's value
-    char *key = g_strdup_printf(KEY_NONHIER_d_NAME, i);
-    char *value = g_key_file_get_value(keyfile, group, key, err);
-    g_free(key);
+    g_autofree char *name_key = g_strdup_printf(KEY_NONHIER_d_NAME, i);
+    g_autofree char *value =
+      g_key_file_get_value(keyfile, group, name_key, err);
 
     if (!value) {
       return -1;
     }
 
     // save count for this name
-    key = g_strdup_printf(KEY_NONHIER_d_COUNT, i);
-    int count = g_key_file_get_integer(keyfile, group, key, &tmp_err);
-    g_free(key);
+    g_autofree char *count_key = g_strdup_printf(KEY_NONHIER_d_COUNT, i);
+    GError *tmp_err = NULL;
+    int count = g_key_file_get_integer(keyfile, group, count_key, &tmp_err);
     if (!count) {
       if (tmp_err) {
         g_propagate_error(err, tmp_err);
@@ -1308,16 +1259,13 @@ static int get_nonhier_name_offset_helper(GKeyFile *keyfile,
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Nonhier val count is zero");
       }
-      g_free(value);
       return -1;
     }
     *name_count_out = count;
 
     if (strcmp(target_name, value) == 0) {
-      g_free(value);
       return offset;
     }
-    g_free(value);
 
     // otherwise, increase offset
     offset += count;
@@ -1360,22 +1308,18 @@ static int get_nonhier_val_offset(GKeyFile *keyfile,
   }
 
   for (int i = 0; i < name_count; i++) {
-    char *key = g_strdup_printf(KEY_NONHIER_d_VAL_d, name_index, i);
-    char *value = g_key_file_get_value(keyfile, group, key, err);
-    g_free(key);
+    g_autofree char *key = g_strdup_printf(KEY_NONHIER_d_VAL_d, name_index, i);
+    g_autofree char *value = g_key_file_get_value(keyfile, group, key, err);
 
     if (!value) {
       return -1;
     }
 
     if (strcmp(target_value, value) == 0) {
-      g_free(value);
-
       if (section_name != NULL) {
-        char *section_key = g_strdup_printf(KEY_NONHIER_d_VAL_d_SECTION,
-                                            name_index, i);
+        g_autofree char *section_key =
+          g_strdup_printf(KEY_NONHIER_d_VAL_d_SECTION, name_index, i);
         *section_name = g_key_file_get_value(keyfile, group, section_key, err);
-        g_free(section_key);
 
         if (!*section_name) {
           return -1;
@@ -1386,7 +1330,6 @@ static int get_nonhier_val_offset(GKeyFile *keyfile,
     }
 
     // otherwise, increase offset
-    g_free(value);
     offset++;
   }
 
@@ -1400,7 +1343,7 @@ static int get_associated_image_nonhier_offset(GKeyFile *keyfile,
                                                const char *target_value,
                                                const char *target_format_key,
                                                GError **err) {
-  char *section_name;
+  g_autofree char *section_name = NULL;
   int offset = get_nonhier_val_offset(keyfile,
                                       nonhier_count,
                                       group,
@@ -1412,9 +1355,8 @@ static int get_associated_image_nonhier_offset(GKeyFile *keyfile,
     return -1;
   }
 
-  char *format = g_key_file_get_value(keyfile, section_name,
-                                      target_format_key, err);
-  g_free(section_name);
+  g_autofree char *format =
+    g_key_file_get_value(keyfile, section_name, target_format_key, err);
   if (format == NULL) {
     return -1;
   }
@@ -1424,10 +1366,8 @@ static int get_associated_image_nonhier_offset(GKeyFile *keyfile,
   if (parse_image_format(format, NULL) != FORMAT_JPEG) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Unsupported associated image format: %s", format);
-    g_free(format);
     return -1;
   }
-  g_free(format);
 
   return offset;
 }
@@ -1435,68 +1375,25 @@ static int get_associated_image_nonhier_offset(GKeyFile *keyfile,
 static bool mirax_open(openslide_t *osr, const char *filename,
                        struct _openslide_tifflike *tl G_GNUC_UNUSED,
                        struct _openslide_hash *quickhash1, GError **err) {
-  struct level **levels = NULL;
-
-  char *dirname = NULL;
-
-  GKeyFile *slidedat = NULL;
-  GError *tmp_err = NULL;
-
-  bool success = false;
-  char *tmp = NULL;
-
-  // info about this slide
-  char *slide_version = NULL;
-  char *slide_id = NULL;
-  int images_x = 0;
-  int images_y = 0;
-  int image_divisions = 0;
-  int objective_magnification = 0;
-
-  char *index_filename = NULL;
-  int zoom_levels = 0;
-  int hier_count = 0;
-  int nonhier_count = 0;
-  int position_nonhier_vimslide_offset = -1;  // VIMSLIDE_POSITION_BUFFER
-  int position_nonhier_stitching_offset = -1; // StitchingIntensityLayer
-  int macro_nonhier_offset = -1;
-  int label_nonhier_offset = -1;
-  int thumbnail_nonhier_offset = -1;
-
-  int slide_zoom_level_value = -1;
-  char *key_slide_zoom_level_count = NULL;
-  char **slide_zoom_level_section_names = NULL;
-  struct slide_zoom_level_section *slide_zoom_level_sections = NULL;
-  struct slide_zoom_level_params *slide_zoom_level_params = NULL;
-
-  int datafile_count = 0;
-  char **datafile_paths = NULL;
-
-  struct _openslide_file *indexfile = NULL;
-
-  int64_t base_w = 0;
-  int64_t base_h = 0;
-
-  int total_concat_exponent = 0;
-
   // get directory from filename
-  dirname = g_strndup(filename, strlen(filename) - strlen(MRXS_EXT));
+  g_autofree char *dirname =
+    g_strndup(filename, strlen(filename) - strlen(MRXS_EXT));
 
   // first, check slidedat
-  tmp = g_build_filename(dirname, SLIDEDAT_INI, NULL);
+  g_autofree char *slidedat_path =
+    g_build_filename(dirname, SLIDEDAT_INI, NULL);
   // hash the slidedat
-  if (!_openslide_hash_file(quickhash1, tmp, err)) {
-    goto FAIL;
+  if (!_openslide_hash_file(quickhash1, slidedat_path, err)) {
+    return false;
   }
 
-  slidedat = _openslide_read_key_file(tmp, SLIDEDAT_MAX_SIZE,
-                                      G_KEY_FILE_NONE, err);
+  g_autoptr(GKeyFile) slidedat =
+    _openslide_read_key_file(slidedat_path, SLIDEDAT_MAX_SIZE,
+                             G_KEY_FILE_NONE, err);
   if (!slidedat) {
     g_prefix_error(err, "Can't load Slidedat.ini file: ");
-    goto FAIL;
+    return false;
   }
-  g_free(tmp);
-  tmp = NULL;
 
   // add properties
   add_properties(osr, slidedat);
@@ -1504,20 +1401,26 @@ static bool mirax_open(openslide_t *osr, const char *filename,
   // load general stuff
   HAVE_GROUP_OR_FAIL(slidedat, GROUP_GENERAL);
 
+  g_autofree char *slide_version = NULL;
   READ_KEY_OR_FAIL(slide_version, slidedat, GROUP_GENERAL,
                    KEY_SLIDE_VERSION, value);
+  g_autofree char *slide_id = NULL;
   READ_KEY_OR_FAIL(slide_id, slidedat, GROUP_GENERAL,
                    KEY_SLIDE_ID, value);
+  int images_x = 0;
   READ_KEY_OR_FAIL(images_x, slidedat, GROUP_GENERAL,
                    KEY_IMAGENUMBER_X, integer);
+  int images_y = 0;
   READ_KEY_OR_FAIL(images_y, slidedat, GROUP_GENERAL,
                    KEY_IMAGENUMBER_Y, integer);
+  int objective_magnification = 0;
   READ_KEY_OR_FAIL(objective_magnification, slidedat, GROUP_GENERAL,
                    KEY_OBJECTIVE_MAGNIFICATION, integer);
 
-  image_divisions = g_key_file_get_integer(slidedat, GROUP_GENERAL,
-					   KEY_CAMERA_IMAGE_DIVISIONS_PER_SIDE,
-					   &tmp_err);
+  GError *tmp_err = NULL;
+  int image_divisions =
+    g_key_file_get_integer(slidedat, GROUP_GENERAL,
+                           KEY_CAMERA_IMAGE_DIVISIONS_PER_SIDE, &tmp_err);
   if (tmp_err != NULL) {
     image_divisions = 1;
     g_clear_error(&tmp_err);
@@ -1531,8 +1434,10 @@ static bool mirax_open(openslide_t *osr, const char *filename,
   // load hierarchical stuff
   HAVE_GROUP_OR_FAIL(slidedat, GROUP_HIERARCHICAL);
 
+  int hier_count = 0;
   READ_KEY_OR_FAIL(hier_count, slidedat, GROUP_HIERARCHICAL,
                    KEY_HIER_COUNT, integer);
+  int nonhier_count = 0;
   READ_KEY_OR_FAIL(nonhier_count, slidedat, GROUP_HIERARCHICAL,
                    KEY_NONHIER_COUNT, integer);
 
@@ -1540,77 +1445,74 @@ static bool mirax_open(openslide_t *osr, const char *filename,
   NON_NEGATIVE_OR_FAIL(nonhier_count);
 
   // find key for slide zoom level
+  g_autofree char *key_slide_zoom_level_count = NULL;
+  int slide_zoom_level_value = -1;
   for (int i = 0; i < hier_count; i++) {
-    char *key = g_strdup_printf(KEY_HIER_d_NAME, i);
-    char *value = g_key_file_get_value(slidedat, GROUP_HIERARCHICAL, key, err);
-    g_free(key);
+    g_autofree char *key = g_strdup_printf(KEY_HIER_d_NAME, i);
+    g_autofree char *value =
+      g_key_file_get_value(slidedat, GROUP_HIERARCHICAL, key, err);
 
     if (!value) {
-      goto FAIL;
+      return false;
     }
 
     if (strcmp(VALUE_SLIDE_ZOOM_LEVEL, value) == 0) {
-      g_free(value);
       slide_zoom_level_value = i;
       key_slide_zoom_level_count = g_strdup_printf(KEY_HIER_d_COUNT, i);
       break;
     }
-    g_free(value);
   }
 
   if (slide_zoom_level_value == -1) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Can't find slide zoom level");
-    goto FAIL;
+    return false;
   }
 
   // TODO allow slide_zoom_level_value to be at another hierarchy value
   if (slide_zoom_level_value != 0) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Slide zoom level not HIER_0");
-    goto FAIL;
+    return false;
   }
 
+  g_autofree char *index_filename = NULL;
   READ_KEY_OR_FAIL(index_filename, slidedat, GROUP_HIERARCHICAL,
                    KEY_INDEXFILE, value);
+  int zoom_levels = 0;
   READ_KEY_OR_FAIL(zoom_levels, slidedat, GROUP_HIERARCHICAL,
                    key_slide_zoom_level_count, integer);
   POSITIVE_OR_FAIL(zoom_levels);
 
-
-  slide_zoom_level_section_names = g_new0(char *, zoom_levels + 1);
+  g_auto(GStrv) slide_zoom_level_section_names =
+    g_new0(char *, zoom_levels + 1);
   for (int i = 0; i < zoom_levels; i++) {
-    tmp = g_strdup_printf(KEY_HIER_d_VAL_d_SECTION, slide_zoom_level_value, i);
+    g_autofree char *key =
+      g_strdup_printf(KEY_HIER_d_VAL_d_SECTION, slide_zoom_level_value, i);
 
     READ_KEY_OR_FAIL(slide_zoom_level_section_names[i], slidedat,
-                     GROUP_HIERARCHICAL, tmp, value);
-
-    g_free(tmp);
-    tmp = NULL;
+                     GROUP_HIERARCHICAL, key, value);
   }
 
   // load datafile stuff
   HAVE_GROUP_OR_FAIL(slidedat, GROUP_DATAFILE);
 
+  int datafile_count = 0;
   READ_KEY_OR_FAIL(datafile_count, slidedat, GROUP_DATAFILE,
                    KEY_FILE_COUNT, integer);
   POSITIVE_OR_FAIL(datafile_count);
 
-  datafile_paths = g_new0(char *, datafile_count + 1);
+  g_auto(GStrv) datafile_paths = g_new0(char *, datafile_count + 1);
   for (int i = 0; i < datafile_count; i++) {
-    tmp = g_strdup_printf(KEY_d_FILE, i);
-
-    gchar *name;
-    READ_KEY_OR_FAIL(name, slidedat, GROUP_DATAFILE, tmp, value);
+    g_autofree char *key = g_strdup_printf(KEY_d_FILE, i);
+    g_autofree char *name = NULL;
+    READ_KEY_OR_FAIL(name, slidedat, GROUP_DATAFILE, key, value);
     datafile_paths[i] = g_build_filename(dirname, name, NULL);
-    g_free(name);
-
-    g_free(tmp);
-    tmp = NULL;
   }
 
   // load data from all slide_zoom_level_section_names sections
-  slide_zoom_level_sections = g_new0(struct slide_zoom_level_section, zoom_levels);
+  g_autofree struct slide_zoom_level_section *slide_zoom_level_sections =
+    g_new0(struct slide_zoom_level_section, zoom_levels);
   for (int i = 0; i < zoom_levels; i++) {
     struct slide_zoom_level_section *hs = slide_zoom_level_sections + i;
 
@@ -1646,57 +1548,62 @@ static bool mirax_open(openslide_t *osr, const char *filename,
       ((bgr >> 16) & 0x000000FF);
 
     // read image format
-    READ_KEY_OR_FAIL(tmp, slidedat, group, KEY_IMAGE_FORMAT, value);
-    hs->image_format = parse_image_format(tmp, err);
-    g_free(tmp);
-    tmp = NULL;
+    g_autofree char *format = NULL;
+    READ_KEY_OR_FAIL(format, slidedat, group, KEY_IMAGE_FORMAT, value);
+    hs->image_format = parse_image_format(format, err);
     if (hs->image_format == FORMAT_UNKNOWN) {
-      goto FAIL;
+      return false;
     }
   }
 
   // load position stuff
   // find key for position, if present
-  position_nonhier_vimslide_offset = get_nonhier_name_offset(slidedat,
-                                                             nonhier_count,
-                                                             GROUP_HIERARCHICAL,
-                                                             VALUE_VIMSLIDE_POSITION_BUFFER,
-                                                             &tmp_err);
+  int position_nonhier_vimslide_offset =
+    get_nonhier_name_offset(slidedat,
+                            nonhier_count,
+                            GROUP_HIERARCHICAL,
+                            VALUE_VIMSLIDE_POSITION_BUFFER,
+                            &tmp_err);
   SUCCESSFUL_OR_FAIL(tmp_err);
 
+  int position_nonhier_stitching_offset = -1;
   if (position_nonhier_vimslide_offset == -1) {
-    position_nonhier_stitching_offset = get_nonhier_name_offset(slidedat,
-							        nonhier_count,
-							        GROUP_HIERARCHICAL,
-							        VALUE_STITCHING_INTENSITY_LAYER,
-							        &tmp_err);
+    position_nonhier_stitching_offset =
+      get_nonhier_name_offset(slidedat,
+                              nonhier_count,
+                              GROUP_HIERARCHICAL,
+                              VALUE_STITCHING_INTENSITY_LAYER,
+                              &tmp_err);
     SUCCESSFUL_OR_FAIL(tmp_err);
   }
 
   // associated images
-  macro_nonhier_offset = get_associated_image_nonhier_offset(slidedat,
-                                                             nonhier_count,
-                                                             GROUP_HIERARCHICAL,
-                                                             VALUE_SCAN_DATA_LAYER,
-                                                             VALUE_SCAN_DATA_LAYER_MACRO,
-                                                             KEY_MACRO_IMAGE_TYPE,
-                                                             &tmp_err);
+  int macro_nonhier_offset =
+    get_associated_image_nonhier_offset(slidedat,
+                                        nonhier_count,
+                                        GROUP_HIERARCHICAL,
+                                        VALUE_SCAN_DATA_LAYER,
+                                        VALUE_SCAN_DATA_LAYER_MACRO,
+                                        KEY_MACRO_IMAGE_TYPE,
+                                        &tmp_err);
   SUCCESSFUL_OR_FAIL(tmp_err);
-  label_nonhier_offset = get_associated_image_nonhier_offset(slidedat,
-                                                             nonhier_count,
-                                                             GROUP_HIERARCHICAL,
-                                                             VALUE_SCAN_DATA_LAYER,
-                                                             VALUE_SCAN_DATA_LAYER_LABEL,
-                                                             KEY_LABEL_IMAGE_TYPE,
-                                                             &tmp_err);
+  int label_nonhier_offset =
+    get_associated_image_nonhier_offset(slidedat,
+                                        nonhier_count,
+                                        GROUP_HIERARCHICAL,
+                                        VALUE_SCAN_DATA_LAYER,
+                                        VALUE_SCAN_DATA_LAYER_LABEL,
+                                        KEY_LABEL_IMAGE_TYPE,
+                                        &tmp_err);
   SUCCESSFUL_OR_FAIL(tmp_err);
-  thumbnail_nonhier_offset = get_associated_image_nonhier_offset(slidedat,
-                                                                 nonhier_count,
-                                                                 GROUP_HIERARCHICAL,
-                                                                 VALUE_SCAN_DATA_LAYER,
-                                                                 VALUE_SCAN_DATA_LAYER_THUMBNAIL,
-                                                                 KEY_THUMBNAIL_IMAGE_TYPE,
-                                                                 &tmp_err);
+  int thumbnail_nonhier_offset =
+    get_associated_image_nonhier_offset(slidedat,
+                                        nonhier_count,
+                                        GROUP_HIERARCHICAL,
+                                        VALUE_SCAN_DATA_LAYER,
+                                        VALUE_SCAN_DATA_LAYER_THUMBNAIL,
+                                        KEY_THUMBNAIL_IMAGE_TYPE,
+                                        &tmp_err);
   SUCCESSFUL_OR_FAIL(tmp_err);
 
   /*
@@ -1726,13 +1633,10 @@ static bool mirax_open(openslide_t *osr, const char *filename,
   */
 
   // read indexfile
-  tmp = g_build_filename(dirname, index_filename, NULL);
-  indexfile = _openslide_fopen(tmp, err);
-  g_free(tmp);
-  tmp = NULL;
-
+  g_autofree char *index_path = g_build_filename(dirname, index_filename, NULL);
+  g_autoptr(_openslide_file) indexfile = _openslide_fopen(index_path, err);
   if (!indexfile) {
-    goto FAIL;
+    return false;
   }
 
   // The camera on MIRAX takes a photo and records a position.
@@ -1755,8 +1659,8 @@ static bool mirax_open(openslide_t *osr, const char *filename,
   // subtiles. This significantly complicates the code.
 
   // compute dimensions base_w and base_h in stupid but clear way
-  base_w = 0;
-  base_h = 0;
+  int64_t base_w = 0;
+  int64_t base_h = 0;
 
   for (int i = 0; i < images_x; i++) {
     if (((i % image_divisions) != (image_divisions - 1))
@@ -1779,14 +1683,15 @@ static bool mirax_open(openslide_t *osr, const char *filename,
     }
   }
 
-
   // set up level dimensions and such
-  levels = g_new0(struct level *, zoom_levels);
-  slide_zoom_level_params = g_new(struct slide_zoom_level_params, zoom_levels);
-  total_concat_exponent = 0;
+  g_autoptr(GPtrArray) level_array =
+    g_ptr_array_new_with_free_func((GDestroyNotify) destroy_level);
+  g_autofree struct slide_zoom_level_params *slide_zoom_level_params =
+    g_new(struct slide_zoom_level_params, zoom_levels);
+  int total_concat_exponent = 0;
   for (int i = 0; i < zoom_levels; i++) {
     struct level *l = g_slice_new0(struct level);
-    levels[i] = l;
+    g_ptr_array_add(level_array, l);
     struct slide_zoom_level_section *hs = slide_zoom_level_sections + i;
     struct slide_zoom_level_params *lp = slide_zoom_level_params + i;
 
@@ -1797,7 +1702,7 @@ static bool mirax_open(openslide_t *osr, const char *filename,
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "image_concat exponent too large: %d",
                   total_concat_exponent);
-      goto FAIL;
+      return false;
     }
     lp->image_concat = 1 << total_concat_exponent;
 
@@ -1900,14 +1805,15 @@ static bool mirax_open(openslide_t *osr, const char *filename,
 			 image_divisions,
 			 slide_zoom_level_params,
 			 indexfile,
-			 levels,
+			 (struct level **) level_array->pdata,
 			 quickhash1,
 			 err)) {
-    goto FAIL;
+    return false;
   }
 
   // set properties
-  _openslide_set_bounds_props_from_grid(osr, levels[0]->grid);
+  struct level *l0 = level_array->pdata[0];
+  _openslide_set_bounds_props_from_grid(osr, l0->grid);
   uint32_t fill = slide_zoom_level_sections[0].fill_rgb;
   _openslide_set_background_color_prop(osr,
                                        (fill >> 16) & 0xFF,
@@ -1925,7 +1831,7 @@ static bool mirax_open(openslide_t *osr, const char *filename,
 
   /*
   for (int i = 0; i < zoom_levels; i++) {
-    struct level *l = levels[i];
+    struct level *l = level_array->pdata[i];
     g_debug("level %d", i);
     g_debug(" size %"PRId64" %"PRId64, l->base.w, l->base.h);
     g_debug(" image size %d %d", l->image_width, l->image_height);
@@ -1935,71 +1841,34 @@ static bool mirax_open(openslide_t *osr, const char *filename,
 
   // if any level is missing tile size hints, we must invalidate all hints
   for (int i = 0; i < zoom_levels; i++) {
-    if (!levels[i]->base.tile_w || !levels[i]->base.tile_h) {
+    struct level *l = level_array->pdata[i];
+    if (!l->base.tile_w || !l->base.tile_h) {
       // invalidate
       for (i = 0; i < zoom_levels; i++) {
-        levels[i]->base.tile_w = 0;
-        levels[i]->base.tile_h = 0;
+        struct level *l = level_array->pdata[i];
+        l->base.tile_w = 0;
+        l->base.tile_h = 0;
       }
       break;
     }
   }
 
-  // populate the level_count
-  osr->level_count = zoom_levels;
-
   // populate levels
   g_assert(osr->levels == NULL);
-  osr->levels = (struct _openslide_level **) levels;
-  levels = NULL;
+  osr->level_count = zoom_levels;
+  osr->levels = (struct _openslide_level **)
+    g_ptr_array_free(g_steal_pointer(&level_array), false);
 
   // set private data
   g_assert(osr->data == NULL);
   struct mirax_ops_data *data = g_slice_new0(struct mirax_ops_data);
-  data->datafile_paths = datafile_paths;
-  datafile_paths = NULL;
+  data->datafile_paths = g_steal_pointer(&datafile_paths);
   osr->data = data;
 
   // set ops
   osr->ops = &mirax_ops;
 
-  success = true;
-  goto DONE;
-
- FAIL:
-  if (levels != NULL) {
-    for (int i = 0; i < zoom_levels; i++) {
-      struct level *l = levels[i];
-      if (l) {
-        _openslide_grid_destroy(l->grid);
-        g_slice_free(struct level, l);
-      }
-    }
-    g_free(levels);
-  }
-
-  success = false;
-
- DONE:
-  g_free(dirname);
-  g_free(tmp);
-  g_free(slide_version);
-  g_free(slide_id);
-  g_free(index_filename);
-  g_strfreev(datafile_paths);
-  g_strfreev(slide_zoom_level_section_names);
-  g_free(slide_zoom_level_sections);
-  g_free(slide_zoom_level_params);
-  g_free(key_slide_zoom_level_count);
-
-  if (slidedat) {
-    g_key_file_free(slidedat);
-  }
-  if (indexfile) {
-    _openslide_fclose(indexfile);
-  }
-
-  return success;
+  return true;
 }
 
 const struct _openslide_format _openslide_format_mirax = {

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -223,26 +223,26 @@ static uint32_t *read_image(openslide_t *osr,
   struct mirax_ops_data *data = osr->data;
   bool result = false;
 
-  uint32_t *dest = g_slice_alloc(w * h * 4);
+  g_auto(_openslide_slice) dest = _openslide_slice_alloc(w * h * 4);
 
   switch (format) {
   case FORMAT_JPEG:
     result = _openslide_jpeg_read(data->datafile_paths[image->fileno],
                                   image->start_in_file,
-                                  dest, w, h,
+                                  dest.p, w, h,
                                   err);
     break;
   case FORMAT_PNG:
     result = _openslide_png_read(data->datafile_paths[image->fileno],
                                  image->start_in_file,
-                                 dest, w, h,
+                                 dest.p, w, h,
                                  err);
     break;
   case FORMAT_BMP:
     result = _openslide_gdkpixbuf_read("bmp",
                                        data->datafile_paths[image->fileno],
                                        image->start_in_file, image->length,
-                                       dest, w, h,
+                                       dest.p, w, h,
                                        err);
     break;
   default:
@@ -250,10 +250,9 @@ static uint32_t *read_image(openslide_t *osr,
   }
 
   if (!result) {
-    g_slice_free1(w * h * 4, dest);
     return NULL;
   }
-  return dest;
+  return _openslide_slice_steal(&dest);
 }
 
 static bool read_tile(openslide_t *osr,

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -950,7 +950,7 @@ static int32_t *read_slide_position_buffer(const void *buffer,
 
   const char *p = buffer;
   int64_t count = buffer_size / SLIDE_POSITION_RECORD_SIZE;
-  int32_t *result = g_new(int, count * 2);
+  int32_t *result = g_new(int32_t, count * 2);
   int32_t x;
   int32_t y;
   char zz;

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -1464,7 +1464,6 @@ static bool mirax_open(openslide_t *osr, const char *filename,
   int thumbnail_nonhier_offset = -1;
 
   int slide_zoom_level_value = -1;
-  char *key_slide_zoom_level_name = NULL;
   char *key_slide_zoom_level_count = NULL;
   char **slide_zoom_level_section_names = NULL;
   struct slide_zoom_level_section *slide_zoom_level_sections = NULL;
@@ -1553,7 +1552,6 @@ static bool mirax_open(openslide_t *osr, const char *filename,
     if (strcmp(VALUE_SLIDE_ZOOM_LEVEL, value) == 0) {
       g_free(value);
       slide_zoom_level_value = i;
-      key_slide_zoom_level_name = g_strdup_printf(KEY_HIER_d_NAME, i);
       key_slide_zoom_level_count = g_strdup_printf(KEY_HIER_d_COUNT, i);
       break;
     }
@@ -1992,7 +1990,6 @@ static bool mirax_open(openslide_t *osr, const char *filename,
   g_strfreev(slide_zoom_level_section_names);
   g_free(slide_zoom_level_sections);
   g_free(slide_zoom_level_params);
-  g_free(key_slide_zoom_level_name);
   g_free(key_slide_zoom_level_count);
 
   if (slidedat) {

--- a/src/openslide-vendor-philips.c
+++ b/src/openslide-vendor-philips.c
@@ -79,15 +79,18 @@ struct xml_associated_image {
   const char *xpath;  // static string; do not free
 };
 
+static void destroy_level(struct level *l) {
+  _openslide_grid_destroy(l->grid);
+  g_slice_free(struct level, l);
+}
+
 static void destroy(openslide_t *osr) {
   struct philips_ops_data *data = osr->data;
   _openslide_tiffcache_destroy(data->tc);
   g_slice_free(struct philips_ops_data, data);
 
   for (int32_t i = 0; i < osr->level_count; i++) {
-    struct level *l = (struct level *) osr->levels[i];
-    _openslide_grid_destroy(l->grid);
-    g_slice_free(struct level, l);
+    destroy_level((struct level *) osr->levels[i]);
   }
   g_free(osr->levels);
 }
@@ -402,8 +405,7 @@ static void add_properties(openslide_t *osr,
 static bool parse_pixel_spacing(const char *spacing,
                                 double *w, double *h,
                                 GError **err) {
-  bool success = false;
-  char **spacings = g_strsplit(spacing, " ", 0);
+  g_auto(GStrv) spacings = g_strsplit(spacing, " ", 0);
   if (g_strv_length(spacings) == 2) {
     for (int i = 0; i < 2; i++) {
       // strip quotes
@@ -412,14 +414,13 @@ static bool parse_pixel_spacing(const char *spacing,
     // row spacing, then column spacing
     *w = _openslide_parse_double(spacings[1]);
     *h = _openslide_parse_double(spacings[0]);
-    success = !isnan(*w) && !isnan(*h);
+    if (!isnan(*w) && !isnan(*h)) {
+      return true;
+    }
   }
-  g_strfreev(spacings);
-  if (!success) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Couldn't parse pixel spacing");
-  }
-  return success;
+  g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+              "Couldn't parse pixel spacing");
+  return false;
 }
 
 static void add_mpp_properties(openslide_t *osr) {
@@ -510,29 +511,27 @@ static bool philips_open(openslide_t *osr,
                          struct _openslide_tifflike *tl,
                          struct _openslide_hash *quickhash1,
                          GError **err) {
-  GPtrArray *level_array = g_ptr_array_new();
-  xmlDoc *doc = NULL;
-  bool success = false;
-
   // open TIFF
   g_autoptr(_openslide_tiffcache) tc = _openslide_tiffcache_create(filename);
   g_auto(_openslide_cached_tiff) ct = _openslide_tiffcache_get(tc, err);
   if (!ct.tiff) {
-    goto FAIL;
+    return false;
   }
 
   // parse XML document
-  doc = parse_xml(ct.tiff, err);
+  g_autoptr(xmlDoc) doc = parse_xml(ct.tiff, err);
   if (doc == NULL) {
-    goto FAIL;
+    return false;
   }
 
   // ensure there is only one WSI DPScannedImage in the XML
   if (!verify_main_image_count(doc, err)) {
-    goto FAIL;
+    return false;
   }
 
   // create levels
+  g_autoptr(GPtrArray) level_array =
+    g_ptr_array_new_with_free_func((GDestroyNotify) destroy_level);
   struct level *prev_l = NULL;
   do {
     // get directory
@@ -554,7 +553,7 @@ static bool philips_open(openslide_t *osr,
             !(subfiletype & FILETYPE_REDUCEDIMAGE)) {
           g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                       "Directory %d is not reduced-resolution", dir);
-          goto FAIL;
+          return false;
         }
       }
 
@@ -563,22 +562,23 @@ static bool philips_open(openslide_t *osr,
       if (!TIFFGetField(ct.tiff, TIFFTAG_COMPRESSION, &compression)) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Can't read compression scheme");
-        goto FAIL;
+        return false;
       };
       if (!TIFFIsCODECConfigured(compression)) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Unsupported TIFF compression: %u", compression);
-        goto FAIL;
+        return false;
       }
 
       // create level
       struct level *l = g_slice_new0(struct level);
       struct _openslide_tiff_level *tiffl = &l->tiffl;
+      g_ptr_array_add(level_array, l);
+
       if (!_openslide_tiff_level_init(ct.tiff, dir,
                                       (struct _openslide_level *) l, tiffl,
                                       err)) {
-        g_slice_free(struct level, l);
-        goto FAIL;
+        return false;
       }
       l->grid = _openslide_grid_create_simple(osr,
                                               tiffl->tiles_across,
@@ -587,16 +587,13 @@ static bool philips_open(openslide_t *osr,
                                               tiffl->tile_h,
                                               read_tile);
 
-      // add to array
-      g_ptr_array_add(level_array, l);
-
       // verify that levels are sorted by size
       if (prev_l &&
           (tiffl->image_w > prev_l->tiffl.image_w ||
            tiffl->image_h > prev_l->tiffl.image_h)) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Unexpected dimensions for directory %d", dir);
-        goto FAIL;
+        return false;
       }
       prev_l = l;
 
@@ -605,7 +602,7 @@ static bool philips_open(openslide_t *osr,
       // label
       //g_debug("Adding label image from directory %d", dir);
       if (!_openslide_tiff_add_associated_image(osr, "label", tc, dir, err)) {
-        goto FAIL;
+        return false;
       }
 
     } else if (image_desc &&
@@ -613,7 +610,7 @@ static bool philips_open(openslide_t *osr,
       // macro image
       //g_debug("Adding macro image from directory %d", dir);
       if (!_openslide_tiff_add_associated_image(osr, "macro", tc, dir, err)) {
-        goto FAIL;
+        return false;
       }
     }
   } while (TIFFReadDirectory(ct.tiff));
@@ -623,7 +620,7 @@ static bool philips_open(openslide_t *osr,
   if (!fix_level_dimensions((struct level **) level_array->pdata,
                             level_array->len,
                             doc, err)) {
-    goto FAIL;
+    return false;
   }
 
   // set hash and properties
@@ -633,7 +630,7 @@ static bool philips_open(openslide_t *osr,
                                                     top_level->tiffl.dir,
                                                     0,
                                                     err)) {
-    goto FAIL;
+    return false;
   }
 
   // keep the XML document out of the properties
@@ -641,10 +638,9 @@ static bool philips_open(openslide_t *osr,
   g_hash_table_remove(osr->properties, "tiff.ImageDescription");
 
   // add properties from XML
-  xmlXPathContext *ctx = _openslide_xml_xpath_create(doc);
+  g_autoptr(xmlXPathContext) ctx = _openslide_xml_xpath_create(doc);
   add_properties(osr, ctx, "philips", "/DataObject/Attribute");
   add_mpp_properties(osr);
-  xmlXPathFreeContext(ctx);
 
   // add associated images from XML
   // errors are non-fatal
@@ -653,47 +649,20 @@ static bool philips_open(openslide_t *osr,
   maybe_add_xml_associated_image(osr, tc, doc,
                                  "macro", MACRO_DATA_XPATH, NULL);
 
-  // unwrap level array
-  int32_t level_count = level_array->len;
-  struct level **levels =
-    (struct level **) g_ptr_array_free(level_array, false);
-  level_array = NULL;
-
   // allocate private data
   struct philips_ops_data *data = g_slice_new0(struct philips_ops_data);
+  data->tc = g_steal_pointer(&tc);
 
   // store osr data
   g_assert(osr->data == NULL);
   g_assert(osr->levels == NULL);
-  osr->levels = (struct _openslide_level **) levels;
-  osr->level_count = level_count;
+  osr->level_count = level_array->len;
+  osr->levels = (struct _openslide_level **)
+    g_ptr_array_free(g_steal_pointer(&level_array), false);
   osr->data = data;
   osr->ops = &philips_ops;
 
-  // store tiffcache reference
-  data->tc = g_steal_pointer(&tc);
-
-  // done
-  success = true;
-  goto DONE;
-
-FAIL:
-  // free the level array
-  if (level_array) {
-    for (uint32_t n = 0; n < level_array->len; n++) {
-      struct level *l = level_array->pdata[n];
-      _openslide_grid_destroy(l->grid);
-      g_slice_free(struct level, l);
-    }
-    g_ptr_array_free(level_array, true);
-  }
-
-DONE:
-  // free XML
-  if (doc) {
-    xmlFreeDoc(doc);
-  }
-  return success;
+  return true;
 }
 
 const struct _openslide_format _openslide_format_philips = {

--- a/src/openslide-vendor-philips.c
+++ b/src/openslide-vendor-philips.c
@@ -119,29 +119,27 @@ static bool read_tile(openslide_t *osr,
                                             &is_missing, err)) {
       return false;
     }
-
     if (is_missing) {
-      // fill with transparent
-      tiledata = g_slice_alloc0(tw * th * 4);
+      // nothing to draw
+      return true;
+    }
 
-    } else {
-      tiledata = g_slice_alloc(tw * th * 4);
-      if (!_openslide_tiff_read_tile(tiffl, tiff,
-                                     tiledata, tile_col, tile_row,
-                                     err)) {
-        g_slice_free1(tw * th * 4, tiledata);
-        return false;
-      }
+    tiledata = g_slice_alloc(tw * th * 4);
+    if (!_openslide_tiff_read_tile(tiffl, tiff,
+                                   tiledata, tile_col, tile_row,
+                                   err)) {
+      g_slice_free1(tw * th * 4, tiledata);
+      return false;
+    }
 
-      // clip, if necessary
-      if (!_openslide_clip_tile(tiledata,
-                                tw, th,
-                                l->base.w - tile_col * tw,
-                                l->base.h - tile_row * th,
-                                err)) {
-        g_slice_free1(tw * th * 4, tiledata);
-        return false;
-      }
+    // clip, if necessary
+    if (!_openslide_clip_tile(tiledata,
+                              tw, th,
+                              l->base.w - tile_col * tw,
+                              l->base.h - tile_row * th,
+                              err)) {
+      g_slice_free1(tw * th * 4, tiledata);
+      return false;
     }
 
     // put it in the cache

--- a/src/openslide-vendor-sakura.c
+++ b/src/openslide-vendor-sakura.c
@@ -299,38 +299,34 @@ static bool read_image(uint32_t *tiledata,
                        int32_t tile_size,
                        sqlite3_stmt *stmt,
                        GError **err) {
-  uint8_t *red_channel = g_slice_alloc(tile_size * tile_size);
-  uint8_t *green_channel = g_slice_alloc(tile_size * tile_size);
-  uint8_t *blue_channel = g_slice_alloc(tile_size * tile_size);
-  bool success = false;
+  g_auto(_openslide_slice) red_channel =
+    _openslide_slice_alloc(tile_size * tile_size);
+  g_auto(_openslide_slice) green_channel =
+    _openslide_slice_alloc(tile_size * tile_size);
+  g_auto(_openslide_slice) blue_channel =
+    _openslide_slice_alloc(tile_size * tile_size);
 
-  if (!read_channel(red_channel, tile_col, tile_row, downsample,
+  if (!read_channel(red_channel.p, tile_col, tile_row, downsample,
                     INDEX_RED, focal_plane, tile_size, stmt, err)) {
-    goto OUT;
+    return false;
   }
-  if (!read_channel(green_channel, tile_col, tile_row, downsample,
+  if (!read_channel(green_channel.p, tile_col, tile_row, downsample,
                     INDEX_GREEN, focal_plane, tile_size, stmt, err)) {
-    goto OUT;
+    return false;
   }
-  if (!read_channel(blue_channel, tile_col, tile_row, downsample,
+  if (!read_channel(blue_channel.p, tile_col, tile_row, downsample,
                     INDEX_BLUE, focal_plane, tile_size, stmt, err)) {
-    goto OUT;
+    return false;
   }
 
   for (int32_t i = 0; i < tile_size * tile_size; i++) {
     tiledata[i] = 0xff000000 |
-                  (red_channel[i] << 16) |
-                  (green_channel[i] << 8) |
-                  blue_channel[i];
+                  (((uint8_t *) red_channel.p)[i] << 16) |
+                  (((uint8_t *) green_channel.p)[i] << 8) |
+                  ((uint8_t *) blue_channel.p)[i];
   }
 
-  success = true;
-
-OUT:
-  g_slice_free1(tile_size * tile_size, red_channel);
-  g_slice_free1(tile_size * tile_size, green_channel);
-  g_slice_free1(tile_size * tile_size, blue_channel);
-  return success;
+  return true;
 }
 
 static bool read_tile(openslide_t *osr,
@@ -351,10 +347,11 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    tiledata = g_slice_alloc(tile_size * tile_size * 4);
+    g_auto(_openslide_slice) box =
+      _openslide_slice_alloc(tile_size * tile_size * 4);
 
     // read tile
-    if (!read_image(tiledata, tile_col, tile_row, l->base.downsample,
+    if (!read_image(box.p, tile_col, tile_row, l->base.downsample,
                     data->focal_plane, tile_size, stmt, &tmp_err)) {
       if (g_error_matches(tmp_err, OPENSLIDE_ERROR,
                           OPENSLIDE_ERROR_NO_VALUE)) {
@@ -363,22 +360,21 @@ static bool read_tile(openslide_t *osr,
         return true;
       } else {
         g_propagate_error(err, tmp_err);
-        g_slice_free1(tile_size * tile_size * 4, tiledata);
         return false;
       }
     }
 
     // clip, if necessary
-    if (!_openslide_clip_tile(tiledata,
+    if (!_openslide_clip_tile(box.p,
                               tile_size, tile_size,
                               l->base.w - tile_col * tile_size,
                               l->base.h - tile_row * tile_size,
                               err)) {
-      g_slice_free1(tile_size * tile_size * 4, tiledata);
       return false;
     }
 
     // put it in the cache
+    tiledata = _openslide_slice_steal(&box);
     _openslide_cache_put(osr->cache,
 			 level, tile_col, tile_row,
 			 tiledata, tile_size * tile_size * 4,

--- a/src/openslide-vendor-synthetic.c
+++ b/src/openslide-vendor-synthetic.c
@@ -263,13 +263,13 @@ static bool read_tile(openslide_t *osr G_GNUC_UNUSED,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    tiledata = g_slice_alloc(IMAGE_BUFSIZE);
-    if (!decode_item(item, tiledata, err)) {
-      g_slice_free1(IMAGE_BUFSIZE, tiledata);
+    g_auto(_openslide_slice) box = _openslide_slice_alloc(IMAGE_BUFSIZE);
+    if (!decode_item(item, box.p, err)) {
       return false;
     }
 
     // put it in the cache
+    tiledata = _openslide_slice_steal(&box);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
                          tiledata, IMAGE_BUFSIZE, &cache_entry);
   }

--- a/src/openslide-vendor-trestle.c
+++ b/src/openslide-vendor-trestle.c
@@ -100,23 +100,22 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    tiledata = g_slice_alloc(tw * th * 4);
+    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
-                                   tiledata, tile_col, tile_row,
+                                   box.p, tile_col, tile_row,
                                    err)) {
-      g_slice_free1(tw * th * 4, tiledata);
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_tiff_clip_tile(tiffl, tiledata,
+    if (!_openslide_tiff_clip_tile(tiffl, box.p,
                                    tile_col, tile_row,
                                    err)) {
-      g_slice_free1(tw * th * 4, tiledata);
       return false;
     }
 
     // put it in the cache
+    tiledata = _openslide_slice_steal(&box);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
                          tiledata, tw * th * 4,
                          &cache_entry);

--- a/src/openslide-vendor-trestle.c
+++ b/src/openslide-vendor-trestle.c
@@ -54,30 +54,21 @@ struct level {
   struct _openslide_grid *grid;
 };
 
-static void destroy_data(struct trestle_ops_data *data,
-                         struct level **levels, int32_t level_count) {
-  if (data) {
-    _openslide_tiffcache_destroy(data->tc);
-    g_slice_free(struct trestle_ops_data, data);
-  }
-
-  if (levels) {
-    for (int32_t i = 0; i < level_count; i++) {
-      if (levels[i]) {
-        _openslide_grid_destroy(levels[i]->grid);
-        g_slice_free(struct level, levels[i]);
-      }
-    }
-    g_free(levels);
-  }
+static void destroy_level(struct level *l) {
+  _openslide_grid_destroy(l->grid);
+  g_slice_free(struct level, l);
 }
 
 static void destroy(openslide_t *osr) {
-  struct trestle_ops_data *data = osr->data;
-  struct level **levels = (struct level **) osr->levels;
-  destroy_data(data, levels, osr->level_count);
-}
+  for (int32_t i = 0; i < osr->level_count; i++) {
+    destroy_level((struct level *) osr->levels[i]);
+  }
+  g_free(osr->levels);
 
+  struct trestle_ops_data *data = osr->data;
+  _openslide_tiffcache_destroy(data->tc);
+  g_slice_free(struct trestle_ops_data, data);
+}
 
 static bool read_tile(openslide_t *osr,
                       cairo_t *cr,
@@ -199,7 +190,7 @@ static bool trestle_detect(const char *filename G_GNUC_UNUSED,
 
 static void add_properties(openslide_t *osr, char **tags) {
   for (char **tag = tags; *tag != NULL; tag++) {
-    char **pair = g_strsplit(*tag, "=", 2);
+    g_auto(GStrv) pair = g_strsplit(*tag, "=", 2);
     if (pair) {
       char *name = g_strstrip(pair[0]);
       if (name) {
@@ -210,7 +201,6 @@ static void add_properties(openslide_t *osr, char **tags) {
                             g_strdup(value));
       }
     }
-    g_strfreev(pair);
   }
 
   _openslide_duplicate_int_prop(osr, "trestle.Objective Power",
@@ -221,18 +211,16 @@ static void parse_trestle_image_description(openslide_t *osr,
                                             const char *description,
                                             int32_t *overlap_count_OUT,
                                             int32_t **overlaps_OUT) {
-  char **first_pass = g_strsplit(description, ";", -1);
-
-  int32_t overlap_count = 0;
-  int32_t *overlaps = NULL;
-
+  g_auto(GStrv) first_pass = g_strsplit(description, ";", -1);
   add_properties(osr, first_pass);
 
+  int32_t overlap_count = 0;
+  g_autofree int32_t *overlaps = NULL;
   for (char **cur_str = first_pass; *cur_str != NULL; cur_str++) {
     //g_debug(" XX: %s", *cur_str);
     if (g_str_has_prefix(*cur_str, OVERLAPS_XY)) {
       // found it
-      char **second_pass = g_strsplit(*cur_str, " ", -1);
+      g_auto(GStrv) second_pass = g_strsplit(*cur_str, " ", -1);
 
       overlap_count = g_strv_length(second_pass) - 1; // skip fieldname
       overlaps = g_new(int32_t, overlap_count);
@@ -243,8 +231,6 @@ static void parse_trestle_image_description(openslide_t *osr,
         overlaps[i] = g_ascii_strtoull(*cur_str2, NULL, 10);
         i++;
       }
-
-      g_strfreev(second_pass);
     } else if (g_str_has_prefix(*cur_str, BACKGROUND_COLOR)) {
       // found background color
       errno = 0;
@@ -257,14 +243,13 @@ static void parse_trestle_image_description(openslide_t *osr,
       }
     }
   }
-  g_strfreev(first_pass);
 
   *overlap_count_OUT = overlap_count / 2;
-  *overlaps_OUT = overlaps;
+  *overlaps_OUT = g_steal_pointer(&overlaps);
 }
 
 static char *get_associated_path(TIFF *tiff, const char *extension) {
-  char *base_path = g_strdup(TIFFFileName(tiff));
+  g_autofree char *base_path = g_strdup(TIFFFileName(tiff));
 
   // strip file extension, if present
   char *dot = g_strrstr(base_path, ".");
@@ -272,87 +257,73 @@ static char *get_associated_path(TIFF *tiff, const char *extension) {
     *dot = 0;
   }
 
-  char *path = g_strdup_printf("%s%s", base_path, extension);
-  g_free(base_path);
-  return path;
+  return g_strdup_printf("%s%s", base_path, extension);
 }
 
 static void add_associated_jpeg(openslide_t *osr, TIFF *tiff,
                                 const char *extension,
                                 const char *name) {
-  char *path = get_associated_path(tiff, extension);
+  g_autofree char *path = get_associated_path(tiff, extension);
   _openslide_jpeg_add_associated_image(osr, name, path, 0, NULL);
-  g_free(path);
 }
 
 static bool trestle_open(openslide_t *osr, const char *filename,
                          struct _openslide_tifflike *tl,
                          struct _openslide_hash *quickhash1, GError **err) {
-  struct trestle_ops_data *data = NULL;
-  struct level **levels = NULL;
-  int32_t overlap_count = 0;
-  int32_t *overlaps = NULL;
-  int32_t level_count = 0;
-
   // open TIFF
   g_autoptr(_openslide_tiffcache) tc = _openslide_tiffcache_create(filename);
   g_auto(_openslide_cached_tiff) ct = _openslide_tiffcache_get(tc, err);
   if (!ct.tiff) {
-    goto FAIL;
+    return false;
   }
 
   // parse ImageDescription
   char *image_desc;
+  int32_t overlap_count = 0;
+  g_autofree int32_t *overlaps = NULL;
   if (!TIFFGetField(ct.tiff, TIFFTAG_IMAGEDESCRIPTION, &image_desc)) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "Couldn't read ImageDescription");
-    goto FAIL;
+    return false;
   }
   parse_trestle_image_description(osr, image_desc, &overlap_count, &overlaps);
 
-  // count and validate levels
+  // create levels
+  g_autoptr(GPtrArray) level_array =
+    g_ptr_array_new_with_free_func((GDestroyNotify) destroy_level);
+  bool report_geometry = true;
   do {
     // verify that we can read this compression (hard fail if not)
     uint16_t compression;
     if (!TIFFGetField(ct.tiff, TIFFTAG_COMPRESSION, &compression)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Can't read compression scheme");
-      goto FAIL;
+      return false;
     };
     if (!TIFFIsCODECConfigured(compression)) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Unsupported TIFF compression: %u", compression);
-      goto FAIL;
+      return false;
     }
 
-    // level ok
-    level_count++;
-  } while (TIFFReadDirectory(ct.tiff));
-
-  // create ops data
-  data = g_slice_new0(struct trestle_ops_data);
-
-  // create levels
-  levels = g_new0(struct level *, level_count);
-  bool report_geometry = true;
-  for (int32_t i = 0; i < level_count; i++) {
     struct level *l = g_slice_new0(struct level);
     struct _openslide_tiff_level *tiffl = &l->tiffl;
-    levels[i] = l;
+    g_ptr_array_add(level_array, l);
 
     // directories are linear
-    if (!_openslide_tiff_level_init(ct.tiff, i,
+    tdir_t dir = TIFFCurrentDirectory(ct.tiff);
+    if (!_openslide_tiff_level_init(ct.tiff, dir,
                                     (struct _openslide_level *) l, tiffl,
                                     err)) {
-      goto FAIL;
+      return false;
     }
 
     // get overlaps
     int32_t overlap_x = 0;
     int32_t overlap_y = 0;
-    if (i < overlap_count) {
-      overlap_x = overlaps[2 * i];
-      overlap_y = overlaps[2 * i + 1];
+    if (dir < overlap_count) {
+      overlap_x = overlaps[2 * dir];
+      overlap_y = overlaps[2 * dir + 1];
       // if any level has overlaps, reporting tile advances would mislead the
       // application
       if (overlap_x || overlap_y) {
@@ -384,31 +355,36 @@ static bool trestle_open(openslide_t *osr, const char *filename,
                                          NULL);
       }
     }
-  }
-  g_free(overlaps);
-  overlaps = NULL;
+  } while (TIFFReadDirectory(ct.tiff));
 
   // clear tile size hints if necessary
   if (!report_geometry) {
-    for (int32_t i = 0; i < level_count; i++) {
-      levels[i]->base.tile_w = 0;
-      levels[i]->base.tile_h = 0;
+    for (guint i = 0; i < level_array->len; i++) {
+      struct level *l = level_array->pdata[i];
+      l->base.tile_w = 0;
+      l->base.tile_h = 0;
     }
   }
 
   // set hash and properties
+  struct level *top_level = level_array->pdata[level_array->len - 1];
   if (!_openslide_tifflike_init_properties_and_hash(osr, tl, quickhash1,
-                                                    levels[level_count - 1]->tiffl.dir,
+                                                    top_level->tiffl.dir,
                                                     0,
                                                     err)) {
-    goto FAIL;
+    return false;
   }
+
+  // create ops data
+  struct trestle_ops_data *data = g_slice_new0(struct trestle_ops_data);
+  data->tc = g_steal_pointer(&tc);
 
   // store osr data
   g_assert(osr->data == NULL);
   g_assert(osr->levels == NULL);
-  osr->levels = (struct _openslide_level **) levels;
-  osr->level_count = level_count;
+  osr->level_count = level_array->len;
+  osr->levels = (struct _openslide_level **)
+    g_ptr_array_free(g_steal_pointer(&level_array), false);
   osr->data = data;
   osr->ops = &trestle_ops;
 
@@ -422,15 +398,7 @@ static bool trestle_open(openslide_t *osr, const char *filename,
   // add associated images
   add_associated_jpeg(osr, ct.tiff, ".Full", "macro");
 
-  // store tiffcache reference
-  data->tc = g_steal_pointer(&tc);
-
   return true;
-
-FAIL:
-  destroy_data(data, levels, level_count);
-  g_free(overlaps);
-  return false;
 }
 
 const struct _openslide_format _openslide_format_trestle = {

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -175,23 +175,22 @@ static bool read_subtile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    tiledata = g_slice_alloc(tw * th * 4);
+    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
-                                   tiledata, tile_col, tile_row,
+                                   box.p, tile_col, tile_row,
                                    err)) {
-      g_slice_free1(tw * th * 4, tiledata);
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_tiff_clip_tile(tiffl, tiledata,
+    if (!_openslide_tiff_clip_tile(tiffl, box.p,
                                    tile_col, tile_row,
                                    err)) {
-      g_slice_free1(tw * th * 4, tiledata);
       return false;
     }
 
     // put it in the cache
+    tiledata = _openslide_slice_steal(&box);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
                          tiledata, tw * th * 4,
                          &cache_entry);

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -119,7 +119,7 @@ struct area {
   int64_t tiles_across;
   int64_t tiles_down;
   int64_t tile_count;
-  struct tile **tiles;
+  struct tile *tiles;
 };
 
 struct joint {
@@ -333,9 +333,6 @@ static bool ventana_detect(const char *filename G_GNUC_UNUSED,
 }
 
 static void area_free(struct area *area) {
-  for (int64_t j = 0; j < area->tile_count; j++) {
-    g_slice_free(struct tile, area->tiles[j]);
-  }
   g_free(area->tiles);
   g_slice_free(struct area, area);
 }
@@ -519,10 +516,7 @@ static struct bif *parse_level0_xml(const char *xml,
 
     // create tile structs
     area->tile_count = area->tiles_across * area->tiles_down;
-    area->tiles = g_new(struct tile *, area->tile_count);
-    for (int64_t j = 0; j < area->tile_count; j++) {
-      area->tiles[j] = g_slice_new0(struct tile);
-    }
+    area->tiles = g_new0(struct tile, area->tile_count);
 
     // walk tiles
     ctx->node = info;
@@ -558,13 +552,13 @@ static struct bif *parse_level0_xml(const char *xml,
       if (!xmlStrcmp(direction, BAD_CAST DIRECTION_RIGHT)) {
         // get left joint of right tile
         struct tile *tile =
-          area->tiles[tile2_row * area->tiles_across + tile2_col];
+          &area->tiles[tile2_row * area->tiles_across + tile2_col];
         joint = &tile->left;
         ok = (tile2_col == tile1_col + 1 && tile2_row == tile1_row);
       } else if (!xmlStrcmp(direction, BAD_CAST DIRECTION_UP)) {
         // get top joint of bottom tile
         struct tile *tile =
-          area->tiles[tile1_row * area->tiles_across + tile1_col];
+          &area->tiles[tile1_row * area->tiles_across + tile1_col];
         joint = &tile->top;
         ok = (tile2_col == tile1_col && tile2_row == tile1_row - 1);
         direction_y = true;


### PR DESCRIPTION
Also migrate the holdout functions in the PNG and gdk-pixbuf decoders, and convert `make-vmu.py` (for testing VMU support) to Python 3.

Closes #310.