### PR TITLE
synthetic: test decoding corrupt JPEG and PNG

### DIFF
--- a/misc/make-synthetic-item.py
+++ b/misc/make-synthetic-item.py
@@ -10,6 +10,7 @@ for name in sys.argv[1:]:
     print(f'  &(const struct synthetic_item){{')
     print(f'    .name = "{name}",')
     print(f'    .description = "fill this in",')
+    print(f'    .is_valid = true,')
     print(f'    .is_image = true,')
     print(f'    .decode = decode_{name},')
     print(f'    .uncompressed_size = {len(uncompressed)},')

--- a/test/cases/synthetic/config.yaml
+++ b/test/cases/synthetic/config.yaml
@@ -5,7 +5,7 @@ vendor: synthetic
 primary: true
 properties:
   # quickhash will change whenever items are added
-  openslide.quickhash-1: 62cbc433ecbbe3fe0ab32199bdea864c7e4ccbee5388313696abd4bd0c1506c3
+  openslide.quickhash-1: ed28afbe7a7a4ac2cc6bee2c89dd45740c9cfea0bb691ad41777006eb9bc1f46
   openslide.vendor: synthetic
 debug:
 - synthetic


### PR DESCRIPTION
Both decoders use `setjmp`/`longjmp` for error handling, which has historically had problems on 64-bit Windows with MinGW.  Let's include it in our smoke tests.

For https://github.com/openslide/openslide-winbuild/pull/49.