### PR TITLE
workflows: `brew update` before installing Mac packages

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -148,7 +148,10 @@ jobs:
             echo "Disabling file descriptor leak check"
             export CPPFLAGS="-DNONATOMIC_CLOEXEC"
         fi
-        ./configure
+        if ! ./configure; then
+            cat config.log
+            exit 1
+        fi
         make -j4 CFLAGS="-O2 -g -Werror"
     - name: Check
       run: |

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -51,7 +51,7 @@ jobs:
         macos-latest)
             brew update
             brew install \
-                gcc make autoconf automake libtool pkg-config \
+                autoconf automake libtool pkg-config \
                 zlib \
                 libpng \
                 jpeg-turbo \

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -49,6 +49,7 @@ jobs:
       run: |
         case "${{ matrix.os }}" in
         macos-latest)
+            brew update
             brew install \
                 gcc make autoconf automake libtool pkg-config \
                 zlib \


### PR DESCRIPTION
Make sure we have the latest package definitions.  We do this on Debian/Ubuntu and implicitly on Fedora/CentOS, so do it on macOS too for consistency.  This fixes a build failure with `macos-11` image 20220807.1, which was built in the middle of Homebrew's transition from libjpeg to libjpeg-turbo.

Also skip installing gcc and GNU Make on macOS.  We're not currently using either of them.