### PR TITLE
JPEG and PNG cleanups; fix JPEG error path when compiled with clang

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -18,7 +18,6 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    continue-on-error: ${{ matrix.failing || false }}
     strategy:
       matrix:
         include:
@@ -39,7 +38,6 @@ jobs:
             ignore-fd-leaks: true
           - os: ubuntu-22.04
           - os: macos-latest
-            failing: true
     steps:
     # Quick way to get Python 3 on macOS
     - name: Set up Python (macOS)

--- a/src/openslide-decode-jpeg.c
+++ b/src/openslide-decode-jpeg.c
@@ -114,7 +114,7 @@ static void my_emit_message(j_common_ptr cinfo, int msg_level) {
 // while decoding a tiny RGB JPEG.
 static void *detect_jcs_alpha_extensions(void *arg G_GNUC_UNUSED) {
   struct jpeg_decompress_struct *cinfo;
-  g_autoptr(_openslide_jpeg_decompress) dc =
+  g_auto(_openslide_jpeg_decompress) dc =
     _openslide_jpeg_decompress_create(&cinfo);
 
   jmp_buf env;
@@ -265,7 +265,7 @@ static bool jpeg_get_dimensions(struct _openslide_file *f,  // or:
   jmp_buf env;
 
   struct jpeg_decompress_struct *cinfo;
-  g_autoptr(_openslide_jpeg_decompress) dc =
+  g_auto(_openslide_jpeg_decompress) dc =
     _openslide_jpeg_decompress_create(&cinfo);
 
   if (setjmp(env) == 0) {
@@ -325,7 +325,7 @@ static bool jpeg_decode(struct _openslide_file *f,  // or:
   jmp_buf env;
 
   struct jpeg_decompress_struct *cinfo;
-  g_autoptr(_openslide_jpeg_decompress) dc =
+  g_auto(_openslide_jpeg_decompress) dc =
     _openslide_jpeg_decompress_create(&cinfo);
 
   if (setjmp(env) == 0) {

--- a/src/openslide-decode-jpeg.c
+++ b/src/openslide-decode-jpeg.c
@@ -105,17 +105,6 @@ static void my_emit_message(j_common_ptr cinfo, int msg_level) {
   }
 }
 
-static struct jpeg_error_mgr *error_handler_init(struct openslide_jpeg_error_mgr *jerr,
-                                                 jmp_buf *env) {
-  jpeg_std_error(&jerr->base);
-  jerr->base.error_exit = my_error_exit;
-  jerr->base.output_message = my_output_message;
-  jerr->base.emit_message = my_emit_message;
-  jerr->env = env;
-  return (struct jpeg_error_mgr *) jerr;
-}
-
-
 // Detect support for JCS_ALPHA_EXTENSIONS.  Even if the extensions were
 // available at compile time, they may not be available at runtime because
 // support for JCS_ALPHA_EXTENSIONS isn't reflected in the libjpeg soname.
@@ -124,33 +113,24 @@ static struct jpeg_error_mgr *error_handler_init(struct openslide_jpeg_error_mgr
 // and we need that for Aperio slides.  Instead, try enabling the extensions
 // while decoding a tiny RGB JPEG.
 static void *detect_jcs_alpha_extensions(void *arg G_GNUC_UNUSED) {
+  struct jpeg_decompress_struct *cinfo;
+  g_autoptr(_openslide_jpeg_decompress) dc =
+    _openslide_jpeg_decompress_create(&cinfo);
+
   jmp_buf env;
-  volatile bool alpha_extensions = false;
-
-  struct jpeg_decompress_struct *cinfo =
-    g_slice_new0(struct jpeg_decompress_struct);
-  struct openslide_jpeg_error_mgr *jerr =
-    g_slice_new0(struct openslide_jpeg_error_mgr);
-
   if (!setjmp(env)) {
-    cinfo->err = error_handler_init(jerr, &env);
-    jpeg_create_decompress(cinfo);
+    _openslide_jpeg_decompress_init(dc, &env);
     _openslide_jpeg_mem_src(cinfo, one_pixel_rgb_jpeg,
                             sizeof(one_pixel_rgb_jpeg));
     jpeg_read_header(cinfo, true);
     cinfo->out_color_space = JCS_EXT_BGRA;
     jpeg_start_decompress(cinfo);
-    alpha_extensions = true;
+    return GINT_TO_POINTER(true);
   } else {
-    g_clear_error(&jerr->err);
+    g_clear_error(&dc->jerr.err);
     _openslide_performance_warn("Optimized libjpeg color space not available");
+    return GINT_TO_POINTER(false);
   }
-
-  jpeg_destroy_decompress(cinfo);
-  g_slice_free(struct jpeg_decompress_struct, cinfo);
-  g_slice_free(struct openslide_jpeg_error_mgr, jerr);
-  //g_debug("have JCS_ALPHA_EXTENSIONS: %d", alpha_extensions);
-  return GINT_TO_POINTER(alpha_extensions);
 }
 
 // the caller must assign the struct _openslide_jpeg_decompress * before
@@ -164,7 +144,12 @@ struct _openslide_jpeg_decompress *_openslide_jpeg_decompress_create(struct jpeg
 // after setjmp(), initialize error handler and start decompressing
 void _openslide_jpeg_decompress_init(struct _openslide_jpeg_decompress *dc,
                                      jmp_buf *env) {
-  dc->cinfo.err = error_handler_init(&dc->jerr, env);
+  jpeg_std_error(&dc->jerr.base);
+  dc->jerr.base.error_exit = my_error_exit;
+  dc->jerr.base.output_message = my_output_message;
+  dc->jerr.base.emit_message = my_emit_message;
+  dc->jerr.env = env;
+  dc->cinfo.err = (struct jpeg_error_mgr *) &dc->jerr;
   jpeg_create_decompress(&dc->cinfo);
 }
 

--- a/src/openslide-decode-jpeg.h
+++ b/src/openslide-decode-jpeg.h
@@ -98,8 +98,12 @@ void _openslide_jpeg_propagate_error(GError **err,
 
 void _openslide_jpeg_decompress_destroy(struct _openslide_jpeg_decompress *dc);
 
-typedef struct _openslide_jpeg_decompress _openslide_jpeg_decompress;
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_jpeg_decompress,
-                              _openslide_jpeg_decompress_destroy)
+// volatile pointer, to ensure clang doesn't incorrectly optimize field
+// accesses after setjmp() returns again in the function allocating the struct
+// https://github.com/llvm/llvm-project/issues/57110
+typedef struct _openslide_jpeg_decompress * volatile _openslide_jpeg_decompress;
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(_openslide_jpeg_decompress,
+                                _openslide_jpeg_decompress_destroy,
+                                NULL)
 
 #endif

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -218,7 +218,7 @@ static bool decode_jpeg(const void *buf, uint32_t buflen,
   jmp_buf env;
 
   struct jpeg_decompress_struct *cinfo;
-  g_autoptr(_openslide_jpeg_decompress) dc =
+  g_auto(_openslide_jpeg_decompress) dc =
     _openslide_jpeg_decompress_create(&cinfo);
 
   if (setjmp(env) == 0) {

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -601,7 +601,7 @@ static bool read_from_jpeg(openslide_t *osr,
 
   // begin decompress
   struct jpeg_decompress_struct *cinfo;
-  g_autoptr(_openslide_jpeg_decompress) dc =
+  g_auto(_openslide_jpeg_decompress) dc =
     _openslide_jpeg_decompress_create(&cinfo);
   jmp_buf env;
 
@@ -1002,7 +1002,7 @@ static bool validate_jpeg_header(struct _openslide_file *f,
   }
 
   struct jpeg_decompress_struct *cinfo;
-  g_autoptr(_openslide_jpeg_decompress) dc =
+  g_auto(_openslide_jpeg_decompress) dc =
     _openslide_jpeg_decompress_create(&cinfo);
 
   if (setjmp(env) == 0) {


### PR DESCRIPTION
Fixes macOS CI.  See individual commits for details.