### PR TITLE
workflows: install xdelta from EPEL 9

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -80,7 +80,7 @@ jobs:
                 9)
                     dnf install -y 'dnf-command(config-manager)'
                     dnf config-manager --set-enabled crb
-                    dnf copr enable -y bgilbert/xdelta
+                    dnf install -y epel-release epel-next-release
                     ;;
                 *)
                     extra=git-core


### PR DESCRIPTION
Now that xdelta is [packaged in EPEL 9](https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2022-3db3325f4c), stop using the Copr.