### PR TITLE
Fix Valgrind failures and enable it in CI

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -81,7 +81,8 @@ jobs:
                     dnf install -y epel-release epel-next-release
                     ;;
                 *)
-                    extra=git-core
+                    extra="git-core valgrind valgrind-devel dnf-plugins-core"
+                    valgrind=1
                     ;;
                 esac
 
@@ -100,6 +101,10 @@ jobs:
                     glib2-devel \
                     doxygen \
                     xdelta libjpeg-turbo-utils $extra
+
+                if [ -n "$valgrind" ]; then
+                    dnf debuginfo-install -y cairo fontconfig glib2
+                fi
                 ;;
             *debian*|"")
                 if [ -n "${{ matrix.container }}" ]; then
@@ -184,6 +189,13 @@ jobs:
         ./driver unpack nonfrozen
     - name: Test
       run: cd test && ./driver run
+    - name: Valgrind
+      # Valgrind tests are expensive, and maintaining suppressions across
+      # multiple distros can be fiddly.  We might catch some additional bugs
+      # if we enabled this everywhere (mainly when there are different code
+      # paths for different dependency versions) but it doesn't seem worth it.
+      if: matrix.extra
+      run: cd test && ./driver valgrind
     - name: Check exports
       if: matrix.extra
       run: cd test && ./driver exports

--- a/Makefile.am
+++ b/Makefile.am
@@ -115,7 +115,7 @@ noinst_SCRIPTS = test/driver
 CLEANFILES += test/driver
 EXTRA_DIST += test/driver.in
 
-test_try_open_CPPFLAGS = $(COMMON_CPPFLAGS)
+test_try_open_CPPFLAGS = $(COMMON_CPPFLAGS) $(VALGRIND_CFLAGS)
 test_try_open_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS) -Wno-deprecated-declarations
 test_try_open_LDADD = $(COMMON_LDADD)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -154,6 +154,7 @@ endif
 test/driver: test/driver.in Makefile
 	$(AM_V_GEN)sed -e 's:!!SRCDIR!!:$(abs_srcdir)/test:g' \
 		-e 's:!!BUILDDIR!!:$(abs_builddir)/test:g' \
+		-e 's:!!GLIB2_DATADIR!!:$(GLIB2_DATADIR):g' \
 		-e 's:!!VERSION!!:$(VERSION):g' \
 		-e 's:!!CYGWIN_CROSS_TEST!!:$(CYGWIN_CROSS_TEST):g' \
 		-e 's:!!FEATURES!!:$(FEATURE_FLAGS):g' "$<" > "$@" && \

--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,9 @@ AS_CASE([$host],
   ]
 )
 
+# Path prefix for glib Valgrind suppressions
+PKG_CHECK_VAR(GLIB2_DATADIR, [gio-2.0], datadir)
+
 # Compiler warnings
 WARN_CFLAGS="-Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wnested-externs"
 AC_SUBST([WARN_CFLAGS])

--- a/test/driver.in
+++ b/test/driver.in
@@ -199,6 +199,12 @@ def _launch_test(test, slidefile, valgrind=False, extra_checks=True,
                 '--suppressions=' + VALGRIND_SUPPRESSIONS,
                 '--suppressions=' + VALGRIND_SUPPRESSIONS_GLIB,
                 '--leak-check=full', '--num-callers=30'] + args
+        env.update(
+            # Valgrind has known issues detecting memory initialization by
+            # libjpeg-turbo SIMD code.  Disable SIMD support.
+            # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/277
+            JSIMD_FORCENONE='1',
+        )
     elif extra_checks:
         # debug-blocks retains pointers to freed slices, so don't use it
         # with Valgrind

--- a/test/driver.in
+++ b/test/driver.in
@@ -52,6 +52,7 @@ from zipfile import ZipFile
 TESTDATA_URL = 'https://openslide.cs.cmu.edu/download/openslide-testdata/'
 DEFAULT_FROZEN_BUCKET = 'openslide-frozen-testdata'
 VALGRIND_SUPPRESSIONS = '!!SRCDIR!!/valgrind.supp'
+VALGRIND_SUPPRESSIONS_GLIB = '!!GLIB2_DATADIR!!/glib-2.0/valgrind/glib.supp'
 CASEROOT = '!!SRCDIR!!/cases'
 SLIDELIST = '!!SRCDIR!!/cases/slides.yaml'
 FROZENLIST = '!!SRCDIR!!/cases/frozen.yaml'
@@ -196,6 +197,7 @@ def _launch_test(test, slidefile, valgrind=False, extra_checks=True,
         args = [os.path.join(testdir, '../libtool'), '--mode=execute',
                 'valgrind', '--quiet', '--error-exitcode=3',
                 '--suppressions=' + VALGRIND_SUPPRESSIONS,
+                '--suppressions=' + VALGRIND_SUPPRESSIONS_GLIB,
                 '--leak-check=full', '--num-callers=30'] + args
     elif extra_checks:
         # debug-blocks retains pointers to freed slices, so don't use it

--- a/test/valgrind.supp
+++ b/test/valgrind.supp
@@ -1,43 +1,5 @@
 # Valgrind suppressions
 
-# The GType initializer "possibly leaks" many things
-{
-   g_type_init() leaks
-   Memcheck:Leak
-   ...
-   fun:g_type_init_with_debug_flags
-}
-{
-   New GObject constructor leaks
-   Memcheck:Leak
-   ...
-   fun:gobject_init_ctor
-}
-{
-   GType registration
-   Memcheck:Leak
-   ...
-   fun:g_type_register_static
-}
-{
-   GType registration
-   Memcheck:Leak
-   ...
-   fun:g_type_register_fundamental
-}
-{
-   GType registration
-   Memcheck:Leak
-   ...
-   fun:g_type_add_interface_static
-}
-{
-   GType referencing
-   Memcheck:Leak
-   ...
-   fun:g_type_class_ref
-}
-
 # fontconfig
 {
     fontconfig leak through cairo_text_extents()

--- a/test/valgrind.supp
+++ b/test/valgrind.supp
@@ -8,22 +8,3 @@
     fun:FcPatternObjectInsertElt
     fun:FcPatternObjectAddWithBinding
 }
-{
-    Apparent false positive in FcGetPrgname()
-    Memcheck:Leak
-    ...
-    fun:FcGetPrgname
-}
-{
-    Invalid read in fontconfig 2.8.0
-    Memcheck:Addr4
-    fun:FcConfigFileExists
-}
-
-# zlib 1.2.3
-{
-    Harmless access to uninitialized data
-    Memcheck:Cond
-    fun:inflateReset2
-    fun:inflateInit2_
-}


### PR DESCRIPTION
Update suppressions and ignore some warnings out of our control.  Add Valgrind to the Fedora job, but not to the other jobs as we used to do in Buildbot, since the marginal additional value doesn't seem worth the overhead and suppression maintenance.