### PR TITLE
workflows: install diffutils on RPM-based systems

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -89,6 +89,7 @@ jobs:
                 dnf install -y \
                     gcc make autoconf automake libtool pkg-config \
                     $python python${pyver}-requests python${pyver}-pyyaml \
+                    diffutils \
                     zlib-devel \
                     libpng-devel \
                     libjpeg-turbo-devel \


### PR DESCRIPTION
Fixes `configure` warnings:

    ./configure: line 7482: cmp: command not found
    ./configure: line 9571: diff: command not found