### PR TITLE
Fail `openslide_open()` on unpatched pixman 0.38.x

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -77,6 +77,8 @@ jobs:
                 case "$VERSION_ID" in
                 8)
                     dnf config-manager --set-enabled powertools
+                    # https://bugzilla.redhat.com/show_bug.cgi?id=2124013
+                    dnf copr enable -y bgilbert/el8-pixman-openslide
                     pyver=38
                     python=python38
                     ;;

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -123,6 +123,12 @@ jobs:
                     # Ubuntu, on host
                     jpeg=libjpeg-turbo8-dev
                     sudo=sudo
+
+                    # https://launchpad.net/bugs/1988796
+                    . /etc/os-release
+                    if [ "$VERSION_ID" = "20.04" ]; then
+                        sudo add-apt-repository -ny "ppa:bgilbert/focal-pixman-openslide"
+                    fi
                 fi
                 $sudo apt-get update
                 $sudo apt-get -y install \
@@ -136,6 +142,7 @@ jobs:
                     libgdk-pixbuf2.0-dev \
                     libxml2-dev \
                     libsqlite3-dev \
+                    libpixman-1-dev \
                     libcairo2-dev \
                     libglib2.0-dev \
                     doxygen \


### PR DESCRIPTION
pixman 0.38.x produces corrupt output when subpixel rendering is used with the `SATURATE` operator.  This is [fixed](https://gitlab.freedesktop.org/pixman/pixman/-/commit/8256c235) in 0.40.0.  The consequence is pretty bad (blank output in some regions of some slides) so detect it and refuse to open any slide.  Perform a behavior test at runtime, since we might have been compiled with a different version or the distro might have backported a fix.

Run CI with pixman from a Copr for EL 8, and from a PPA for Ubuntu 20.04, until those distro versions are fixed.

See https://github.com/openslide/openslide/issues/278.