### PR TITLE
workflows: switch the C9S runner back to ubuntu-latest

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -27,10 +27,7 @@ jobs:
             sanitize: sanitize
           - os: ubuntu-latest
             container: quay.io/centos/centos:stream8
-          # Use ubuntu-22.04 to get a newer Docker seccomp filter.  Otherwise
-          # "make check" fails with:
-          #     Spawning child failed: Failed to close file descriptor for child process (Operation not permitted)
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             container: quay.io/centos/centos:stream9
           - os: ubuntu-latest
             container: debian:stable


### PR DESCRIPTION
`ubuntu-latest` is an alias for 22.04 now, so stop hardcoding 22.04.