### PR TITLE
Revert "workflows: install Ubuntu 20.04 pixman from PPA"

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -123,12 +123,6 @@ jobs:
                     # Ubuntu, on host
                     jpeg=libjpeg-turbo8-dev
                     sudo=sudo
-
-                    # https://launchpad.net/bugs/1988796
-                    . /etc/os-release
-                    if [ "$VERSION_ID" = "20.04" ]; then
-                        sudo add-apt-repository -ny "ppa:bgilbert/focal-pixman-openslide"
-                    fi
                 fi
                 $sudo apt-get update
                 $sudo apt-get -y install \
@@ -142,7 +136,6 @@ jobs:
                     libgdk-pixbuf2.0-dev \
                     libxml2-dev \
                     libsqlite3-dev \
-                    libpixman-1-dev \
                     libcairo2-dev \
                     libglib2.0-dev \
                     doxygen \


### PR DESCRIPTION
The bug is fixed in `pixman-0.38.4-0ubuntu2` for 20.04.

This reverts commit 692c572dba49c03f8bf52ddf693b10ca267c837e.

xref https://github.com/openslide/openslide/issues/278