### PR TITLE
Drop glib slice allocator

### DIFF
--- a/src/openslide-cache.c
+++ b/src/openslide-cache.c
@@ -364,7 +364,7 @@ void _openslide_cache_entry_unref(struct _openslide_cache_entry *entry) {
 
   if (g_atomic_int_dec_and_test(&entry->refcount)) {
     // free the data
-    g_slice_free1(entry->size, entry->data);
+    g_free(entry->data);
 
     // free the entry
     g_slice_free(struct _openslide_cache_entry, entry);

--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -88,7 +88,7 @@ static void gdkpixbuf_ctx_free(struct gdkpixbuf_ctx *ctx) {
     g_object_unref(ctx->loader);
   }
   g_clear_error(&ctx->err);
-  g_slice_free(struct gdkpixbuf_ctx, ctx);
+  g_free(ctx);
 }
 
 typedef struct gdkpixbuf_ctx gdkpixbuf_ctx;
@@ -112,7 +112,7 @@ static bool gdkpixbuf_ctx_check_error(struct gdkpixbuf_ctx *ctx,
 static struct gdkpixbuf_ctx *gdkpixbuf_ctx_new(const char *format,
                                                int32_t w, int32_t h,
                                                GError **err) {
-  g_autoptr(gdkpixbuf_ctx) ctx = g_slice_new0(struct gdkpixbuf_ctx);
+  g_autoptr(gdkpixbuf_ctx) ctx = g_new0(struct gdkpixbuf_ctx, 1);
   ctx->w = w;
   ctx->h = h;
 

--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -140,15 +140,15 @@ static bool gdkpixbuf_read(const char *format,
   }
 
   // read data
-  g_auto(_openslide_slice) box = _openslide_slice_alloc(BUFSIZE);
+  g_autofree void *buf = g_malloc(BUFSIZE);
   while (length) {
-    size_t count = read_callback(box.p, callback_data, MIN(length, box.len));
+    size_t count = read_callback(buf, callback_data, MIN(length, BUFSIZE));
     if (!count) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Short read loading pixbuf");
       return false;
     }
-    if (!gdk_pixbuf_loader_write(ctx->loader, box.p, count, err)) {
+    if (!gdk_pixbuf_loader_write(ctx->loader, buf, count, err)) {
       gdkpixbuf_ctx_check_error(ctx, err);
       return false;
     }

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -422,7 +422,7 @@ static bool get_associated_image_data(struct _openslide_associated_image *_img,
 static void destroy_associated_image(struct _openslide_associated_image *_img) {
   struct associated_image *img = (struct associated_image *) _img;
 
-  g_slice_free(struct associated_image, img);
+  g_free(img);
 }
 
 static const struct _openslide_associated_image_ops tiff_associated_ops = {
@@ -454,7 +454,7 @@ static bool _add_associated_image(openslide_t *osr,
   }
 
   // load into struct
-  struct associated_image *img = g_slice_new0(struct associated_image);
+  struct associated_image *img = g_new0(struct associated_image, 1);
   img->base.ops = &tiff_associated_ops;
   img->base.w = w;
   img->base.h = h;
@@ -529,7 +529,7 @@ static toff_t tiff_do_seek(thandle_t th, toff_t offset, int whence) {
 static int tiff_do_close(thandle_t th) {
   struct tiff_file_handle *hdl = th;
 
-  g_slice_free(struct tiff_file_handle, hdl);
+  g_free(hdl);
   return 0;
 }
 
@@ -592,7 +592,7 @@ static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
   }
 
   // allocate
-  struct tiff_file_handle *hdl = g_slice_new0(struct tiff_file_handle);
+  struct tiff_file_handle *hdl = g_new0(struct tiff_file_handle, 1);
   hdl->tc = tc;
   hdl->size = size;
 
@@ -611,7 +611,7 @@ static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
 #define TIFFClientOpen _OPENSLIDE_POISON(_openslide_tiffcache_get)
 
 struct _openslide_tiffcache *_openslide_tiffcache_create(const char *filename) {
-  struct _openslide_tiffcache *tc = g_slice_new0(struct _openslide_tiffcache);
+  struct _openslide_tiffcache *tc = g_new0(struct _openslide_tiffcache, 1);
   tc->filename = g_strdup(filename);
   tc->cache = g_queue_new();
   g_mutex_init(&tc->lock);
@@ -681,5 +681,5 @@ void _openslide_tiffcache_destroy(struct _openslide_tiffcache *tc) {
   g_queue_free(tc->cache);
   g_mutex_clear(&tc->lock);
   g_free(tc->filename);
-  g_slice_free(struct _openslide_tiffcache, tc);
+  g_free(tc);
 }

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -407,7 +407,7 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
                 "Loop detected");
     return NULL;
   }
-  uint64_t *key = g_slice_new(uint64_t);
+  uint64_t *key = g_new(uint64_t, 1);
   *key = off;
   g_hash_table_insert(loop_detector, key, NULL);
 
@@ -594,8 +594,7 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
 
   // initialize directory reading
   g_autoptr(GHashTable) loop_detector =
-    g_hash_table_new_full(g_int64_hash, g_int64_equal,
-                          _openslide_int64_free, NULL);
+    g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free, NULL);
   struct tiff_directory *first_dir = NULL;
 
   // NDPI needs special quirks, since it is classic TIFF pretending to be

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -365,7 +365,7 @@ static void tiff_directory_destroy(struct tiff_directory *d) {
     return;
   }
   g_hash_table_unref(d->items);
-  g_slice_free(struct tiff_directory, d);
+  g_free(d);
 }
 
 typedef struct tiff_directory tiff_directory;
@@ -378,7 +378,7 @@ static void tiff_item_destroy(gpointer data) {
   g_free(item->sints);
   g_free(item->floats);
   g_free(item->buffer);
-  g_slice_free(struct tiff_item, item);
+  g_free(item);
 }
 
 static struct tiff_directory *read_directory(struct _openslide_file *f,
@@ -430,7 +430,7 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
 
 
   // initial checks passed, initialize the directory
-  g_autoptr(tiff_directory) d = g_slice_new0(struct tiff_directory);
+  g_autoptr(tiff_directory) d = g_new0(struct tiff_directory, 1);
   d->items = g_hash_table_new_full(g_direct_hash, g_direct_equal,
                                    NULL, tiff_item_destroy);
   d->offset = off;
@@ -450,7 +450,7 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
     //    g_debug(" tag: %d, type: %d, count: %"PRId64, tag, type, count);
 
     // allocate the item
-    struct tiff_item *item = g_slice_new0(struct tiff_item);
+    struct tiff_item *item = g_new0(struct tiff_item, 1);
     item->type = type;
     item->count = count;
     g_hash_table_insert(d->items, GINT_TO_POINTER(tag), item);
@@ -586,7 +586,7 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   }
 
   // allocate struct
-  g_autoptr(_openslide_tifflike) tl = g_slice_new0(struct _openslide_tifflike);
+  g_autoptr(_openslide_tifflike) tl = g_new0(struct _openslide_tifflike, 1);
   tl->filename = g_strdup(filename);
   tl->big_endian = big_endian;
   tl->directories = g_ptr_array_new();
@@ -678,7 +678,7 @@ void _openslide_tifflike_destroy(struct _openslide_tifflike *tl) {
   g_ptr_array_free(tl->directories, true);
   g_free(tl->filename);
   g_mutex_clear(&tl->value_lock);
-  g_slice_free(struct _openslide_tifflike, tl);
+  g_free(tl);
 }
 
 static struct tiff_item *get_item(struct _openslide_tifflike *tl,

--- a/src/openslide-file.c
+++ b/src/openslide-file.c
@@ -123,7 +123,7 @@ struct _openslide_file *_openslide_fopen(const char *path, GError **err)
   }
 #endif
 
-  struct _openslide_file *file = g_slice_new0(struct _openslide_file);
+  struct _openslide_file *file = g_new0(struct _openslide_file, 1);
   file->fp = g_steal_pointer(&f);
   return file;
 }
@@ -180,7 +180,7 @@ off_t _openslide_fsize(struct _openslide_file *file, GError **err) {
 
 void _openslide_fclose(struct _openslide_file *file) {
   fclose(file->fp);
-  g_slice_free(struct _openslide_file, file);
+  g_free(file);
 }
 
 bool _openslide_fexists(const char *path, GError **err G_GNUC_UNUSED) {
@@ -188,7 +188,7 @@ bool _openslide_fexists(const char *path, GError **err G_GNUC_UNUSED) {
 }
 
 struct _openslide_dir *_openslide_dir_open(const char *dirname, GError **err) {
-  g_autoptr(_openslide_dir) d = g_slice_new0(struct _openslide_dir);
+  g_autoptr(_openslide_dir) d = g_new0(struct _openslide_dir, 1);
   d->dir = g_dir_open(dirname, 0, err);
   if (!d->dir) {
     return NULL;
@@ -204,5 +204,5 @@ void _openslide_dir_close(struct _openslide_dir *d) {
   if (d->dir) {
     g_dir_close(d->dir);
   }
-  g_slice_free(struct _openslide_dir, d);
+  g_free(d);
 }

--- a/src/openslide-grid.c
+++ b/src/openslide-grid.c
@@ -367,7 +367,7 @@ static bool simple_paint_region(struct _openslide_grid *_grid,
 static void simple_destroy(struct _openslide_grid *_grid) {
   struct simple_grid *grid = (struct simple_grid *) _grid;
 
-  g_slice_free(struct simple_grid, grid);
+  g_free(grid);
 }
 
 static const struct grid_ops simple_grid_ops = {
@@ -382,7 +382,7 @@ struct _openslide_grid *_openslide_grid_create_simple(openslide_t *osr,
                                                       int32_t tile_w,
                                                       int32_t tile_h,
                                                       _openslide_grid_simple_read_fn read_tile) {
-  struct simple_grid *grid = g_slice_new0(struct simple_grid);
+  struct simple_grid *grid = g_new0(struct simple_grid, 1);
   grid->base.osr = osr;
   grid->base.ops = &simple_grid_ops;
   grid->base.tile_advance_x = tile_w;
@@ -414,7 +414,7 @@ static void tilemap_tile_hash_destroy_value(gpointer data) {
   if (tile->grid->destroy_tile && tile->data) {
     tile->grid->destroy_tile(tile->data);
   }
-  g_slice_free(struct tilemap_tile, tile);
+  g_free(tile);
 }
 
 static void tilemap_get_bounds(struct _openslide_grid *_grid,
@@ -514,7 +514,7 @@ static void tilemap_destroy(struct _openslide_grid *_grid) {
   struct tilemap_grid *grid = (struct tilemap_grid *) _grid;
 
   g_hash_table_destroy(grid->tiles);
-  g_slice_free(struct tilemap_grid, grid);
+  g_free(grid);
 }
 
 static const struct grid_ops tilemap_grid_ops = {
@@ -531,7 +531,7 @@ void _openslide_grid_tilemap_add_tile(struct _openslide_grid *_grid,
   struct tilemap_grid *grid = (struct tilemap_grid *) _grid;
   g_assert(grid->base.ops == &tilemap_grid_ops);
 
-  struct tilemap_tile *tile = g_slice_new0(struct tilemap_tile);
+  struct tilemap_tile *tile = g_new0(struct tilemap_tile, 1);
   tile->grid = grid;
   tile->col = col;
   tile->row = row;
@@ -583,7 +583,7 @@ struct _openslide_grid *_openslide_grid_create_tilemap(openslide_t *osr,
                                                        double tile_advance_y,
                                                        _openslide_grid_tilemap_read_fn read_tile,
                                                        GDestroyNotify destroy_tile) {
-  struct tilemap_grid *grid = g_slice_new0(struct tilemap_grid);
+  struct tilemap_grid *grid = g_new0(struct tilemap_grid, 1);
   grid->base.osr = osr;
   grid->base.ops = &tilemap_grid_ops;
   grid->base.tile_advance_x = tile_advance_x;
@@ -622,7 +622,7 @@ static gboolean range_bin_address_hash_key_equal(gconstpointer a,
 }
 
 static void range_bin_address_free(void *data) {
-  g_slice_free(struct range_bin_address, data);
+  g_free(data);
 }
 
 static void range_ptr_array_free(void *data) {
@@ -757,10 +757,10 @@ static void range_destroy(struct _openslide_grid *_grid) {
     if (grid->destroy_tile && tile->data) {
       grid->destroy_tile(tile->data);
     }
-    g_slice_free(struct range_tile, tile);
+    g_free(tile);
   }
   g_ptr_array_free(grid->tiles, true);
-  g_slice_free(struct range_grid, grid);
+  g_free(grid);
 }
 
 static const struct grid_ops range_grid_ops = {
@@ -777,7 +777,7 @@ void _openslide_grid_range_add_tile(struct _openslide_grid *_grid,
   g_assert(grid->base.ops == &range_grid_ops);
   g_assert(grid->bins_init);
 
-  struct range_tile *tile = g_slice_new0(struct range_tile);
+  struct range_tile *tile = g_new0(struct range_tile, 1);
   tile->id = grid->tiles->len;
   tile->data = data;
   tile->x = x;
@@ -796,8 +796,7 @@ void _openslide_grid_range_add_tile(struct _openslide_grid *_grid,
       GPtrArray *bin = g_hash_table_lookup(grid->bins_init, &addr);
       if (!bin) {
         bin = g_ptr_array_new();
-        struct range_bin_address *addr2 =
-          g_slice_new(struct range_bin_address);
+        struct range_bin_address *addr2 = g_new(struct range_bin_address, 1);
         addr2->col = addr.col;
         addr2->row = addr.row;
         g_hash_table_insert(grid->bins_init, addr2, bin);
@@ -844,7 +843,7 @@ struct _openslide_grid *_openslide_grid_create_range(openslide_t *osr,
                                                      int typical_tile_height,
                                                      _openslide_grid_range_read_fn read_tile,
                                                      GDestroyNotify destroy_tile) {
-  struct range_grid *grid = g_slice_new0(struct range_grid);
+  struct range_grid *grid = g_new0(struct range_grid, 1);
   grid->base.osr = osr;
   grid->base.ops = &range_grid_ops;
   grid->base.tile_advance_x = NAN;  // unused

--- a/src/openslide-hash.c
+++ b/src/openslide-hash.c
@@ -33,7 +33,7 @@ struct _openslide_hash {
 };
 
 struct _openslide_hash *_openslide_hash_quickhash1_create(void) {
-  struct _openslide_hash *hash = g_slice_new(struct _openslide_hash);
+  struct _openslide_hash *hash = g_new(struct _openslide_hash, 1);
   hash->checksum = g_checksum_new(G_CHECKSUM_SHA256);
   hash->enabled = true;
 
@@ -123,5 +123,5 @@ const char *_openslide_hash_get_string(struct _openslide_hash *hash) {
 
 void _openslide_hash_destroy(struct _openslide_hash *hash) {
   g_checksum_free(hash->checksum);
-  g_slice_free(struct _openslide_hash, hash);
+  g_free(hash);
 }

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -138,9 +138,6 @@ extern const struct _openslide_format _openslide_format_synthetic;
 extern const struct _openslide_format _openslide_format_trestle;
 extern const struct _openslide_format _openslide_format_ventana;
 
-/* GHashTable utils */
-void _openslide_int64_free(gpointer data);
-
 /* g_key_file_new() + g_key_file_load_from_file() wrapper */
 GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
                                    GKeyFileFlags flags, GError **err);

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -173,22 +173,6 @@ bool _openslide_clip_tile(uint32_t *tiledata,
                           GError **err);
 
 
-// Slice allocator wrapper for g_auto
-struct _openslide_slice {
-  void *p;
-  gsize len;
-};
-
-struct _openslide_slice _openslide_slice_alloc(gsize len);
-
-void *_openslide_slice_steal(struct _openslide_slice *box);
-
-void _openslide_slice_free(struct _openslide_slice *box);
-
-typedef struct _openslide_slice _openslide_slice;
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(_openslide_slice, _openslide_slice_free)
-
-
 // File handling
 struct _openslide_file;
 

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -339,24 +339,3 @@ void _openslide_performance_warn_once(gint *warned_flag,
     }
   }
 }
-
-struct _openslide_slice _openslide_slice_alloc(gsize len) {
-  struct _openslide_slice box = {
-    .p = g_slice_alloc(len),
-    .len = len,
-  };
-  return box;
-}
-
-void *_openslide_slice_steal(struct _openslide_slice *box) {
-  void *p = box->p;
-  box->p = NULL;
-  return p;
-}
-
-void _openslide_slice_free(struct _openslide_slice *box) {
-  if (box && box->p) {
-    g_slice_free1(box->len, box->p);
-    box->p = NULL;
-  }
-}

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -57,10 +57,6 @@ static const struct debug_option {
 
 static uint32_t debug_flags;
 
-void _openslide_int64_free(gpointer data) {
-  g_slice_free(int64_t, data);
-}
-
 GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
                                    GKeyFileFlags flags, GError **err) {
   /* We load the whole key file into memory and parse it with

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -188,20 +188,20 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
-    if (!decode_tile(l, tiff, box.p, tile_col, tile_row, err)) {
+    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
+    if (!decode_tile(l, tiff, buf, tile_col, tile_row, err)) {
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_tiff_clip_tile(tiffl, box.p,
+    if (!_openslide_tiff_clip_tile(tiffl, buf,
                                    tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // put it in the cache
-    tiledata = _openslide_slice_steal(&box);
+    tiledata = g_steal_pointer(&buf);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
 			 tiledata, tw * th * 4,
 			 &cache_entry);

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -61,7 +61,7 @@ static void destroy_level(struct level *l) {
     g_hash_table_destroy(l->missing_tiles);
   }
   _openslide_grid_destroy(l->grid);
-  g_slice_free(struct level, l);
+  g_free(l);
 }
 
 static void destroy(openslide_t *osr) {
@@ -72,7 +72,7 @@ static void destroy(openslide_t *osr) {
 
   struct aperio_ops_data *data = osr->data;
   _openslide_tiffcache_destroy(data->tc);
-  g_slice_free(struct aperio_ops_data, data);
+  g_free(data);
 }
 
 static bool render_missing_tile(struct level *l,
@@ -437,7 +437,7 @@ static bool aperio_open(openslide_t *osr,
     // for aperio, the tiled directories are the ones we want
     if (TIFFIsTiled(ct.tiff)) {
       //g_debug("tiled directory: %d", dir);
-      struct level *l = g_slice_new0(struct level);
+      struct level *l = g_new0(struct level, 1);
       struct _openslide_tiff_level *tiffl = &l->tiffl;
       if (level_array->len) {
         l->prev = level_array->pdata[level_array->len - 1];
@@ -525,7 +525,7 @@ static bool aperio_open(openslide_t *osr,
   }
 
   // allocate private data
-  struct aperio_ops_data *data = g_slice_new0(struct aperio_ops_data);
+  struct aperio_ops_data *data = g_new0(struct aperio_ops_data, 1);
   data->tc = g_steal_pointer(&tc);
 
   // store osr data

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -288,7 +288,7 @@ static void dicom_file_destroy(struct dicom_file *f) {
   dcm_bot_destroy(f->bot);
   g_mutex_clear(&f->lock);
   g_free(f->filename);
-  g_slice_free(struct dicom_file, f);
+  g_free(f);
 }
 
 typedef struct dicom_file dicom_file;
@@ -349,7 +349,7 @@ static bool verify_tag_str(DcmDataSet *dataset,
 }
 
 static struct dicom_file *dicom_file_new(const char *filename, GError **err) {
-  g_autoptr(dicom_file) f = g_slice_new0(struct dicom_file);
+  g_autoptr(dicom_file) f = g_new0(struct dicom_file, 1);
 
   f->filename = g_strdup(filename);
   f->filehandle = dicom_open_openslide_vfs(filename, err);
@@ -389,7 +389,7 @@ static void level_destroy(struct dicom_level *l) {
   if (l->file) {
     dicom_file_destroy(l->file);
   }
-  g_slice_free(struct dicom_level, l);
+  g_free(l);
 }
 
 typedef struct dicom_level dicom_level;
@@ -577,7 +577,7 @@ static void _associated_destroy(struct associated *a) {
   if (a->file) {
     dicom_file_destroy(a->file);
   }
-  g_slice_free(struct associated, a);
+  g_free(a);
 }
 
 typedef struct associated associated;
@@ -598,7 +598,7 @@ static bool add_associated(openslide_t *osr,
                            struct dicom_file *f,
                            char **image_type,
                            GError **err) {
-  g_autoptr(associated) a = g_slice_new0(struct associated);
+  g_autoptr(associated) a = g_new0(struct associated, 1);
   a->base.ops = &dicom_associated_ops;
   a->file = f;
 
@@ -633,7 +633,7 @@ static bool add_level(openslide_t *osr,
                       GPtrArray *level_array,
                       struct dicom_file *f,
                       GError **err) {
-  g_autoptr(dicom_level) l = g_slice_new0(struct dicom_level);
+  g_autoptr(dicom_level) l = g_new0(struct dicom_level, 1);
   l->file = f;
 
   // dimensions

--- a/src/openslide-vendor-generic-tiff.c
+++ b/src/openslide-vendor-generic-tiff.c
@@ -48,7 +48,7 @@ struct level {
 
 static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
-  g_slice_free(struct level, l);
+  g_free(l);
 }
 
 typedef struct level level;
@@ -57,7 +57,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(level, destroy_level)
 static void destroy(openslide_t *osr) {
   struct generic_tiff_ops_data *data = osr->data;
   _openslide_tiffcache_destroy(data->tc);
-  g_slice_free(struct generic_tiff_ops_data, data);
+  g_free(data);
 
   for (int32_t i = 0; i < osr->level_count; i++) {
     destroy_level((struct level *) osr->levels[i]);
@@ -222,7 +222,7 @@ static bool generic_tiff_open(openslide_t *osr,
     }
 
     // create level
-    g_autoptr(level) l = g_slice_new0(struct level);
+    g_autoptr(level) l = g_new0(struct level, 1);
     struct _openslide_tiff_level *tiffl = &l->tiffl;
     if (!_openslide_tiff_level_init(ct.tiff,
                                     TIFFCurrentDirectory(ct.tiff),
@@ -255,8 +255,7 @@ static bool generic_tiff_open(openslide_t *osr,
   }
 
   // allocate private data
-  struct generic_tiff_ops_data *data =
-    g_slice_new0(struct generic_tiff_ops_data);
+  struct generic_tiff_ops_data *data = g_new0(struct generic_tiff_ops_data, 1);
   data->tc = g_steal_pointer(&tc);
 
   // store osr data

--- a/src/openslide-vendor-generic-tiff.c
+++ b/src/openslide-vendor-generic-tiff.c
@@ -85,22 +85,22 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
-                                   box.p, tile_col, tile_row,
+                                   buf, tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_tiff_clip_tile(tiffl, box.p,
+    if (!_openslide_tiff_clip_tile(tiffl, buf,
                                    tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // put it in the cache
-    tiledata = _openslide_slice_steal(&box);
+    tiledata = g_steal_pointer(&buf);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
                          tiledata, tw * th * 4,
                          &cache_entry);

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -679,16 +679,16 @@ static bool read_jpeg_tile(openslide_t *osr,
                                             &cache_entry);
 
   if (!tiledata) {
-    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
     if (!read_from_jpeg(osr,
                         jp, tileno,
                         l->scale_denom,
-                        box.p, tw, th,
+                        buf, tw, th,
                         err)) {
       return false;
     }
 
-    tiledata = _openslide_slice_steal(&box);
+    tiledata = g_steal_pointer(&buf);
     _openslide_cache_put(osr->cache,
 			 level, tile_col, tile_row,
 			 tiledata,
@@ -1570,7 +1570,7 @@ static bool ngr_read_tile(openslide_t *osr,
     }
 
     // got the data, now convert to 8-bit xRGB
-    tiledata = g_slice_alloc(tilesize);
+    tiledata = g_malloc(tilesize);
     uint16_t *buf = buf_box.p;
     for (int i = 0; i < tw * th; i++) {
       // scale down from 12 bits

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -1562,8 +1562,9 @@ static bool ngr_read_tile(openslide_t *osr,
     }
 
     // alloc and read
-    g_auto(_openslide_slice) buf_box = _openslide_slice_alloc(tw * th * 6);
-    if (_openslide_fread(f, buf_box.p, buf_box.len) != buf_box.len) {
+    uint64_t len = tw * th * 6;
+    g_autofree uint16_t *buf = g_malloc(len);
+    if (_openslide_fread(f, buf, len) != len) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                   "Cannot read file %s", l->filename);
       return false;
@@ -1571,7 +1572,6 @@ static bool ngr_read_tile(openslide_t *osr,
 
     // got the data, now convert to 8-bit xRGB
     tiledata = g_malloc(tilesize);
-    uint16_t *buf = buf_box.p;
     for (int i = 0; i < tw * th; i++) {
       // scale down from 12 bits
       uint8_t r = GINT16_FROM_LE(buf[(i * 3)]) >> 4;

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -1180,15 +1180,14 @@ static void add_properties(openslide_t *osr,
 static void create_scaled_jpeg_levels(openslide_t *osr,
                                       GPtrArray *levels) {
   g_autoptr(GHashTable) expanded_levels =
-    g_hash_table_new_full(g_int64_hash, g_int64_equal,
-                          _openslide_int64_free,
+    g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free,
                           (GDestroyNotify) jpeg_level_free);
 
   for (guint i = 0; i < levels->len; i++) {
     struct jpeg_level *l = g_steal_pointer(&levels->pdata[i]);
 
     // add level
-    int64_t *key = g_slice_new(int64_t);
+    int64_t *key = g_new(int64_t, 1);
     *key = l->base.w;
     g_hash_table_insert(expanded_levels, key, l);
 
@@ -1228,7 +1227,7 @@ static void create_scaled_jpeg_levels(openslide_t *osr,
                                                  sd_l->tile_height,
                                                  read_jpeg_tile);
 
-      key = g_slice_new(int64_t);
+      key = g_new(int64_t, 1);
       *key = sd_l->base.w;
       g_hash_table_insert(expanded_levels, key, sd_l);
     }
@@ -1249,7 +1248,7 @@ static void create_scaled_jpeg_levels(openslide_t *osr,
     // move
     g_ptr_array_add(levels, l);
     g_hash_table_steal(expanded_levels, level_keys->data);
-    _openslide_int64_free(level_keys->data);  // key
+    g_free(level_keys->data);  // key
 
     // consume the head and continue
     level_keys = g_list_delete_link(level_keys, level_keys);

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -283,18 +283,18 @@ static void jpeg_level_free(struct jpeg_level *l) {
   }
   g_free(l->jpegs);
   _openslide_grid_destroy(l->grid);
-  g_slice_free(struct jpeg_level, l);
+  g_free(l);
 }
 
 static void jpeg_free(struct jpeg *jpeg) {
   g_free(jpeg->filename);
   g_free(jpeg->mcu_starts);
   g_free(jpeg->unreliable_mcu_starts);
-  g_slice_free(struct jpeg, jpeg);
+  g_free(jpeg);
 }
 
 static struct jpeg_setup *jpeg_setup_new(void) {
-  struct jpeg_setup *setup = g_slice_new0(struct jpeg_setup);
+  struct jpeg_setup *setup = g_new0(struct jpeg_setup, 1);
   setup->levels =
     g_ptr_array_new_with_free_func((GDestroyNotify) jpeg_level_free);
   setup->jpegs = g_ptr_array_new_with_free_func((GDestroyNotify) jpeg_free);
@@ -308,7 +308,7 @@ static void jpeg_setup_free(struct jpeg_setup *setup) {
   if (setup->jpegs) {
     g_ptr_array_free(setup->jpegs, true);
   }
-  g_slice_free(struct jpeg_setup, setup);
+  g_free(setup);
 }
 
 typedef struct jpeg_setup jpeg_setup;
@@ -792,7 +792,7 @@ static void jpeg_do_destroy(openslide_t *osr) {
   g_mutex_clear(&data->restart_marker_cond_mutex);
 
   // the structure
-  g_slice_free(struct hamamatsu_jpeg_ops_data, data);
+  g_free(data);
 }
 
 static const struct _openslide_ops hamamatsu_jpeg_ops = {
@@ -1200,7 +1200,7 @@ static void create_scaled_jpeg_levels(openslide_t *osr,
       }
 
       // create a derived level
-      struct jpeg_level *sd_l = g_slice_new0(struct jpeg_level);
+      struct jpeg_level *sd_l = g_new0(struct jpeg_level, 1);
       sd_l->scale_denom = scale_denom;
 
       sd_l->base.w = l->base.w / scale_denom;
@@ -1269,7 +1269,7 @@ static bool init_jpeg_ops(openslide_t *_osr,
   g_autoptr(jpeg_osr) osr = _osr;
   g_assert(osr->data == NULL);
   struct hamamatsu_jpeg_ops_data *data =
-    g_slice_new0(struct hamamatsu_jpeg_ops_data);
+    g_new0(struct hamamatsu_jpeg_ops_data, 1);
   data->jpeg_count = setup->jpegs->len;
   data->all_jpegs = (struct jpeg **)
     g_ptr_array_free(g_steal_pointer(&setup->jpegs), false);
@@ -1334,7 +1334,7 @@ static struct jpeg_level *create_jpeg_level(openslide_t *osr,
                                             struct jpeg **jpegs,
                                             int32_t jpeg_cols,
                                             int32_t jpeg_rows) {
-  struct jpeg_level *l = g_slice_new0(struct jpeg_level);
+  struct jpeg_level *l = g_new0(struct jpeg_level, 1);
 
   // accumulate dimensions
   for (int32_t x = 0; x < jpeg_cols; x++) {
@@ -1384,7 +1384,7 @@ static bool hamamatsu_vms_part2(openslide_t *osr,
 
   // process jpegs
   for (int i = 0; i < num_jpegs; i++) {
-    struct jpeg *jp = g_slice_new0(struct jpeg);
+    struct jpeg *jp = g_new0(struct jpeg, 1);
     g_ptr_array_add(setup->jpegs, jp);
 
     jp->filename = g_strdup(image_filenames[i]);
@@ -1517,7 +1517,7 @@ static bool hamamatsu_vms_part2(openslide_t *osr,
 static void ngr_level_free(struct ngr_level *l) {
   g_free(l->filename);
   _openslide_grid_destroy(l->grid);
-  g_slice_free(struct ngr_level, l);
+  g_free(l);
 }
 
 static void ngr_destroy(openslide_t *osr) {
@@ -1639,7 +1639,7 @@ static bool hamamatsu_vmu_part2(openslide_t *osr,
 
   // open files
   for (int i = 0; i < num_levels; i++) {
-    struct ngr_level *l = g_slice_new0(struct ngr_level);
+    struct ngr_level *l = g_new0(struct ngr_level, 1);
     g_ptr_array_add(level_array, l);
 
     l->filename = g_strdup(image_filenames[i]);
@@ -2207,7 +2207,7 @@ static bool hamamatsu_ndpi_open(openslide_t *osr, const char *filename,
       }
 
       // init jpeg
-      struct jpeg *jp = g_slice_new0(struct jpeg);
+      struct jpeg *jp = g_new0(struct jpeg, 1);
       g_ptr_array_add(setup->jpegs, jp);
       jp->filename = g_strdup(filename);
       jp->start_in_file = start_in_file;

--- a/src/openslide-vendor-leica.c
+++ b/src/openslide-vendor-leica.c
@@ -122,18 +122,18 @@ struct dimension {
 
 static void destroy_area(struct area *area) {
   _openslide_grid_destroy(area->grid);
-  g_slice_free(struct area, area);
+  g_free(area);
 }
 
 static void destroy_level(struct level *l) {
   g_ptr_array_free(l->areas, true);
-  g_slice_free(struct level, l);
+  g_free(l);
 }
 
 static void destroy(openslide_t *osr) {
   struct leica_ops_data *data = osr->data;
   _openslide_tiffcache_destroy(data->tc);
-  g_slice_free(struct leica_ops_data, data);
+  g_free(data);
 
   for (int32_t i = 0; i < osr->level_count; i++) {
     destroy_level((struct level *) osr->levels[i]);
@@ -279,7 +279,7 @@ static bool leica_detect(const char *filename G_GNUC_UNUSED,
 }
 
 static void dimension_free(struct dimension *dimension) {
-  g_slice_free(struct dimension, dimension);
+  g_free(dimension);
 }
 
 static void image_free(struct image *image) {
@@ -290,13 +290,13 @@ static void image_free(struct image *image) {
   g_free(image->illumination_source);
   g_free(image->objective);
   g_free(image->aperture);
-  g_slice_free(struct image, image);
+  g_free(image);
 }
 
 static void collection_free(struct collection *collection) {
   g_ptr_array_free(collection->images, true);
   g_free(collection->barcode);
-  g_slice_free(struct collection, collection);
+  g_free(collection);
 }
 
 typedef struct collection collection;
@@ -405,7 +405,7 @@ static struct collection *parse_xml_description(const char *xml,
   }
 
   // create collection struct
-  g_autoptr(collection) collection = g_slice_new0(struct collection);
+  g_autoptr(collection) collection = g_new0(struct collection, 1);
   collection->images =
     g_ptr_array_new_with_free_func((GDestroyNotify) image_free);
 
@@ -455,7 +455,7 @@ static struct collection *parse_xml_description(const char *xml,
     }
 
     // create image struct
-    struct image *image = g_slice_new0(struct image);
+    struct image *image = g_new0(struct image, 1);
     image->dimensions =
       g_ptr_array_new_with_free_func((GDestroyNotify) dimension_free);
     g_ptr_array_add(collection->images, image);
@@ -503,7 +503,7 @@ static struct collection *parse_xml_description(const char *xml,
         continue;
       }
 
-      struct dimension *dimension = g_slice_new0(struct dimension);
+      struct dimension *dimension = g_new0(struct dimension, 1);
       g_ptr_array_add(image->dimensions, dimension);
 
       PARSE_INT_ATTRIBUTE_OR_RETURN(dimension_node, LEICA_ATTR_IFD,
@@ -622,7 +622,7 @@ static bool create_levels_from_collection(openslide_t *osr,
       struct level *l;
       if (image == first_main_image) {
         // no level yet; create it
-        l = g_slice_new0(struct level);
+        l = g_new0(struct level, 1);
         l->areas =
           g_ptr_array_new_with_free_func((GDestroyNotify) destroy_area);
         l->nm_per_pixel = dimension->nm_per_pixel;
@@ -650,7 +650,7 @@ static bool create_levels_from_collection(openslide_t *osr,
       }
 
       // create area
-      struct area *area = g_slice_new0(struct area);
+      struct area *area = g_new0(struct area, 1);
       struct _openslide_tiff_level *tiffl = &area->tiffl;
       g_ptr_array_add(l->areas, area);
 
@@ -831,7 +831,7 @@ static bool leica_open(openslide_t *osr, const char *filename,
   set_region_bounds_props(osr, level0);
 
   // allocate private data
-  struct leica_ops_data *data = g_slice_new0(struct leica_ops_data);
+  struct leica_ops_data *data = g_new0(struct leica_ops_data, 1);
   data->tc = g_steal_pointer(&tc);
 
   // store osr data

--- a/src/openslide-vendor-leica.c
+++ b/src/openslide-vendor-leica.c
@@ -160,22 +160,22 @@ static bool read_tile(openslide_t *osr,
                                             args->area, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
     if (!_openslide_tiff_read_tile(tiffl, args->tiff,
-                                   box.p, tile_col, tile_row,
+                                   buf, tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_tiff_clip_tile(tiffl, box.p,
+    if (!_openslide_tiff_clip_tile(tiffl, buf,
                                    tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // put it in the cache
-    tiledata = _openslide_slice_steal(&box);
+    tiledata = g_steal_pointer(&buf);
     _openslide_cache_put(osr->cache,
 			 args->area, tile_col, tile_row,
 			 tiledata, tw * th * 4,

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -202,7 +202,7 @@ struct mirax_ops_data {
 
 static void image_unref(struct image *image) {
   if (!--image->refcount) {
-    g_slice_free(struct image, image);
+    g_free(image);
   }
 }
 
@@ -212,7 +212,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(image, image_unref)
 static void tile_free(gpointer data) {
   struct tile *tile = data;
   image_unref(tile->image);
-  g_slice_free(struct tile, tile);
+  g_free(tile);
 }
 
 static uint32_t *read_image(openslide_t *osr,
@@ -342,7 +342,7 @@ static bool paint_region(openslide_t *osr G_GNUC_UNUSED, cairo_t *cr,
 
 static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
-  g_slice_free(struct level, l);
+  g_free(l);
 }
 
 static void destroy(openslide_t *osr) {
@@ -356,7 +356,7 @@ static void destroy(openslide_t *osr) {
 
   // the ops data
   g_strfreev(data->datafile_paths);
-  g_slice_free(struct mirax_ops_data, data);
+  g_free(data);
 }
 
 static const struct _openslide_ops mirax_ops = {
@@ -569,7 +569,7 @@ static void insert_tile(struct level *l,
   image->refcount++;
 
   // generate tile
-  struct tile *tile = g_slice_new0(struct tile);
+  struct tile *tile = g_new0(struct tile, 1);
   tile->image = image;
   tile->src_x = src_x;
   tile->src_y = src_y;
@@ -827,7 +827,7 @@ static bool process_hier_data_pages_from_indexfile(struct _openslide_file *f,
 	}
 
 	// populate the image structure
-	g_autoptr(image) image = g_slice_new0(struct image);
+	g_autoptr(image) image = g_new0(struct image, 1);
 	image->fileno = fileno;
 	image->start_in_file = offset;
 	image->length = length;
@@ -1683,7 +1683,7 @@ static bool mirax_open(openslide_t *osr, const char *filename,
     g_new(struct slide_zoom_level_params, zoom_levels);
   int total_concat_exponent = 0;
   for (int i = 0; i < zoom_levels; i++) {
-    struct level *l = g_slice_new0(struct level);
+    struct level *l = g_new0(struct level, 1);
     g_ptr_array_add(level_array, l);
     struct slide_zoom_level_section *hs = slide_zoom_level_sections + i;
     struct slide_zoom_level_params *lp = slide_zoom_level_params + i;
@@ -1854,7 +1854,7 @@ static bool mirax_open(openslide_t *osr, const char *filename,
 
   // set private data
   g_assert(osr->data == NULL);
-  struct mirax_ops_data *data = g_slice_new0(struct mirax_ops_data);
+  struct mirax_ops_data *data = g_new0(struct mirax_ops_data, 1);
   data->datafile_paths = g_steal_pointer(&datafile_paths);
   osr->data = data;
 

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -223,26 +223,26 @@ static uint32_t *read_image(openslide_t *osr,
   struct mirax_ops_data *data = osr->data;
   bool result = false;
 
-  g_auto(_openslide_slice) dest = _openslide_slice_alloc(w * h * 4);
+  g_autofree uint32_t *dest = g_malloc(w * h * 4);
 
   switch (format) {
   case FORMAT_JPEG:
     result = _openslide_jpeg_read(data->datafile_paths[image->fileno],
                                   image->start_in_file,
-                                  dest.p, w, h,
+                                  dest, w, h,
                                   err);
     break;
   case FORMAT_PNG:
     result = _openslide_png_read(data->datafile_paths[image->fileno],
                                  image->start_in_file,
-                                 dest.p, w, h,
+                                 dest, w, h,
                                  err);
     break;
   case FORMAT_BMP:
     result = _openslide_gdkpixbuf_read("bmp",
                                        data->datafile_paths[image->fileno],
                                        image->start_in_file, image->length,
-                                       dest.p, w, h,
+                                       dest, w, h,
                                        err);
     break;
   default:
@@ -252,7 +252,7 @@ static uint32_t *read_image(openslide_t *osr,
   if (!result) {
     return NULL;
   }
-  return _openslide_slice_steal(&dest);
+  return g_steal_pointer(&dest);
 }
 
 static bool read_tile(openslide_t *osr,

--- a/src/openslide-vendor-philips.c
+++ b/src/openslide-vendor-philips.c
@@ -79,13 +79,13 @@ struct xml_associated_image {
 
 static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
-  g_slice_free(struct level, l);
+  g_free(l);
 }
 
 static void destroy(openslide_t *osr) {
   struct philips_ops_data *data = osr->data;
   _openslide_tiffcache_destroy(data->tc);
-  g_slice_free(struct philips_ops_data, data);
+  g_free(data);
 
   for (int32_t i = 0; i < osr->level_count; i++) {
     destroy_level((struct level *) osr->levels[i]);
@@ -298,7 +298,7 @@ static bool get_xml_associated_image_data(struct _openslide_associated_image *_i
 static void destroy_xml_associated_image(struct _openslide_associated_image *_img) {
   struct xml_associated_image *img = (struct xml_associated_image *) _img;
 
-  g_slice_free(struct xml_associated_image, img);
+  g_free(img);
 }
 
 static const struct _openslide_associated_image_ops philips_xml_associated_ops = {
@@ -333,7 +333,7 @@ static bool maybe_add_xml_associated_image(openslide_t *osr,
   }
 
   //g_debug("Adding %s image from XML", name);
-  struct xml_associated_image *img = g_slice_new0(struct xml_associated_image);
+  struct xml_associated_image *img = g_new0(struct xml_associated_image, 1);
   img->base.ops = &philips_xml_associated_ops;
   img->base.w = w;
   img->base.h = h;
@@ -569,7 +569,7 @@ static bool philips_open(openslide_t *osr,
       }
 
       // create level
-      struct level *l = g_slice_new0(struct level);
+      struct level *l = g_new0(struct level, 1);
       struct _openslide_tiff_level *tiffl = &l->tiffl;
       g_ptr_array_add(level_array, l);
 
@@ -648,7 +648,7 @@ static bool philips_open(openslide_t *osr,
                                  "macro", MACRO_DATA_XPATH, NULL);
 
   // allocate private data
-  struct philips_ops_data *data = g_slice_new0(struct philips_ops_data);
+  struct philips_ops_data *data = g_new0(struct philips_ops_data, 1);
   data->tc = g_steal_pointer(&tc);
 
   // store osr data

--- a/src/openslide-vendor-philips.c
+++ b/src/openslide-vendor-philips.c
@@ -125,15 +125,15 @@ static bool read_tile(openslide_t *osr,
       return true;
     }
 
-    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
-                                   box.p, tile_col, tile_row,
+                                   buf, tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_clip_tile(box.p,
+    if (!_openslide_clip_tile(buf,
                               tw, th,
                               l->base.w - tile_col * tw,
                               l->base.h - tile_row * th,
@@ -142,7 +142,7 @@ static bool read_tile(openslide_t *osr,
     }
 
     // put it in the cache
-    tiledata = _openslide_slice_steal(&box);
+    tiledata = g_steal_pointer(&buf);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
                          tiledata, tw * th * 4,
                          &cache_entry);

--- a/src/openslide-vendor-sakura.c
+++ b/src/openslide-vendor-sakura.c
@@ -345,11 +345,10 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_auto(_openslide_slice) box =
-      _openslide_slice_alloc(tile_size * tile_size * 4);
+    g_autofree uint32_t *buf = g_malloc(tile_size * tile_size * 4);
 
     // read tile
-    if (!read_image(box.p, tile_col, tile_row, l->base.downsample,
+    if (!read_image(buf, tile_col, tile_row, l->base.downsample,
                     data->focal_plane, tile_size, stmt, &tmp_err)) {
       if (g_error_matches(tmp_err, OPENSLIDE_ERROR,
                           OPENSLIDE_ERROR_NO_VALUE)) {
@@ -363,7 +362,7 @@ static bool read_tile(openslide_t *osr,
     }
 
     // clip, if necessary
-    if (!_openslide_clip_tile(box.p,
+    if (!_openslide_clip_tile(buf,
                               tile_size, tile_size,
                               l->base.w - tile_col * tile_size,
                               l->base.h - tile_row * tile_size,
@@ -372,7 +371,7 @@ static bool read_tile(openslide_t *osr,
     }
 
     // put it in the cache
-    tiledata = _openslide_slice_steal(&box);
+    tiledata = g_steal_pointer(&buf);
     _openslide_cache_put(osr->cache,
 			 level, tile_col, tile_row,
 			 tiledata, tile_size * tile_size * 4,

--- a/src/openslide-vendor-sakura.c
+++ b/src/openslide-vendor-sakura.c
@@ -162,14 +162,14 @@ static bool sakura_detect(const char *filename,
 
 static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
-  g_slice_free(struct level, l);
+  g_free(l);
 }
 
 static void destroy(openslide_t *osr) {
   struct sakura_ops_data *data = osr->data;
   g_free(data->filename);
   g_free(data->data_sql);
-  g_slice_free(struct sakura_ops_data, data);
+  g_free(data);
 
   for (int32_t i = 0; i < osr->level_count; i++) {
     destroy_level((struct level *) osr->levels[i]);
@@ -443,7 +443,7 @@ static void destroy_associated_image(struct _openslide_associated_image *_img) {
 
   g_free(img->filename);
   g_free(img->data_sql);
-  g_slice_free(struct associated_image, img);
+  g_free(img);
 }
 
 static const struct _openslide_associated_image_ops sakura_associated_ops = {
@@ -478,7 +478,7 @@ static bool add_associated_image(openslide_t *osr,
   }
 
   // create struct
-  struct associated_image *img = g_slice_new0(struct associated_image);
+  struct associated_image *img = g_new0(struct associated_image, 1);
   img->base.ops = &sakura_associated_ops;
   img->base.w = w;
   img->base.h = h;
@@ -829,7 +829,7 @@ static bool sakura_open(openslide_t *osr, const char *filename,
         return false;
       }
 
-      l = g_slice_new0(struct level);
+      l = g_new0(struct level, 1);
       l->base.downsample = downsample;
       l->base.w = image_width / downsample;
       l->base.h = image_height / downsample;
@@ -904,7 +904,7 @@ static bool sakura_open(openslide_t *osr, const char *filename,
   compute_quickhash1(quickhash1, db, unique_table_name, quickhash_tileids);
 
   // build ops data
-  struct sakura_ops_data *data = g_slice_new0(struct sakura_ops_data);
+  struct sakura_ops_data *data = g_new0(struct sakura_ops_data, 1);
   data->filename = g_strdup(filename);
   data->data_sql =
     g_strdup_printf("SELECT data FROM %s WHERE id=?", unique_table_name);

--- a/src/openslide-vendor-sakura.c
+++ b/src/openslide-vendor-sakura.c
@@ -297,31 +297,28 @@ static bool read_image(uint32_t *tiledata,
                        int32_t tile_size,
                        sqlite3_stmt *stmt,
                        GError **err) {
-  g_auto(_openslide_slice) red_channel =
-    _openslide_slice_alloc(tile_size * tile_size);
-  g_auto(_openslide_slice) green_channel =
-    _openslide_slice_alloc(tile_size * tile_size);
-  g_auto(_openslide_slice) blue_channel =
-    _openslide_slice_alloc(tile_size * tile_size);
+  g_autofree uint8_t *red_channel = g_malloc(tile_size * tile_size);
+  g_autofree uint8_t *green_channel = g_malloc(tile_size * tile_size);
+  g_autofree uint8_t *blue_channel = g_malloc(tile_size * tile_size);
 
-  if (!read_channel(red_channel.p, tile_col, tile_row, downsample,
+  if (!read_channel(red_channel, tile_col, tile_row, downsample,
                     INDEX_RED, focal_plane, tile_size, stmt, err)) {
     return false;
   }
-  if (!read_channel(green_channel.p, tile_col, tile_row, downsample,
+  if (!read_channel(green_channel, tile_col, tile_row, downsample,
                     INDEX_GREEN, focal_plane, tile_size, stmt, err)) {
     return false;
   }
-  if (!read_channel(blue_channel.p, tile_col, tile_row, downsample,
+  if (!read_channel(blue_channel, tile_col, tile_row, downsample,
                     INDEX_BLUE, focal_plane, tile_size, stmt, err)) {
     return false;
   }
 
   for (int32_t i = 0; i < tile_size * tile_size; i++) {
     tiledata[i] = 0xff000000 |
-                  (((uint8_t *) red_channel.p)[i] << 16) |
-                  (((uint8_t *) green_channel.p)[i] << 8) |
-                  ((uint8_t *) blue_channel.p)[i];
+                  (red_channel[i] << 16) |
+                  (green_channel[i] << 8) |
+                  blue_channel[i];
   }
 
   return true;

--- a/src/openslide-vendor-synthetic.c
+++ b/src/openslide-vendor-synthetic.c
@@ -261,13 +261,13 @@ static bool read_tile(openslide_t *osr G_GNUC_UNUSED,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_auto(_openslide_slice) box = _openslide_slice_alloc(IMAGE_BUFSIZE);
-    if (!decode_item(item, box.p, err)) {
+    g_autofree uint32_t *buf = g_malloc(IMAGE_BUFSIZE);
+    if (!decode_item(item, buf, err)) {
       return false;
     }
 
     // put it in the cache
-    tiledata = _openslide_slice_steal(&box);
+    tiledata = g_steal_pointer(&buf);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
                          tiledata, IMAGE_BUFSIZE, &cache_entry);
   }

--- a/src/openslide-vendor-synthetic.c
+++ b/src/openslide-vendor-synthetic.c
@@ -188,7 +188,7 @@ static bool decode_xml(const void *data, uint32_t len,
 
 static void level_free(struct level *level) {
   _openslide_grid_destroy(level->grid);
-  g_slice_free(struct level, level);
+  g_free(level);
 }
 typedef struct level level;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(level, level_free)
@@ -327,7 +327,7 @@ static bool synthetic_open(openslide_t *osr,
                            struct _openslide_tifflike *tl G_GNUC_UNUSED,
                            struct _openslide_hash *quickhash1,
                            GError **err) {
-  g_autoptr(level) level = g_slice_new0(struct level);
+  g_autoptr(level) level = g_new0(struct level, 1);
   level->grid =
     _openslide_grid_create_tilemap(osr, IMAGE_PIXELS, IMAGE_PIXELS,
                                    read_tile, NULL);

--- a/src/openslide-vendor-trestle.c
+++ b/src/openslide-vendor-trestle.c
@@ -54,7 +54,7 @@ struct level {
 
 static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
-  g_slice_free(struct level, l);
+  g_free(l);
 }
 
 static void destroy(openslide_t *osr) {
@@ -65,7 +65,7 @@ static void destroy(openslide_t *osr) {
 
   struct trestle_ops_data *data = osr->data;
   _openslide_tiffcache_destroy(data->tc);
-  g_slice_free(struct trestle_ops_data, data);
+  g_free(data);
 }
 
 static bool read_tile(openslide_t *osr,
@@ -304,7 +304,7 @@ static bool trestle_open(openslide_t *osr, const char *filename,
       return false;
     }
 
-    struct level *l = g_slice_new0(struct level);
+    struct level *l = g_new0(struct level, 1);
     struct _openslide_tiff_level *tiffl = &l->tiffl;
     g_ptr_array_add(level_array, l);
 
@@ -374,7 +374,7 @@ static bool trestle_open(openslide_t *osr, const char *filename,
   }
 
   // create ops data
-  struct trestle_ops_data *data = g_slice_new0(struct trestle_ops_data);
+  struct trestle_ops_data *data = g_new0(struct trestle_ops_data, 1);
   data->tc = g_steal_pointer(&tc);
 
   // store osr data

--- a/src/openslide-vendor-trestle.c
+++ b/src/openslide-vendor-trestle.c
@@ -89,22 +89,22 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
-                                   box.p, tile_col, tile_row,
+                                   buf, tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_tiff_clip_tile(tiffl, box.p,
+    if (!_openslide_tiff_clip_tile(tiffl, buf,
                                    tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // put it in the cache
-    tiledata = _openslide_slice_steal(&box);
+    tiledata = g_steal_pointer(&buf);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
                          tiledata, tw * th * 4,
                          &cache_entry);

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -176,22 +176,22 @@ static bool read_subtile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_auto(_openslide_slice) box = _openslide_slice_alloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
-                                   box.p, tile_col, tile_row,
+                                   buf, tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // clip, if necessary
-    if (!_openslide_tiff_clip_tile(tiffl, box.p,
+    if (!_openslide_tiff_clip_tile(tiffl, buf,
                                    tile_col, tile_row,
                                    err)) {
       return false;
     }
 
     // put it in the cache
-    tiledata = _openslide_slice_steal(&box);
+    tiledata = g_steal_pointer(&buf);
     _openslide_cache_put(osr->cache, level, tile_col, tile_row,
                          tiledata, tw * th * 4,
                          &cache_entry);

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -133,13 +133,13 @@ struct tile {
 
 static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
-  g_slice_free(struct level, l);
+  g_free(l);
 }
 
 static void destroy(openslide_t *osr) {
   struct ventana_ops_data *data = osr->data;
   _openslide_tiffcache_destroy(data->tc);
-  g_slice_free(struct ventana_ops_data, data);
+  g_free(data);
 
   for (int32_t i = 0; i < osr->level_count; i++) {
     destroy_level((struct level *) osr->levels[i]);
@@ -332,7 +332,7 @@ static bool ventana_detect(const char *filename G_GNUC_UNUSED,
 
 static void area_free(struct area *area) {
   g_free(area->tiles);
-  g_slice_free(struct area, area);
+  g_free(area);
 }
 
 static void bif_free(struct bif *bif) {
@@ -340,7 +340,7 @@ static void bif_free(struct bif *bif) {
     area_free(bif->areas[i]);
   }
   g_free(bif->areas);
-  g_slice_free(struct bif, bif);
+  g_free(bif);
 }
 
 typedef struct bif bif;
@@ -470,7 +470,7 @@ static struct bif *parse_level0_xml(const char *xml,
     }
 
     // create area
-    struct area *area = g_slice_new0(struct area);
+    struct area *area = g_new0(struct area, 1);
     g_ptr_array_add(area_array, area);
 
     // get start tiles
@@ -596,7 +596,7 @@ static struct bif *parse_level0_xml(const char *xml,
   }
 
   // create wrapper struct
-  g_autoptr(bif) bif = g_slice_new0(struct bif);
+  g_autoptr(bif) bif = g_new0(struct bif, 1);
   bif->num_areas = area_array->len;
   bif->areas =
     (struct area **) g_ptr_array_free(g_steal_pointer(&area_array), false);
@@ -839,7 +839,7 @@ static bool ventana_open(openslide_t *osr, const char *filename,
       }
 
       // create level
-      struct level *l = g_slice_new0(struct level);
+      struct level *l = g_new0(struct level, 1);
       struct _openslide_tiff_level *tiffl = &l->tiffl;
       g_ptr_array_add(level_array, l);
       if (!_openslide_tiff_level_init(ct.tiff, dir,
@@ -930,7 +930,7 @@ static bool ventana_open(openslide_t *osr, const char *filename,
   }
 
   // allocate private data
-  struct ventana_ops_data *data = g_slice_new0(struct ventana_ops_data);
+  struct ventana_ops_data *data = g_new0(struct ventana_ops_data, 1);
   data->tc = g_steal_pointer(&tc);
 
   // store osr data

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -120,7 +120,7 @@ static void *verify_pixman_works(void *arg G_GNUC_UNUSED) {
 }
 
 static openslide_t *create_osr(void) {
-  openslide_t *osr = g_slice_new0(openslide_t);
+  openslide_t *osr = g_new0(openslide_t, 1);
   osr->properties = g_hash_table_new_full(g_str_hash, g_str_equal,
                                           g_free, g_free);
   osr->associated_images = g_hash_table_new_full(g_str_hash, g_str_equal,
@@ -376,7 +376,7 @@ void openslide_close(openslide_t *osr) {
 
   g_free(g_atomic_pointer_get(&osr->error));
 
-  g_slice_free(openslide_t, osr);
+  g_free(osr);
 }
 
 

--- a/test/driver.in
+++ b/test/driver.in
@@ -164,7 +164,6 @@ def _launch_test(test, slidefile, valgrind=False, extra_checks=True,
     if extra_checks:
         env.update(
             G_DEBUG='gc-friendly',
-            G_SLICE='always-malloc',
             MALLOC_CHECK_='1',
         )
     args = [os.path.join(testdir, test), slidefile] + args
@@ -179,10 +178,6 @@ def _launch_test(test, slidefile, valgrind=False, extra_checks=True,
             # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/277
             JSIMD_FORCENONE='1',
         )
-    elif extra_checks:
-        # debug-blocks retains pointers to freed slices, so don't use it
-        # with Valgrind
-        env['G_SLICE'] += ',debug-blocks'
     return subprocess.Popen(args, env=env, **kwargs)
 
 

--- a/test/mosaic.c
+++ b/test/mosaic.c
@@ -78,7 +78,7 @@ static void render_tile(cairo_t *cr, const char *name, const char *path,
   if (osr) {
     error = g_strdup(openslide_get_error(osr));
     if (!error) {
-      uint32_t *buf = g_slice_alloc(TILE_WIDTH * TILE_HEIGHT * 4);
+      g_autofree uint32_t *buf = g_malloc(TILE_WIDTH * TILE_HEIGHT * 4);
       openslide_read_region(osr, buf, x, y, level, TILE_WIDTH, TILE_HEIGHT);
       error = g_strdup(openslide_get_error(osr));
       if (!error) {
@@ -97,7 +97,6 @@ static void render_tile(cairo_t *cr, const char *name, const char *path,
         cairo_surface_destroy(surface);
         cairo_paint(cr);
       }
-      g_slice_free1(TILE_WIDTH * TILE_HEIGHT * 4, buf);
     }
   } else {
     error = g_strdup("File not recognized");

--- a/test/parallel.c
+++ b/test/parallel.c
@@ -47,8 +47,7 @@ static struct tile sentinel;
 static void *thread_func(void *data) {
   struct state *state = data;
   struct tile *tile;	
-  uint32_t bufsz = TILE_SIZE * TILE_SIZE * sizeof(uint32_t);
-  uint32_t *buf = g_slice_alloc(bufsz);
+  g_autofree uint32_t *buf = g_malloc(TILE_SIZE * TILE_SIZE * sizeof(uint32_t));
 
   g_async_queue_push(state->completions, &sentinel);
   while (1) {
@@ -61,7 +60,6 @@ static void *thread_func(void *data) {
     g_async_queue_push(state->completions, tile);
   }
   g_async_queue_push(state->completions, &sentinel);
-  g_slice_free1(bufsz, buf);
   return NULL;
 }
 
@@ -114,7 +112,7 @@ int main(int argc, char **argv) {
   for (int64_t y = 0; y < h; y += TILE_SIZE) {
     for (int64_t x = 0; x < w; x += TILE_SIZE) {
       if (priming) {
-        tile = g_slice_new(struct tile);
+        tile = g_new(struct tile, 1);
         priming--;
       } else {
         tile = g_async_queue_pop(state.completions);
@@ -136,7 +134,7 @@ int main(int argc, char **argv) {
     if (tile == &sentinel) {
       threads--;
     } else {
-      g_slice_free(struct tile, tile);
+      g_free(tile);
     }
   }
 

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -172,10 +172,9 @@ static void check_regions(openslide_t *osr) {
     int64_t w = g_ascii_strtoll(args[3], NULL, 10);
     int64_t h = g_ascii_strtoll(args[4], NULL, 10);
 
-    uint32_t *buf = g_slice_alloc(w * h * 4);
+    g_autofree uint32_t *buf = g_malloc(w * h * 4);
     openslide_read_region(osr, buf, x, y, level, w, h);
     check_error(osr);
-    g_slice_free1(w * h * 4, buf);
   }
 }
 


### PR DESCRIPTION
glib deprecated it.

Fixes https://github.com/openslide/openslide/issues/430.