### PR TITLE
meson: don't use string-typed defaults for boolean options

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,24 +32,24 @@ option(
 option(
   '_export_internal_symbols',
   type : 'boolean',
-  value : 'false',
+  value : false,
   description : 'For test suite; do not use',
 )
 option(
   '_gcov',
   type : 'boolean',
-  value : 'false',
+  value : false,
   description : 'For test suite; do not use',
 )
 option(
   '_nonatomic_cloexec',
   type : 'boolean',
-  value : 'false',
+  value : false,
   description : 'For CI; do not use',
 )
 option(
   '_sanitize',
   type : 'boolean',
-  value : 'false',
+  value : false,
   description : 'For test suite; do not use',
 )


### PR DESCRIPTION
It produces a deprecation warning with Meson 1.1.0.