### PR TITLE
Add support for Leica DICOMs

### DIFF
--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -490,6 +490,7 @@ static bool read_tile(openslide_t *osr,
                                         l->base.tile_w * 4);
   cairo_set_source_surface(cr, surface, 0, 0);
   cairo_paint(cr);
+  _openslide_grid_draw_tile_info(cr, "%"PRId64, frame_number);
 
   return true;
 }

--- a/test/cases/dicom-tiled-sparse-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-sparse-jpeg/config.yaml
@@ -1,0 +1,8 @@
+base: DICOM/Leica-4.zip
+slide: 1.3.6.1.4.1.36533.116129230228107214763613716719238114924751.dcm
+success: true
+vendor: dicom
+primary: true
+requires: [dicom]
+properties:
+  openslide.vendor: dicom

--- a/test/cases/slides.yaml
+++ b/test/cases/slides.yaml
@@ -4,6 +4,7 @@ Aperio/CMU-1-Small-Region.svs:         ed92d5a9f2e86df67640d6f92ce3e231419ce1271
 Aperio/JP2K-33003-1.svs:               6205ccf75a8fa6c32df7c5c04b7377398971a490fb6b320d50d91f7ba6a0e6fd
 
 DICOM/3DHISTECH-1.zip:                 f7306843363c08ab86539f52acbe492917c440df50231d06b9b2e1657ac9e6a8
+DICOM/Leica-4.zip:                     71bd6db778d8565b28aa358d1abce0c55985c149183630c2ed31d1f8757185bb
 
 Generic-TIFF/CMU-1.tiff:               73a7e89bc15576587c3d68e55d9bf92f09690280166240b48ff4b48230b13bcd
 


### PR DESCRIPTION
This PR adds support for the sample Leica DICOM images.

- use a table to map row-major tile positions to DICOM frame numbers
- test DimensionOrganizationType and for "3D" use PerFrameFunctionalGroupsSequence to construct this table
- support uncompressed RGB pixel data
- support RGB JPEG pixel data