### PR TITLE
Add a tool to query and write associated images.

### DIFF
--- a/tools/meson.build
+++ b/tools/meson.build
@@ -8,6 +8,7 @@ tools = [
   ['openslide-quickhash1sum', tools_deps],
   ['openslide-show-properties', tools_deps],
   ['openslide-write-png', [tools_deps, png_dep]],
+  ['openslide-write-associated-images', [tools_deps, png_dep]],
 ]
 foreach t : tools
   executable(

--- a/tools/openslide-write-associated-images.1.in
+++ b/tools/openslide-write-associated-images.1.in
@@ -1,0 +1,67 @@
+.\"
+.\" OpenSlide, a library for reading whole slide image files
+.\"
+.\" Copyright (c) 2007-2012 Carnegie Mellon University
+.\" Copyright (c) 2023 Alexandr Virodov
+.\" All rights reserved.
+.\"
+.\" OpenSlide is free software: you can redistribute it and/or modify
+.\" it under the terms of the GNU Lesser General Public License as
+.\" published by the Free Software Foundation, version 2.1.
+.\"
+.\" OpenSlide is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+.\" GNU Lesser General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU Lesser General Public
+.\" License along with OpenSlide. If not, see
+.\" <http://www.gnu.org/licenses/>.
+.\"
+
+
+.\" See man-pages(7) for formatting conventions.
+
+
+.TH OPENSLIDE-WRITE-ASSOCIATED-IMAGES 1 2023-05-09 "OpenSlide @SUFFIXED_VERSION@" "User Commands"
+
+.mso www.tmac
+
+.SH NAME
+openslide-write-associated-images \- Query or write associated images  of a virtual slide.
+
+.SH SYNOPSIS
+.BR "openslide-write-associated-images " [ --help "] [" --version ]
+.I slide-file - to list associated images.
+.I slide-file associated_image output.png - to write an associated image.
+
+.SH DESCRIPTION
+Query a list of associated images, or write a single associated image to a PNG file.
+
+.SH OPTIONS
+.TP
+.B --help
+Display usage summary.
+
+.TP
+.B --version
+Display version and copyright information.
+
+.SH EXIT STATUS
+.B openslide-write-associated-images
+returns 0 on success, 1 if an error occurred, or 2 if the arguments are
+invalid.
+
+.SH COPYRIGHT
+Copyright \(co 2007-2023 Carnegie Mellon University and others
+
+OpenSlide is free software: you can redistribute it and/or modify it under
+the terms of the
+.URL http://gnu.org/licenses/lgpl-2.1.html "GNU Lesser General Public License, version 2.1" .
+
+OpenSlide comes with NO WARRANTY, to the extent permitted by law.  See the
+GNU Lesser General Public License for more details.
+
+.SH SEE ALSO
+.BR openslide-quickhash1sum (1),
+.BR openslide-show-properties (1)

--- a/tools/openslide-write-associated-images.c
+++ b/tools/openslide-write-associated-images.c
@@ -149,7 +149,7 @@ int main (int argc, char **argv) {
     int64_t w;
     int64_t h;
     openslide_get_associated_image_dimensions(osr, associated_image_name, &w, &h);
-    printf("Dimensions: %ld, %ld\n", w, h);
+    printf("Dimensions: %"PRId64", %"PRId64"\n", w, h);
 
     g_autofree uint32_t *buffer = g_malloc(w * h * 4);
     openslide_read_associated_image(osr, associated_image_name, buffer);

--- a/tools/openslide-write-associated-images.c
+++ b/tools/openslide-write-associated-images.c
@@ -1,0 +1,166 @@
+/*
+ *  OpenSlide, a library for reading whole slide image files
+ *
+ *  Copyright (c) 2007-2012 Carnegie Mellon University
+ *  Copyright (c) 2023 Alexandr Virodov
+ *  All rights reserved.
+ *
+ *  OpenSlide is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, version 2.1.
+ *
+ *  OpenSlide is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with OpenSlide. If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "openslide.h"
+#include "openslide-common.h"
+
+#include <png.h>
+#include <inttypes.h>
+#include <glib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+
+static const char SOFTWARE[] = "Software";
+static const char OPENSLIDE[] = "OpenSlide <https://openslide.org/>";
+
+static void fail(const char *format, ...) G_GNUC_NORETURN;
+static void fail(const char *format, ...) {
+  va_list ap;
+
+  va_start(ap, format);
+  char *msg = g_strdup_vprintf(format, ap);
+  va_end(ap);
+
+  fprintf(stderr, "%s: %s\n", g_get_prgname(), msg);
+  fflush(stderr);
+
+  exit(1);
+}
+
+
+static void write_png(FILE *f, int64_t w, int64_t h, uint32_t* data) {
+  png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+  if (!png_ptr) {
+    fail("Could not initialize PNG");
+  }
+
+  png_infop info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    fail("Could not initialize PNG");
+  }
+
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    fail("Error writing PNG");
+  }
+
+  png_init_io(png_ptr, f);
+
+  png_set_IHDR(png_ptr, info_ptr, w, h, 8,
+               PNG_COLOR_TYPE_RGB_ALPHA, PNG_INTERLACE_NONE,
+               PNG_COMPRESSION_TYPE_DEFAULT,
+               PNG_FILTER_TYPE_DEFAULT);
+
+  // text
+  png_text text_ptr[1];
+  memset(text_ptr, 0, sizeof text_ptr);
+  text_ptr[0].compression = PNG_TEXT_COMPRESSION_NONE;
+  g_autofree char *key = g_strdup(SOFTWARE);
+  text_ptr[0].key = key;
+  g_autofree char *text = g_strdup(OPENSLIDE);
+  text_ptr[0].text = text;
+  text_ptr[0].text_length = strlen(text);
+
+  png_set_text(png_ptr, info_ptr, text_ptr, 1);
+
+  // start writing
+  png_write_info(png_ptr, info_ptr);
+  for (int i = 0; i < h; ++i) {
+    png_write_row(png_ptr, (png_bytep) &data[w * i]);
+  }
+
+  // end
+  png_write_end(png_ptr, info_ptr);
+  png_destroy_write_struct(&png_ptr, &info_ptr);
+}
+
+
+static const struct common_usage_info usage_info = {
+  "\n\tslide - to list associated images.\n\tslide associated_image output.png - to write an associated image.",
+  "Write an associated image of a virtual slide to a PNG.",
+};
+
+enum mode_t {
+  LIST_IMAGES,
+  WRITE_IMAGE,
+};
+
+int main (int argc, char **argv) {
+  enum mode_t mode;
+  common_parse_commandline(&usage_info, &argc, &argv);
+
+  switch (argc) {
+    case 2: mode = LIST_IMAGES; break;
+    case 4: mode = WRITE_IMAGE; break;
+    default: common_usage(&usage_info); // calls exit().
+  }
+
+  const char *slide = argv[1];
+  printf("Opening slide: '%s'\n", slide);
+
+  // open slide
+  g_autoptr(openslide_t) osr = openslide_open(slide);
+
+  // check errors
+  if (osr == NULL) {
+    fail("%s: Not a file that OpenSlide can recognize", slide);
+  }
+
+  const char *err = openslide_get_error(osr);
+  if (err) {
+    fail("%s: %s", slide, err);
+  }
+
+  if (mode == LIST_IMAGES) {
+    printf("Listing associated images:\n");
+    const char *const *associated_image_names = openslide_get_associated_image_names(osr);
+    while (*associated_image_names) {
+      printf("associated image: '%s'\n", *associated_image_names);
+      associated_image_names++;
+    }
+    printf("Done listing.\n");
+
+  } else if (mode == WRITE_IMAGE) {
+    const char *associated_image_name = argv[2];
+    const char *output_file = argv[3];
+    printf("Extracting associated image: '%s'\n", associated_image_name);
+
+    int64_t w;
+    int64_t h;
+    openslide_get_associated_image_dimensions(osr, associated_image_name, &w, &h);
+    printf("Dimensions: %ld, %ld\n", w, h);
+
+    g_autofree uint32_t *buffer = g_malloc(w * h * 4);
+    openslide_read_associated_image(osr, associated_image_name, buffer);
+
+    printf("Writing output file: '%s'\n", output_file);
+    FILE* f = fopen(output_file, "wb");
+    write_png(f, w, h, buffer);
+    fclose(f);
+  }
+
+  // openslide_close(osr);
+
+  return 0;
+}


### PR DESCRIPTION
This is part of tooling that I need to implement request https://github.com/openslide/openslide/pull/437#discussion_r1174073883.

Tested:
```
~/openslide/builddir$ tools/openslide-write-associated-images /home/me/Downloads/TCGA-86-A456-01A-01-TSA.996EFBE2-10E2-454B-B4E7-981FA24404B0.svs 
Opening slide: '/home/me/Downloads/TCGA-86-A456-01A-01-TSA.996EFBE2-10E2-454B-B4E7-981FA24404B0.svs'
Listing associated images:
associated image: 'thumbnail'
Done listing.

~/openslide/builddir$ tools/openslide-write-associated-images /home/me/Downloads/TCGA-86-A456-01A-01-TSA.996EFBE2-10E2-454B-B4E7-981FA24404B0.svs thumbnail /home/me/openslide/thumbnail.png
Opening slide: '/home/me/Downloads/TCGA-86-A456-01A-01-TSA.996EFBE2-10E2-454B-B4E7-981FA24404B0.svs'
Extracting associated image: 'thumbnail'
Dimensions: 1024, 217
Writing output file: '/home/me/openslide/thumbnail.png'
```
----
Note: the `openslide_close()` fails for some reason on SIGSEGV, trying to `g_free(osr);`. Is this a known bug? I don't see the openslide-write-png closing the openslide handle either. If I add `openslide_close(osr)` to the sample, I get the same failure:
```
/home/me/openslide/builddir/tools/openslide-write-png /home/me/Downloads/TCGA-86-A456-01A-01-TSA.996EFBE2-10E2-454B-B4E7-981FA24404B0.svs 0 0 3 1000 1000 /home/me/openslide/output.png

Process finished with exit code 139 (interrupted by signal 11: SIGSEGV)
```