### PR TITLE
grid: avoid `CAIRO_OPERATOR_SATURATE` in simple grid

### DIFF
--- a/src/openslide-grid.c
+++ b/src/openslide-grid.c
@@ -495,7 +495,11 @@ static bool tilemap_paint_region(struct _openslide_grid *_grid,
   //g_debug("start tile: %"PRId64" %"PRId64", end tile: %"PRId64" %"PRId64, start_tile_x, start_tile_y, end_tile_x, end_tile_y);
 
   // save
-  g_auto(cairo_matrix) matrix G_GNUC_UNUSED = matrix_save(cr);
+  g_auto(cairo_state) state G_GNUC_UNUSED = state_save(cr);
+
+  // saturate (3x-5x total slowdown, including JPEG decompression) to avoid
+  // seams
+  cairo_set_operator(cr, CAIRO_OPERATOR_SATURATE);
 
   // accommodate extra tiles being drawn
   region.start_tile_x -= grid->extra_tiles_left;
@@ -671,7 +675,12 @@ static bool range_paint_region(struct _openslide_grid *_grid,
   g_assert(grid->bins_runtime);
 
   // save
+  g_auto(cairo_state) state G_GNUC_UNUSED = state_save(cr);
   g_auto(cairo_matrix) matrix = matrix_save(cr);
+
+  // saturate (3x-5x total slowdown, including JPEG decompression) to avoid
+  // seams
+  cairo_set_operator(cr, CAIRO_OPERATOR_SATURATE);
 
   // accumulate relevant tiles
   struct range_bin_address addr;

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -498,11 +498,9 @@ void openslide_read_region(openslide_t *osr,
 
   // Break the work into smaller pieces if the region is large, because:
   // 1. Cairo will not allow surfaces larger than 32767 pixels on a side.
-  // 2. cairo_push_group() creates an intermediate surface backed by a
+  // 2. cairo_image_surface_create_for_data() creates a surface backed by a
   //    pixman_image_t, and Pixman requires that every byte of that image
   //    be addressable in 31 bits.
-  // 3. We would like to constrain the intermediate surface to a reasonable
-  //    amount of RAM.
   const int64_t d = 4096;
   double ds = openslide_get_level_downsample(osr, level);
   for (int64_t row = 0; row < (h + d - 1) / d; row++) {

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -434,9 +434,6 @@ static bool read_region_area(openslide_t *osr,
   // create the cairo context
   g_autoptr(cairo_t) cr = cairo_create(surface);
 
-  // saturate those seams away!
-  cairo_set_operator(cr, CAIRO_OPERATOR_SATURATE);
-
   if (level_in_range(osr, level)) {
     struct _openslide_level *l = osr->levels[level];
 


### PR DESCRIPTION
The simple grid doesn't have overlaps or subpixel offsets, so we don't need to use `CAIRO_OPERATOR_SATURATE` to avoid seams.  Use the default `CAIRO_OPERATOR_OVER` in this case.  On my system this gives a 3x-5x performance improvement in single-threaded `test/parallel`.

For https://github.com/openslide/openslide/issues/440.