### PR TITLE
Rename "philips" to "philips-tiff" internally

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -66,7 +66,7 @@ openslide_sources = [
   'openslide-vendor-hamamatsu.c',
   'openslide-vendor-leica.c',
   'openslide-vendor-mirax.c',
-  'openslide-vendor-philips.c',
+  'openslide-vendor-philips-tiff.c',
   'openslide-vendor-sakura.c',
   'openslide-vendor-synthetic.c',
   'openslide-vendor-trestle.c',

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -132,7 +132,7 @@ extern const struct _openslide_format _openslide_format_hamamatsu_ndpi;
 extern const struct _openslide_format _openslide_format_hamamatsu_vms_vmu;
 extern const struct _openslide_format _openslide_format_leica;
 extern const struct _openslide_format _openslide_format_mirax;
-extern const struct _openslide_format _openslide_format_philips;
+extern const struct _openslide_format _openslide_format_philips_tiff;
 extern const struct _openslide_format _openslide_format_sakura;
 extern const struct _openslide_format _openslide_format_synthetic;
 extern const struct _openslide_format _openslide_format_trestle;

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -51,7 +51,7 @@ static const struct _openslide_format *formats[] = {
   &_openslide_format_trestle,
   &_openslide_format_aperio,
   &_openslide_format_leica,
-  &_openslide_format_philips,
+  &_openslide_format_philips_tiff,
   &_openslide_format_ventana,
   &_openslide_format_generic_tiff,
   NULL,


### PR DESCRIPTION
There are plans to add a Philips iSyntax driver.  From the perspective of the `openslide.vendor` property these will both be `philips`, but the two drivers will share no code.  Clarify that the existing driver is for the TIFF format.