### PR TITLE
Revise DICOM loader for libdicom 0.4

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -137,6 +137,7 @@ dicom_dep      = dependency(
   default_options : ['tests=false'],
   fallback : ['libdicom', 'libdicom_dep'],
   required : get_option('dicom'),
+  version : '>=0.4',
 )
 valgrind_dep   = dependency('valgrind', required : false)
 

--- a/src/openslide-decode-dicom.h
+++ b/src/openslide-decode-dicom.h
@@ -29,7 +29,6 @@
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(DcmFilehandle, dcm_filehandle_destroy)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(DcmDataSet, dcm_dataset_destroy)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(DcmBOT, dcm_bot_destroy)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(DcmFrame, dcm_frame_destroy)
 
 DcmFilehandle *_openslide_dicom_open(const char *filename, GError **err);

--- a/src/openslide-vendor-synthetic.c
+++ b/src/openslide-vendor-synthetic.c
@@ -118,20 +118,15 @@ static bool decode_dicom(const void *data, uint32_t len,
   }
 
   // read Data Set metadata and frame
+  // this will pull the rest of the header in, so _read_frame() will work
   g_autoptr(DcmDataSet) metadata = dcm_filehandle_read_metadata(&dcm_error, fh);
   if (!metadata) {
     _openslide_dicom_propagate_error(err, dcm_error);
     g_prefix_error(err, "Reading metadata: ");
     return false;
   }
-  g_autoptr(DcmBOT) bot = dcm_filehandle_read_bot(&dcm_error, fh, metadata);
-  if (!bot) {
-    _openslide_dicom_propagate_error(err, dcm_error);
-    g_prefix_error(err, "Reading BOT: ");
-    return false;
-  }
   g_autoptr(DcmFrame) frame =
-    dcm_filehandle_read_frame(&dcm_error, fh, metadata, bot, 1);
+    dcm_filehandle_read_frame(&dcm_error, fh, 1);
   if (!frame) {
     _openslide_dicom_propagate_error(err, dcm_error);
     g_prefix_error(err, "Reading frame: ");

--- a/subprojects/libdicom.wrap
+++ b/subprojects/libdicom.wrap
@@ -2,5 +2,5 @@
 # NOTE: temporary fork for now
 # https://github.com/openslide/openslide-winbuild/issues/82
 url = https://github.com/jcupitt/libdicom.git
-revision = 49ee15f3a719cb6977085f93625771faf29ebb75
+revision = fd777251f5219a7fcc92ebda26828f26618a1c4e
 depth = 1


### PR DESCRIPTION
libdicom 0.4 has a simplified API that lets us remove quite a bit of code.

libdicom 0.4 is quite a bit quicker and needs less memory. For example, here's openslide plus libdicom 0.2 on a large Leica DICOM:

```
$ /usr/bin/time -f %M:%e openslide-show-properties 272320e7-5abb-ccac-8f8b-9c2008f53845_114626/1.3.6.1.4.1.36533.1214640142408762111756320324051133413.dcm
openslide.level-count: '4'
openslide.level[0].downsample: '1'
openslide.level[0].height: '84441'
openslide.level[0].tile-height: '256'
openslide.level[0].tile-width: '256'
openslide.level[0].width: '108071'
openslide.level[1].downsample: '4.0000792060552719'
openslide.level[1].height: '21110'
openslide.level[1].tile-height: '256'
openslide.level[1].tile-width: '256'
openslide.level[1].width: '27017'
openslide.level[2].downsample: '16.0013709686787'
openslide.level[2].height: '5277'
openslide.level[2].tile-height: '256'
openslide.level[2].tile-width: '256'
openslide.level[2].width: '6754'
openslide.level[3].downsample: '64.021029009122955'
openslide.level[3].height: '1319'
openslide.level[3].tile-height: '256'
openslide.level[3].tile-width: '256'
openslide.level[3].width: '1688'
openslide.mpp-x: '0.26297895237999996'
openslide.mpp-y: '0.26297895237999996'
openslide.vendor: 'dicom'
691592:4.15
```

700mb of memory and 4.2s.

With this PR:

```
$ /usr/bin/time -f %M:%e openslide-show-properties 272320e7-5abb-ccac-8f8b-9c2008f53845_114626/1.3.6.1.4.1.36533.21716722913121316773164147287613518920414871.dcm
openslide.level-count: '4'
openslide.level[0].downsample: '1'
openslide.level[0].height: '84441'
openslide.level[0].tile-height: '256'
openslide.level[0].tile-width: '256'
openslide.level[0].width: '108071'
openslide.level[1].downsample: '4.0000792060552719'
openslide.level[1].height: '21110'
openslide.level[1].tile-height: '256'
openslide.level[1].tile-width: '256'
openslide.level[1].width: '27017'
openslide.level[2].downsample: '16.0013709686787'
openslide.level[2].height: '5277'
openslide.level[2].tile-height: '256'
openslide.level[2].tile-width: '256'
openslide.level[2].width: '6754'
openslide.level[3].downsample: '64.021029009122955'
openslide.level[3].height: '1319'
openslide.level[3].tile-height: '256'
openslide.level[3].tile-width: '256'
openslide.level[3].width: '1688'
openslide.mpp-x: '0.26297895237999996'
openslide.mpp-y: '0.26297895237999996'
openslide.vendor: 'dicom'
89560:0.04
```

90mb of memory and 0.04s. 