### PR TITLE
test/extended: add more error checks

### DIFF
--- a/common/openslide-common-fail.c
+++ b/common/openslide-common-fail.c
@@ -33,3 +33,15 @@ void common_fail(const char *fmt, ...) {
   va_end(ap);
   exit(1);
 }
+
+void common_fail_on_error(openslide_t *osr, const char *fmt, ...) {
+  const char *err = openslide_get_error(osr);
+  if (err != NULL) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, ": %s\n", err);
+    va_end(ap);
+    exit(1);
+  }
+}

--- a/common/openslide-common.h
+++ b/common/openslide-common.h
@@ -24,6 +24,7 @@
 
 #include <stdbool.h>
 #include <glib.h>
+#include <openslide.h>
 
 #ifdef OPENSLIDE_PUBLIC
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(openslide_t, openslide_close)
@@ -50,6 +51,7 @@ void common_usage(const struct common_usage_info *info) G_GNUC_NORETURN;
 // fail
 
 void common_fail(const char *fmt, ...) G_GNUC_NORETURN;
+void common_fail_on_error(openslide_t *osr, const char *fmt, ...);
 
 // fd
 

--- a/test/extended.c
+++ b/test/extended.c
@@ -227,12 +227,14 @@ int main(int argc, char **argv) {
 
   int64_t w, h;
   openslide_get_level0_dimensions(osr, &w, &h);
+  common_fail_on_error(osr, "Getting level 0 dimensions failed");
 
   int32_t levels = openslide_get_level_count(osr);
   for (int32_t i = -1; i < levels + 1; i++) {
     int64_t ww, hh;
     openslide_get_level_dimensions(osr, i, &ww, &hh);
     openslide_get_level_downsample(osr, i);
+    common_fail_on_error(osr, "Querying level %d failed", i);
   }
 
   openslide_get_best_level_for_downsample(osr, 0.8);
@@ -247,12 +249,15 @@ int main(int argc, char **argv) {
   openslide_get_best_level_for_downsample(osr, 100);
   openslide_get_best_level_for_downsample(osr, 1000);
   openslide_get_best_level_for_downsample(osr, 10000);
+  common_fail_on_error(osr, "Getting best level for downsample failed");
 
   // NULL buffer
   openslide_read_region(osr, NULL, 0, 0, 0, 1000, 1000);
+  common_fail_on_error(osr, "Reading NULL buffer failed");
 
   // empty region
   openslide_read_region(osr, NULL, 0, 0, 0, 0, 0);
+  common_fail_on_error(osr, "Reading null region failed");
 
   // read properties
   const char * const *property_names = openslide_get_property_names(osr);
@@ -261,10 +266,12 @@ int main(int argc, char **argv) {
     openslide_get_property_value(osr, name);
     property_names++;
   }
+  common_fail_on_error(osr, "Reading properties failed");
 
   // read associated images
   const char * const *associated_image_names =
     openslide_get_associated_image_names(osr);
+  common_fail_on_error(osr, "Listing associated images failed");
   while (*associated_image_names) {
     int64_t w, h;
     const char *name = *associated_image_names;
@@ -273,6 +280,7 @@ int main(int argc, char **argv) {
     g_autofree uint32_t *buf = g_new(uint32_t, w * h);
     openslide_read_associated_image(osr, name, buf);
 
+    common_fail_on_error(osr, "Reading associated image \"%s\" failed", name);
     associated_image_names++;
   }
 

--- a/test/extended.c
+++ b/test/extended.c
@@ -44,12 +44,9 @@ static void test_image_fetch(openslide_t *osr,
   for (int32_t level = 0; level < openslide_get_level_count(osr); level++) {
     openslide_read_region(osr, buf, x, y, level, w, h);
   }
-
-  const char *err = openslide_get_error(osr);
-  if (err) {
-    common_fail("Read failed: %"PRId64" %"PRId64" %"PRId64" %"PRId64": %s",
-                x, y, w, h, err);
-  }
+  common_fail_on_error(osr,
+                       "Read failed: %"PRId64" %"PRId64" %"PRId64" %"PRId64,
+                       x, y, w, h);
 }
 
 #if !defined(NONATOMIC_CLOEXEC) && !defined(_WIN32)
@@ -220,10 +217,7 @@ int main(int argc, char **argv) {
   if (!osr) {
     common_fail("Couldn't open %s", path);
   }
-  const char *err = openslide_get_error(osr);
-  if (err) {
-    common_fail("Open failed: %s", err);
-  }
+  common_fail_on_error(osr, "Open failed");
   openslide_close(osr);
 
   osr = openslide_open(path);

--- a/test/profile.c
+++ b/test/profile.c
@@ -48,10 +48,7 @@ int main(int argc, char **argv) {
   if (!osr) {
     common_fail("Couldn't open %s", path);
   }
-  const char *err = openslide_get_error(osr);
-  if (err) {
-    common_fail("Open failed: %s", err);
-  }
+  common_fail_on_error(osr, "Open failed");
   if (level >= openslide_get_level_count(osr)) {
     common_fail("No such level: %d", level);
   }
@@ -99,10 +96,7 @@ int main(int argc, char **argv) {
   CALLGRIND_STOP_INSTRUMENTATION;
 #endif
 
-  err = openslide_get_error(osr);
-  if (err) {
-    common_fail("Read failed: %s", err);
-  }
+  common_fail_on_error(osr, "Read failed");
 
   return 0;
 }


### PR DESCRIPTION
We weren't checking for errors between opening the slide and reading regions, which caused misleading error messages if something failed in between.  Add more granular checks.  This would have clarified the CI failure in https://github.com/openslide/openslide/pull/454#pullrequestreview-1461266163.

cc @jcupitt