### PR TITLE
Get dicom objective-power from optical-path

### DIFF
--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -135,6 +135,7 @@ static const char HighBit[] = "HighBit";
 static const char PixelRepresentation[] = "PixelRepresentation";
 static const char LossyImageCompression[] = "LossyImageCompression";
 static const char LossyImageCompressionMethod[] = "LossyImageCompressionMethod";
+static const char OpticalPathSequence[] = "OpticalPathSequence";
 static const char ObjectiveLensPower[] = "ObjectiveLensPower";
 
 static void print_file(struct dicom_file *f G_GNUC_UNUSED) {
@@ -645,7 +646,10 @@ static bool add_level(openslide_t *osr,
   }
 
   // objective power
-  get_tag_decimal_str(f->metadata, ObjectiveLensPower, 0, &l->objective_lens_power);
+  DcmDataSet *optical_path;
+  if (get_tag_seq_item(f->metadata, OpticalPathSequence, 0, &optical_path)) {
+    get_tag_decimal_str(optical_path, ObjectiveLensPower, 0, &l->objective_lens_power);
+  }
 
   // grid
   int64_t tiles_across = (l->base.w / l->base.tile_w) + !!(l->base.w % l->base.tile_w);


### PR DESCRIPTION
The objective-power metadata item is defined in the optical path sequence:

https://dicom.innolitics.com/ciods/vl-microscopic-image/optical-path/00480105/00480112

This PR fetches objective power from that sequence, not from the main metadata dataset.

With this PR, openslide-show-properties gets the OP correctly from the sample DICOMs I have:

```
$ openslide-show-properties 1.3.6.1.4.1.36533.116129230228107214763613716719238114924751.dcm | grep -i obj
openslide.objective-power: '40'
```