### PR TITLE
dicom: support quickhash-1

### DIFF
--- a/misc/dicom-quickhash.py
+++ b/misc/dicom-quickhash.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3
+
+import hashlib
+from pydicom import dcmread
+import sys
+
+h = hashlib.sha256()
+h.update(dcmread(sys.argv[1])[(0x20,0xe)].value.encode() + b'\0')
+
+print(h.hexdigest())

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -23,6 +23,8 @@
 
 /*
  * DICOM (.dcm) support
+ *
+ * quickhash comes from the Series Instance UID
  */
 
 /*
@@ -1095,8 +1097,8 @@ static bool dicom_open(openslide_t *osr,
 
   (void) get_icc_profile(level0->file, &osr->icc_profile_size);
 
-  // no quickhash yet; disable
-  _openslide_hash_disable(quickhash1);
+  // compute quickhash
+  _openslide_hash_string(quickhash1, slide_id);
 
   g_assert(osr->data == NULL);
   g_assert(osr->levels == NULL);

--- a/test/cases/dicom-tiled-full-jp2k-rgb/config.yaml
+++ b/test/cases/dicom-tiled-full-jp2k-rgb/config.yaml
@@ -9,4 +9,5 @@ properties:
   openslide.associated.macro.icc-size: "3144"
   openslide.associated.thumbnail.icc-size: "3144"
   openslide.icc-size: "3144"
+  openslide.quickhash-1: 8d3fcfae032e2758633c75fa65a583acf4dd22e0a28872d628947d3937f5c2f8
   openslide.vendor: dicom

--- a/test/cases/dicom-tiled-full-jp2k-ycbcr/config.yaml
+++ b/test/cases/dicom-tiled-full-jp2k-ycbcr/config.yaml
@@ -9,4 +9,5 @@ properties:
   openslide.associated.macro.icc-size: "141992"
   openslide.associated.thumbnail.icc-size: "141992"
   openslide.icc-size: "141992"
+  openslide.quickhash-1: 2431797d260ab5fab926a01f3cee1d35dbb7281f82aed46d97c5aafeff16079c
   openslide.vendor: dicom

--- a/test/cases/dicom-tiled-full-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-full-jpeg/config.yaml
@@ -8,4 +8,5 @@ properties:
   openslide.associated.label.icc-size: "63928"
   openslide.associated.macro.icc-size: "63928"
   openslide.icc-size: "63928"
+  openslide.quickhash-1: 95620a2bd3ca53b8bdc0830fe99ad5f9f150d80e202c5e74aec3c905ebbad0cb
   openslide.vendor: dicom

--- a/test/cases/dicom-tiled-sparse-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-sparse-jpeg/config.yaml
@@ -7,4 +7,5 @@ primary: true
 properties:
   openslide.associated.thumbnail.icc-size: "13113264"
   openslide.icc-size: "13113264"
+  openslide.quickhash-1: 7ca87626aa9842b867f284a4ac0c9474f5de295455c8bb25be2ed837efcc5b10
   openslide.vendor: dicom


### PR DESCRIPTION
The purpose of the quickhash is to `uniquely identify a particular virtual slide, but [not] to detect file corruption or modification`.  Most slide formats don't include unique identifiers, so we usually have to construct one from metadata that collectively is unique to a slide.

In the case of DICOM, there are already unique identifiers for entities at various conceptual levels.  Those identifiers refer to the conceptual entity, not its exact representation.  For example, the SOP Instance UID doesn't change if the pixel data or metadata are altered in certain ways that don't change the instance's notional semantics.

Rather than second-guessing DICOM's approach to entity naming, adopt it.  That requires us to pick a UID to hash.  The Acquisition UID is too general (two recompressions of the same scan share the same UID) and its presence is optional; the Pyramid UID is optional; and the SOP Instance UID refers to a specific level, portion of a level, or associated image.  We could hash all the SOP Instance UIDs, but then we'd be creating our own definition of a "slide" out of its constituent parts.

The Series Instance UID, however, seems like a good fit, especially since we currently support only one series per slide.  Calculate the quickhash by hashing that UID.  In the future, if we support Z-stacks distributed across multiple series (with a common Acquisition ID), we can hash a sorted list of all Series Instance UIDs.

This will cause quickhash collisions if a single series (or a reused series UID) contains multiple independent slides _and_ we aren't presented with the entire series at once.  We could try to avoid that by hashing additional attributes such as timestamps, but again we'd be second-guessing the existing naming semantics.