### PR TITLE
workflows: build with both Debian 11 and 12

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -30,8 +30,10 @@ jobs:
           - os: ubuntu-latest
             container: quay.io/centos/centos:stream9
           - os: ubuntu-latest
-            container: debian:stable
+            container: debian:11
             ignore-cloexec-leaks: ignore CLOEXEC leaks
+          - os: ubuntu-latest
+            container: debian:12
           - os: ubuntu-20.04
             ignore-cloexec-leaks: ignore CLOEXEC leaks
           - os: ubuntu-22.04


### PR DESCRIPTION
The new Debian stable release is out, and it doesn't leak file descriptors.