### PR TITLE
WiP: Add ICC profile support

### DIFF
--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -1132,5 +1132,15 @@ bool _openslide_tifflike_init_properties_and_hash(openslide_t *osr,
   // load TIFF properties
   store_and_hash_properties(tl, property_dir, osr, quickhash1);
 
+  // attach ICC profile, if any
+  struct tiff_item *item = get_item(tl, property_dir, TIFFTAG_ICCPROFILE);
+  if (item) {
+    const char *icc_profile = _openslide_tifflike_get_buffer(tl, property_dir, TIFFTAG_ICCPROFILE, err);
+    if (icc_profile == NULL) {
+      return false;
+    }
+    _openslide_set_icc_profile(osr, icc_profile, item->count);
+  }
+
   return true;
 }

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -73,6 +73,9 @@ struct _openslide {
 
   // error handling, NULL if no error
   gpointer error; // must use g_atomic_pointer!
+
+  char *icc_profile;
+  int64_t icc_profile_length;
 };
 
 struct _openslide_level {
@@ -90,10 +93,10 @@ struct _openslide_level {
 /* the function pointer structure for backends */
 struct _openslide_ops {
   bool (*paint_region)(openslide_t *osr, cairo_t *cr,
-		       int64_t x, int64_t y,
-		       struct _openslide_level *level,
-		       int32_t w, int32_t h,
-		       GError **err);
+                       int64_t x, int64_t y,
+                       struct _openslide_level *level,
+                       int32_t w, int32_t h,
+                       GError **err);
   void (*destroy)(openslide_t *osr);
 };
 
@@ -168,6 +171,10 @@ bool _openslide_clip_tile(uint32_t *tiledata,
                           int64_t tile_w, int64_t tile_h,
                           int64_t clip_w, int64_t clip_h,
                           GError **err);
+
+void _openslide_set_icc_profile(openslide_t *osr,
+                                const char *icc_profile,
+                                int64_t icc_profile_length);
 
 
 // File handling
@@ -293,18 +300,18 @@ void _openslide_cache_binding_destroy(struct _openslide_cache_binding *cb);
 
 // put and get
 void _openslide_cache_put(struct _openslide_cache_binding *cb,
-			  void *plane,  // coordinate plane (level or grid)
-			  int64_t x,
-			  int64_t y,
-			  void *data,
-			  uint64_t size_in_bytes,
-			  struct _openslide_cache_entry **entry);
+                          void *plane,  // coordinate plane (level or grid)
+                          int64_t x,
+                          int64_t y,
+                          void *data,
+                          uint64_t size_in_bytes,
+                          struct _openslide_cache_entry **entry);
 
 void *_openslide_cache_get(struct _openslide_cache_binding *cb,
-			   void *plane,
-			   int64_t x,
-			   int64_t y,
-			   struct _openslide_cache_entry **entry);
+                           void *plane,
+                           int64_t x,
+                           int64_t y,
+                           struct _openslide_cache_entry **entry);
 
 // value unref
 void _openslide_cache_entry_unref(struct _openslide_cache_entry *entry);

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -335,3 +335,19 @@ void _openslide_performance_warn_once(gint *warned_flag,
     }
   }
 }
+
+void _openslide_set_icc_profile(openslide_t *osr,
+                                const char *icc_profile,
+                                int64_t icc_profile_length) {
+  if (osr->icc_profile) {
+    g_free(osr->icc_profile);
+    osr->icc_profile = NULL;
+    osr->icc_profile_length = 0;
+  }
+
+  if (icc_profile) {
+    osr->icc_profile = g_malloc(icc_profile_length);
+    memcpy(osr->icc_profile, icc_profile, icc_profile_length);
+    osr->icc_profile_length = icc_profile_length;
+  }
+}

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -118,6 +118,7 @@ static const char MediaStorageSOPClassUID[] = "MediaStorageSOPClassUID";
 static const char VLWholeSlideMicroscopyImageStorage[] =
   "1.2.840.10008.5.1.4.1.1.77.1.6";
 static const char ImageType[] = "ImageType";
+static const char ICCProfile[] = "ICCProfile";
 static const char SeriesInstanceUID[] = "SeriesInstanceUID";
 static const char TotalPixelMatrixColumns[] = "TotalPixelMatrixColumns";
 static const char TotalPixelMatrixRows[] = "TotalPixelMatrixRows";
@@ -231,6 +232,21 @@ static bool get_tag_str(DcmDataSet *dataset,
   DcmElement *element = dcm_dataset_get(NULL, dataset, tag);
   return element &&
          dcm_element_get_value_string(NULL, element, index, result);
+}
+
+static bool get_tag_binary(DcmDataSet *dataset,
+                           const char *keyword,
+                           const char **result,
+                           int64_t *length) {
+  uint32_t tag = dcm_dict_tag_from_keyword(keyword);
+  DcmElement *element = dcm_dataset_get(NULL, dataset, tag);
+  if (!element) {
+    return false;
+  }
+  if (length) {
+    *length = dcm_element_get_length(element);
+  }
+  return dcm_element_get_value_binary(NULL, element, result);
 }
 
 static bool get_tag_decimal_str(DcmDataSet *dataset,
@@ -368,13 +384,13 @@ static void rgb_to_cairo(const uint8_t *rgb, uint32_t *dest,
   }
 }
 
-static bool decode_frame(struct dicom_file *file, 
+static bool decode_frame(struct dicom_file *file,
                          int64_t tile_col, int64_t tile_row,
                          uint32_t *dest, int64_t w, int64_t h,
                          GError **err) {
   g_mutex_lock(&file->lock);
   DcmError *dcm_error = NULL;
-  g_autoptr(DcmFrame) frame = 
+  g_autoptr(DcmFrame) frame =
       dcm_filehandle_read_frame_position(&dcm_error,
                                          file->filehandle,
                                          tile_col, tile_row);
@@ -812,6 +828,17 @@ static bool dicom_open(openslide_t *osr,
 
   // no quickhash yet; disable
   _openslide_hash_disable(quickhash1);
+
+  // attach a copy of the icc profile from the main image
+  const char *icc_profile;
+  int64_t icc_profile_length;
+  struct dicom_level *l = (struct dicom_level *) level_array->pdata[0];
+  DcmDataSet *optical_path;
+  if (get_tag_seq_item(l->file->metadata, OpticalPathSequence, 0, &optical_path) &&
+      get_tag_binary(optical_path,
+                     ICCProfile, &icc_profile, &icc_profile_length)) {
+    _openslide_set_icc_profile(osr, icc_profile, icc_profile_length);
+  }
 
   g_assert(osr->data == NULL);
   g_assert(osr->levels == NULL);

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -345,6 +345,10 @@ void openslide_close(openslide_t *osr) {
 
   g_free(g_atomic_pointer_get(&osr->error));
 
+  if (osr->icc_profile) {
+    g_free(osr->icc_profile);
+  }
+
   g_free(osr);
 }
 
@@ -539,6 +543,18 @@ const char *openslide_get_property_value(openslide_t *osr, const char *name) {
   }
 
   return g_hash_table_lookup(osr->properties, name);
+}
+
+const char *openslide_read_icc_profile(openslide_t *osr, uint64_t *len) {
+  if (openslide_get_error(osr)) {
+    return NULL;
+  }
+
+  if (len) {
+    *len = osr->icc_profile_length;
+  }
+
+  return osr->icc_profile;
 }
 
 const char * const *openslide_get_associated_image_names(openslide_t *osr) {

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -388,6 +388,22 @@ const char * const *openslide_get_property_names(openslide_t *osr);
 OPENSLIDE_PUBLIC()
 const char *openslide_get_property_value(openslide_t *osr, const char *name);
 
+/**
+ * Get the value of the ICC profile.
+ *
+ * This function returns a pointer to openslide's internal copy of the ICC
+ * profile associated with this image, or NULL if no profile is found.
+ *
+ * The return value remains valid as long as osr is valid. A copy should
+ * be made of this memory area if it needs to be valid after osr is closed.
+ *
+ * @param osr The OpenSlide object.
+ * @param len If non-NULL, return the length in bytes of the profile.
+ * @return A pointer to the ICC profile, or NULL if no profile is found.
+ */
+OPENSLIDE_PUBLIC()
+const char *openslide_read_icc_profile(openslide_t *osr, uint64_t *len);
+
 //@}
 
 /**


### PR DESCRIPTION
Implemented for DICOM and TIFF-like slides.

No tests yet.

I added some docs.

I read https://github.com/openslide/openslide/issues/139#issuecomment-1505913849 but (fwiw) preferred this API:

```C
const char *openslide_read_icc_profile(openslide_t *osr, uint64_t *len);
```

ie. a pointer to openslide's internal buffer is returned, and remains valid as long as osr is valid. I wanted to avoid forcing a malloc and copy on every read, since profiles can (very unfortunately) be several 10s of MB. A function like this can also be used for has-property, ie.:

```C
    if (openslide_read_icc_profile(osr, NULL)) {
      // a profile is present
    }
```

The internal API is:

```C
void _openslide_set_icc_profile(openslide_t *osr,
                                const char *icc_profile,
                                int64_t icc_profile_length);
```

Which can be called during slide open, perhaps just after setting the properties. This thing makes a copy of the buffer and keeps it in osr, ready to hand out on request.

Marked as a draft since this is for discussion.