### PR TITLE
Improve jp2k DICOM compatibility

### DIFF
--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -91,12 +91,17 @@ struct allowed_types {
 static const char *const ORIGINAL_TYPES[] = {
   "ORIGINAL", "PRIMARY", "VOLUME", "NONE", NULL
 };
+// if the image has been re-encoded during conversion to DICOM
+static const char *const DERIVED_ORIGINAL_TYPES[] = {
+  "DERIVED", "PRIMARY", "VOLUME", "NONE", NULL
+};
 static const char *const RESAMPLED_TYPES[] = {
   "DERIVED", "PRIMARY", "VOLUME", "RESAMPLED", NULL
 };
 static const char *const *const LEVEL_TYPE_STRINGS[] = {
   ORIGINAL_TYPES,
-  RESAMPLED_TYPES
+  DERIVED_ORIGINAL_TYPES,
+  RESAMPLED_TYPES,
 };
 
 static const struct allowed_types LEVEL_TYPES = {
@@ -110,12 +115,20 @@ static const char OVERVIEW_TYPE[] = "OVERVIEW";
 static const char *const LABEL_TYPES[] = {
   "ORIGINAL", "PRIMARY", LABEL_TYPE, "NONE", NULL
 };
+static const char *const DERIVED_LABEL_TYPES[] = {
+  "DERIVED", "PRIMARY", LABEL_TYPE, "NONE", NULL
+};
 static const char *const OVERVIEW_TYPES[] = {
   "ORIGINAL", "PRIMARY", OVERVIEW_TYPE, "NONE", NULL
 };
+static const char *const DERIVED_OVERVIEW_TYPES[] = {
+  "DERIVED", "PRIMARY", OVERVIEW_TYPE, "NONE", NULL
+};
 static const char *const *const ASSOCIATED_TYPE_STRINGS[] = {
   LABEL_TYPES,
-  OVERVIEW_TYPES
+  DERIVED_LABEL_TYPES,
+  OVERVIEW_TYPES,
+  DERIVED_OVERVIEW_TYPES,
 };
 static const struct allowed_types ASSOCIATED_TYPES = {
   ASSOCIATED_TYPE_STRINGS,
@@ -166,11 +179,12 @@ static void print_file(struct dicom_file *f G_GNUC_UNUSED) {
   debug("  filehandle = %p", f->filehandle);
   debug("  file_meta = %p", f->file_meta);
   debug("  metadata = %p", f->metadata);
+  debug("  format = %d", f->format);
 }
 
 static void print_level(struct dicom_level *l) {
-  debug("level:" );
   print_file(l->file);
+  debug("level:" );
   debug("  base.downsample = %g", l->base.downsample);
   debug("  base.w = %" PRId64, l->base.w);
   debug("  base.h = %" PRId64, l->base.h);
@@ -612,6 +626,9 @@ static bool add_associated(openslide_t *osr,
     // is_type() let something unexpected through
     g_assert_not_reached();
   }
+
+  debug("add_associated: %s\n", name);
+  print_file(f);
 
   // add
   g_hash_table_insert(osr->associated_images,

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -390,7 +390,7 @@ static struct dicom_file *dicom_file_new(const char *filename, GError **err) {
     return NULL;
   }
 
-  f->metadata = dcm_filehandle_read_metadata(&dcm_error, f->filehandle);
+  f->metadata = dcm_filehandle_read_metadata(&dcm_error, f->filehandle, NULL);
   if (!f->metadata) {
     _openslide_dicom_propagate_error(err, dcm_error);
     return NULL;

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -112,6 +112,7 @@ static const struct allowed_types LEVEL_TYPES = {
 // the ImageTypes we allow for associated images
 static const char LABEL_TYPE[] = "LABEL";
 static const char OVERVIEW_TYPE[] = "OVERVIEW";
+static const char THUMBNAIL_TYPE[] = "THUMBNAIL";
 static const char *const LABEL_TYPES[] = {
   "ORIGINAL", "PRIMARY", LABEL_TYPE, "NONE", NULL
 };
@@ -124,11 +125,19 @@ static const char *const OVERVIEW_TYPES[] = {
 static const char *const DERIVED_OVERVIEW_TYPES[] = {
   "DERIVED", "PRIMARY", OVERVIEW_TYPE, "NONE", NULL
 };
+static const char *const THUMBNAIL_TYPES[] = {
+  "ORIGINAL", "PRIMARY", THUMBNAIL_TYPE, "RESAMPLED", NULL
+};
+static const char *const DERIVED_THUMBNAIL_TYPES[] = {
+  "DERIVED", "PRIMARY", THUMBNAIL_TYPE, "RESAMPLED", NULL
+};
 static const char *const *const ASSOCIATED_TYPE_STRINGS[] = {
   LABEL_TYPES,
   DERIVED_LABEL_TYPES,
   OVERVIEW_TYPES,
   DERIVED_OVERVIEW_TYPES,
+  THUMBNAIL_TYPES,
+  DERIVED_THUMBNAIL_TYPES,
 };
 static const struct allowed_types ASSOCIATED_TYPES = {
   ASSOCIATED_TYPE_STRINGS,
@@ -622,6 +631,8 @@ static bool add_associated(openslide_t *osr,
     name = "label";
   } else if (g_str_equal(image_type[2], OVERVIEW_TYPE)) {
     name = "macro";
+  } else if (g_str_equal(image_type[2], THUMBNAIL_TYPE)) {
+    name = "thumbnail";
   } else {
     // is_type() let something unexpected through
     g_assert_not_reached();

--- a/src/openslide-vendor-synthetic.c
+++ b/src/openslide-vendor-synthetic.c
@@ -119,7 +119,8 @@ static bool decode_dicom(const void *data, uint32_t len,
 
   // read Data Set metadata and frame
   // this will pull the rest of the header in, so _read_frame() will work
-  g_autoptr(DcmDataSet) metadata = dcm_filehandle_read_metadata(&dcm_error, fh);
+  g_autoptr(DcmDataSet) metadata =
+    dcm_filehandle_read_metadata(&dcm_error, fh, NULL);
   if (!metadata) {
     _openslide_dicom_propagate_error(err, dcm_error);
     g_prefix_error(err, "Reading metadata: ");

--- a/subprojects/libdicom.wrap
+++ b/subprojects/libdicom.wrap
@@ -2,5 +2,5 @@
 # NOTE: temporary fork for now
 # https://github.com/openslide/openslide-winbuild/issues/82
 url = https://github.com/jcupitt/libdicom.git
-revision = 6dfb2b870143e37b4f5620b59e12b3dbefb40c8f
+revision = 532879925086b3d8cfc7b3c090af96fa2ea6589a
 depth = 1


### PR DESCRIPTION
1. Allow DERIVED associated images and DERIVED level 0
2. Support THUMBNAIL associated images
3. Fix color channels in uncompressed RGB images

See https://github.com/openslide/openslide/issues/462