### PR TITLE
Revise dicom compression detection

### DIFF
--- a/subprojects/libdicom.wrap
+++ b/subprojects/libdicom.wrap
@@ -2,5 +2,5 @@
 # NOTE: temporary fork for now
 # https://github.com/openslide/openslide-winbuild/issues/82
 url = https://github.com/jcupitt/libdicom.git
-revision = a6c42cbcf309677df933dc3617b9e760e2af41ee
+revision = 6dfb2b870143e37b4f5620b59e12b3dbefb40c8f
 depth = 1


### PR DESCRIPTION
Compression is set solely by transfer syntax.

Fixes https://github.com/openslide/openslide/issues/462

With this PR I see:

```
$ ./driver run
aperio: OK
aperio-33003: OK
...
ventana-truncated-top-level: OK
ventana-untiled-level: OK

Failed: 0/308
```