### PR TITLE
Add ICC profile support

### DIFF
--- a/src/openslide-decode-tiff.h
+++ b/src/openslide-decode-tiff.h
@@ -92,6 +92,20 @@ bool _openslide_tiff_set_dir(TIFF *tiff,
                              GError **err);
 
 
+// get the profile size from a level for osr->icc_profile_size
+bool _openslide_tiff_get_icc_profile_size(struct _openslide_tiff_level *tiffl,
+                                          TIFF *tiff,
+                                          int64_t *icc_profile_size,
+                                          GError **err);
+
+// read the profile from a level
+bool _openslide_tiff_read_icc_profile(openslide_t *osr,
+                                      struct _openslide_tiff_level *tiffl,
+                                      TIFF *tiff,
+                                      void *dest,
+                                      GError **err);
+
+
 /* TIFF handles are not thread-safe, so we have a handle cache for
    multithreaded access */
 struct _openslide_tiffcache *_openslide_tiffcache_create(const char *filename);

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -68,6 +68,9 @@ struct _openslide {
   GHashTable *properties; // created automatically
   const char **property_names; // filled in automatically from hashtable
 
+  // the size in bytes of the ICC profile, or 0 for no profile available
+  int64_t icc_profile_size;
+
   // cache
   struct _openslide_cache_binding *cache;
 
@@ -94,6 +97,7 @@ struct _openslide_ops {
                        struct _openslide_level *level,
                        int32_t w, int32_t h,
                        GError **err);
+  bool (*read_icc_profile)(openslide_t *osr, void *dest, GError **err);
   void (*destroy)(openslide_t *osr);
 };
 

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -90,10 +90,10 @@ struct _openslide_level {
 /* the function pointer structure for backends */
 struct _openslide_ops {
   bool (*paint_region)(openslide_t *osr, cairo_t *cr,
-		       int64_t x, int64_t y,
-		       struct _openslide_level *level,
-		       int32_t w, int32_t h,
-		       GError **err);
+                       int64_t x, int64_t y,
+                       struct _openslide_level *level,
+                       int32_t w, int32_t h,
+                       GError **err);
   void (*destroy)(openslide_t *osr);
 };
 
@@ -293,18 +293,18 @@ void _openslide_cache_binding_destroy(struct _openslide_cache_binding *cb);
 
 // put and get
 void _openslide_cache_put(struct _openslide_cache_binding *cb,
-			  void *plane,  // coordinate plane (level or grid)
-			  int64_t x,
-			  int64_t y,
-			  void *data,
-			  uint64_t size_in_bytes,
-			  struct _openslide_cache_entry **entry);
+                          void *plane,  // coordinate plane (level or grid)
+                          int64_t x,
+                          int64_t y,
+                          void *data,
+                          uint64_t size_in_bytes,
+                          struct _openslide_cache_entry **entry);
 
 void *_openslide_cache_get(struct _openslide_cache_binding *cb,
-			   void *plane,
-			   int64_t x,
-			   int64_t y,
-			   struct _openslide_cache_entry **entry);
+                           void *plane,
+                           int64_t x,
+                           int64_t y,
+                           struct _openslide_cache_entry **entry);
 
 // value unref
 void _openslide_cache_entry_unref(struct _openslide_cache_entry *entry);

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -238,8 +238,21 @@ static bool paint_region(openslide_t *osr, cairo_t *cr,
                                       err);
 }
 
+static bool read_icc_profile(openslide_t *osr, void *dest, GError **err) {
+  struct level *l = (struct level *) osr->levels[0];
+  struct aperio_ops_data *data = osr->data;
+
+  g_auto(_openslide_cached_tiff) ct = _openslide_tiffcache_get(data->tc, err);
+  if (!ct.tiff) {
+    return false;
+  }
+
+  return _openslide_tiff_read_icc_profile(osr, &l->tiffl, ct.tiff, dest, err);
+}
+
 static const struct _openslide_ops aperio_ops = {
   .paint_region = paint_region,
+  .read_icc_profile = read_icc_profile,
   .destroy = destroy,
 };
 
@@ -514,6 +527,15 @@ static bool aperio_open(openslide_t *osr,
   }
   g_auto(GStrv) props = g_strsplit(image_desc, "|", -1);
   add_properties(osr, props);
+
+  // get icc profile size, if present
+  struct level *base_level = level_array->pdata[0];
+  if (!_openslide_tiff_get_icc_profile_size(&base_level->tiffl,
+                                            ct.tiff,
+                                            &osr->icc_profile_size,
+                                            err)) {
+    return false;
+  }
 
   // set hash and properties
   struct level *top_level = level_array->pdata[level_array->len - 1];

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -171,25 +171,25 @@ static const char Rows[] = "Rows";
 static const char SamplesPerPixel[] = "SamplesPerPixel";
 static const char SeriesInstanceUID[] = "SeriesInstanceUID";
 static const char SharedFunctionalGroupsSequence[] =
-    "SharedFunctionalGroupsSequence";
+  "SharedFunctionalGroupsSequence";
 static const char SOPInstanceUID[] = "SOPInstanceUID";
 static const char TotalPixelMatrixColumns[] = "TotalPixelMatrixColumns";
 static const char TotalPixelMatrixRows[] = "TotalPixelMatrixRows";
 static const char VLWholeSlideMicroscopyImageStorage[] =
-    "1.2.840.10008.5.1.4.1.1.77.1.6";
+  "1.2.840.10008.5.1.4.1.1.77.1.6";
 
 // the transfer syntaxes we support, and the format we use to decode pixels
 static struct syntax_format supported_syntax_formats[] = {
-    // simple uncompressed array
-    { "1.2.840.10008.1.2.1", FORMAT_RGB },
+  // simple uncompressed array
+  { "1.2.840.10008.1.2.1", FORMAT_RGB },
 
-    // jpeg baseline, we don't handle lossless or 12 bit
-    { "1.2.840.10008.1.2.4.50", FORMAT_JPEG },
+  // jpeg baseline, we don't handle lossless or 12 bit
+  { "1.2.840.10008.1.2.4.50", FORMAT_JPEG },
 
-    // lossless and lossy jp2k
-    // we separate RGB and YCbCr with other tags
-    { "1.2.840.10008.1.2.4.90", FORMAT_JPEG2000 },
-    { "1.2.840.10008.1.2.4.91", FORMAT_JPEG2000 },
+  // lossless and lossy jp2k
+  // we separate RGB and YCbCr with other tags
+  { "1.2.840.10008.1.2.4.90", FORMAT_JPEG2000 },
+  { "1.2.840.10008.1.2.4.91", FORMAT_JPEG2000 },
 };
 
 static void print_file(struct dicom_file *f G_GNUC_UNUSED) {
@@ -391,7 +391,7 @@ static struct dicom_file *dicom_file_new(const char *filename, GError **err) {
     return NULL;
   }
 
-  if (!get_format(dcm_filehandle_get_transfer_syntax_uid(f->filehandle), 
+  if (!get_format(dcm_filehandle_get_transfer_syntax_uid(f->filehandle),
                   &f->format, err)) {
     return NULL;
   }

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -158,6 +158,7 @@ static const char BitsAllocated[] = "BitsAllocated";
 static const char BitsStored[] = "BitsStored";
 static const char Columns[] = "Columns";
 static const char HighBit[] = "HighBit";
+static const char ICCProfile[] = "ICCProfile";
 static const char ImageType[] = "ImageType";
 static const char MediaStorageSOPClassUID[] = "MediaStorageSOPClassUID";
 static const char ObjectiveLensPower[] = "ObjectiveLensPower";
@@ -278,6 +279,24 @@ static bool get_tag_str(const DcmDataSet *dataset,
   DcmElement *element = dcm_dataset_get(NULL, dataset, tag);
   return element &&
          dcm_element_get_value_string(NULL, element, index, result);
+}
+
+static bool get_tag_binary(const DcmDataSet *dataset,
+                           const char *keyword,
+                           const void **result,
+                           int64_t *length) {
+  uint32_t tag = dcm_dict_tag_from_keyword(keyword);
+  DcmElement *element = dcm_dataset_get(NULL, dataset, tag);
+  if (!element) {
+    return false;
+  }
+  if (!dcm_element_get_value_binary(NULL, element, result)) {
+    return false;
+  }
+  if (length) {
+    *length = dcm_element_get_length(element);
+  }
+  return true;
 }
 
 static bool get_tag_decimal_str(const DcmDataSet *dataset,
@@ -558,8 +577,43 @@ static bool paint_region(openslide_t *osr G_GNUC_UNUSED,
                                       err);
 }
 
+static const void *get_icc_profile(struct dicom_level *level, int64_t *len) {
+  const DcmDataSet *metadata = level->file->metadata;
+
+  DcmDataSet *optical_path;
+  const void *icc_profile;
+  if (!get_tag_seq_item(metadata, OpticalPathSequence, 0, &optical_path) ||
+      !get_tag_binary(optical_path, ICCProfile, &icc_profile, len)) {
+    return NULL;
+  }
+
+  return icc_profile;
+}
+
+static bool read_icc_profile(openslide_t *osr, void *dest,
+                             GError **err) {
+  struct dicom_level *l = (struct dicom_level *) osr->levels[0];
+  int64_t icc_profile_size;
+  const void *icc_profile = get_icc_profile(l, &icc_profile_size);
+  if (!icc_profile) {
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "No ICC profile");
+    return false;
+  }
+  if (icc_profile_size != osr->icc_profile_size) {
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "ICC profile size changed");
+    return false;
+  }
+
+  memcpy(dest, icc_profile, icc_profile_size);
+
+  return true;
+}
+
 static const struct _openslide_ops dicom_ops = {
   .paint_region = paint_region,
+  .read_icc_profile = read_icc_profile,
   .destroy = destroy,
 };
 
@@ -1052,6 +1106,8 @@ static bool dicom_open(openslide_t *osr,
   }
 
   add_properties(osr, level_array->pdata[0]);
+
+  (void) get_icc_profile(level_array->pdata[0], &osr->icc_profile_size);
 
   // no quickhash yet; disable
   _openslide_hash_disable(quickhash1);

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -541,6 +541,31 @@ const char *openslide_get_property_value(openslide_t *osr, const char *name) {
   return g_hash_table_lookup(osr->properties, name);
 }
 
+int64_t openslide_get_icc_profile_size(openslide_t *osr) {
+  if (openslide_get_error(osr)) {
+    return -1;
+  }
+
+  return osr->icc_profile_size;
+}
+
+void openslide_read_icc_profile(openslide_t *osr, void *dest) {
+  if (openslide_get_error(osr)) {
+    memset(dest, 0, osr->icc_profile_size);
+    return;
+  }
+  if (!osr->icc_profile_size) {
+    return;
+  }
+  g_assert(osr->ops->read_icc_profile);
+
+  GError *tmp_err = NULL;
+  if (!osr->ops->read_icc_profile(osr, dest, &tmp_err)) {
+    _openslide_propagate_error(osr, tmp_err);
+    memset(dest, 0, osr->icc_profile_size);
+  }
+}
+
 const char * const *openslide_get_associated_image_names(openslide_t *osr) {
   if (openslide_get_error(osr)) {
     return EMPTY_STRING_ARRAY;

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -390,6 +390,44 @@ const char *openslide_get_property_value(openslide_t *osr, const char *name);
 //@}
 
 /**
+ * @name ICC profiles
+ * Reading ICC profiles.
+ *
+ * Some slides contain embedded ICC profiles which can be used to transform
+ * pixel colors for display. These functions allow reading ICC profile data.
+ */
+//@{
+
+/**
+ * Get the size in bytes of the ICC profile for the whole slide image.
+ *
+ * @param osr The OpenSlide object.
+ * @return -1 on error, 0 if no profile is available, otherwise the profile
+ * size in bytes.
+ */
+OPENSLIDE_PUBLIC()
+int64_t openslide_get_icc_profile_size(openslide_t *osr);
+
+/**
+ * Copy the ICC profile from a whole slide image.
+ *
+ * This function reads the ICC profile from the slide into the specified
+ * memory location.  @p dest must be a valid pointer to enough memory
+ * to hold the profile.  Get the profile size with
+ * openslide_get_icc_profile_size().
+ *
+ * If an error occurs or has occurred, then the memory pointed to by @p dest
+ * will be cleared.
+ *
+ * @param osr The OpenSlide object.
+ * @param dest The destination buffer for the ICC profile.
+ */
+OPENSLIDE_PUBLIC()
+void openslide_read_icc_profile(openslide_t *osr, void *dest);
+
+//@}
+
+/**
  * @name Associated Images
  * Reading associated images.
  *

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -373,7 +373,6 @@ const char *openslide_get_error(openslide_t *osr);
 OPENSLIDE_PUBLIC()
 const char * const *openslide_get_property_names(openslide_t *osr);
 
-
 /**
  * Get the value of a single property.
  *

--- a/test/extended.c
+++ b/test/extended.c
@@ -284,6 +284,14 @@ int main(int argc, char **argv) {
     associated_image_names++;
   }
 
+  // read ICC profile
+  int64_t icc_len = openslide_get_icc_profile_size(osr);
+  if (icc_len >= 0) {
+    g_autofree void *buf = g_malloc(icc_len);
+    openslide_read_icc_profile(osr, buf);
+  }
+  common_fail_on_error(osr, "Reading ICC profile failed");
+
   test_image_fetch(osr, -10, -10, 200, 200);
   test_image_fetch(osr, w/2, h/2, 500, 500);
   test_image_fetch(osr, w - 200, h - 100, 500, 400);


### PR DESCRIPTION
This adds two new functions:

```C
bool openslide_icc_profile_size(openslide_t *osr, int64_t *len);
bool openslide_icc_profile_read(openslide_t *osr, void *dest, int64_t len);
```

To get the size of the profile in bytes, and then to read the profile to an allocated buffer. `openslide_icc_profile_size()` returns `true` and sets `len` to 0 if no profile is available for this slide, but no other error was encountered.

These two functions execute two member functions of `_openslide_ops`, which loaders can optionally define.

`openslide-decode-tiff.c` has two helpers. Support is implemented for DICOM, Ventana, Aperio and generic TIFF.

`tes/try_open.c` has a new `profile` flag, and `aperio` and `dicom` have tests. The sample slides for Ventana and generic TIFF don't have embedded profiles, so we can't test them yet, though as they use the same helpers as Aperio, which we do test, they should be reasonably safe.

This PR replaces #461