### PR TITLE
Forbid NULL `dest` in `openslide_read_associated_image()`

### DIFF
--- a/src/openslide.c
+++ b/src/openslide.c
@@ -577,25 +577,15 @@ void openslide_read_associated_image(openslide_t *osr,
   size_t pixels = img->w * img->h;
 
   if (openslide_get_error(osr)) {
-    if (dest) {
-      memset(dest, 0, pixels * sizeof(uint32_t));
-    }
+    memset(dest, 0, pixels * sizeof(uint32_t));
     return;
   }
 
-  g_autofree uint32_t *tmp_buf = NULL;
-  if (!dest) {
-    // undocumented special case for testing
-    tmp_buf = g_new(uint32_t, pixels);
-  }
-
   GError *tmp_err = NULL;
-  if (!img->ops->get_argb_data(img, dest ? dest : tmp_buf, &tmp_err)) {
+  if (!img->ops->get_argb_data(img, dest, &tmp_err)) {
     _openslide_propagate_error(osr, tmp_err);
-    if (dest) {
-      // ensure we don't return a partial result
-      memset(dest, 0, pixels * sizeof(uint32_t));
-    }
+    // ensure we don't return a partial result
+    memset(dest, 0, pixels * sizeof(uint32_t));
   }
 }
 

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -126,8 +126,6 @@ static void check_api_failures(openslide_t *osr) {
             -1, -1);
 
   openslide_read_region(osr, NULL, 0, 0, 0, 10, 10);
-  openslide_read_associated_image(osr, "label", NULL);
-  openslide_read_associated_image(osr, "macro", NULL);
 }
 
 static void check_props(openslide_t *osr) {


### PR DESCRIPTION
A NULL `dest` argument has been permitted since `openslide_read_associated_image()` was first added in 85c617fa3e, but the function has always been documented to require a valid pointer.  Unlike in `openslide_read_region()`, there's no real benefit to supporting NULL here, even for testing, since we end up having to allocate the buffer on the caller's behalf.  Since we're making ABI changes anyway, clean this up.

This is an ABI change.