### PR TITLE
Add `openslide.icc-size` property with ICC profile size

### DIFF
--- a/src/openslide.c
+++ b/src/openslide.c
@@ -282,6 +282,11 @@ openslide_t *openslide_open(const char *filename) {
   g_hash_table_insert(osr->properties,
                       g_strdup(OPENSLIDE_PROPERTY_NAME_VENDOR),
                       g_strdup(format->vendor));
+  if (osr->icc_profile_size) {
+    g_hash_table_insert(osr->properties,
+                        g_strdup(OPENSLIDE_PROPERTY_NAME_ICC_SIZE),
+                        g_strdup_printf("%"PRId64, osr->icc_profile_size));
+  }
   g_hash_table_insert(osr->properties,
 		      g_strdup(_OPENSLIDE_PROPERTY_NAME_LEVEL_COUNT),
 		      g_strdup_printf("%d", osr->level_count));

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -260,27 +260,6 @@ const char *openslide_get_error(openslide_t *osr);
 //@{
 
 /**
- * The name of the property containing a slide's comment, if any.
- *
- * @since 3.0.0
- */
-#define OPENSLIDE_PROPERTY_NAME_COMMENT "openslide.comment"
-
-/**
- * The name of the property containing an identification of the vendor.
- *
- * @since 3.0.0
- */
-#define OPENSLIDE_PROPERTY_NAME_VENDOR "openslide.vendor"
-
-/**
- * The name of the property containing the "quickhash-1" sum.
- *
- * @since 3.0.0
- */
-#define OPENSLIDE_PROPERTY_NAME_QUICKHASH1 "openslide.quickhash-1"
-
-/**
  * The name of the property containing a slide's background color, if any.
  * It is represented as an RGB hex triplet.
  *
@@ -289,27 +268,20 @@ const char *openslide_get_error(openslide_t *osr);
 #define OPENSLIDE_PROPERTY_NAME_BACKGROUND_COLOR "openslide.background-color"
 
 /**
- * The name of the property containing a slide's objective power, if known.
+ * The name of the property containing the height of the rectangle bounding
+ * the non-empty region of the slide, if available.
  *
- * @since 3.3.0
+ * @since 3.4.0
  */
-#define OPENSLIDE_PROPERTY_NAME_OBJECTIVE_POWER "openslide.objective-power"
+#define OPENSLIDE_PROPERTY_NAME_BOUNDS_HEIGHT "openslide.bounds-height"
 
 /**
- * The name of the property containing the number of microns per pixel in
- * the X dimension of level 0, if known.
+ * The name of the property containing the width of the rectangle bounding
+ * the non-empty region of the slide, if available.
  *
- * @since 3.3.0
+ * @since 3.4.0
  */
-#define OPENSLIDE_PROPERTY_NAME_MPP_X "openslide.mpp-x"
-
-/**
- * The name of the property containing the number of microns per pixel in
- * the Y dimension of level 0, if known.
- *
- * @since 3.3.0
- */
-#define OPENSLIDE_PROPERTY_NAME_MPP_Y "openslide.mpp-y"
+#define OPENSLIDE_PROPERTY_NAME_BOUNDS_WIDTH "openslide.bounds-width"
 
 /**
  * The name of the property containing the X coordinate of the rectangle
@@ -328,20 +300,49 @@ const char *openslide_get_error(openslide_t *osr);
 #define OPENSLIDE_PROPERTY_NAME_BOUNDS_Y "openslide.bounds-y"
 
 /**
- * The name of the property containing the width of the rectangle bounding
- * the non-empty region of the slide, if available.
+ * The name of the property containing a slide's comment, if any.
  *
- * @since 3.4.0
+ * @since 3.0.0
  */
-#define OPENSLIDE_PROPERTY_NAME_BOUNDS_WIDTH "openslide.bounds-width"
+#define OPENSLIDE_PROPERTY_NAME_COMMENT "openslide.comment"
 
 /**
- * The name of the property containing the height of the rectangle bounding
- * the non-empty region of the slide, if available.
+ * The name of the property containing the number of microns per pixel in
+ * the X dimension of level 0, if known.
  *
- * @since 3.4.0
+ * @since 3.3.0
  */
-#define OPENSLIDE_PROPERTY_NAME_BOUNDS_HEIGHT "openslide.bounds-height"
+#define OPENSLIDE_PROPERTY_NAME_MPP_X "openslide.mpp-x"
+
+/**
+ * The name of the property containing the number of microns per pixel in
+ * the Y dimension of level 0, if known.
+ *
+ * @since 3.3.0
+ */
+#define OPENSLIDE_PROPERTY_NAME_MPP_Y "openslide.mpp-y"
+
+/**
+ * The name of the property containing a slide's objective power, if known.
+ *
+ * @since 3.3.0
+ */
+#define OPENSLIDE_PROPERTY_NAME_OBJECTIVE_POWER "openslide.objective-power"
+
+/**
+ * The name of the property containing the "quickhash-1" sum.
+ *
+ * @since 3.0.0
+ */
+#define OPENSLIDE_PROPERTY_NAME_QUICKHASH1 "openslide.quickhash-1"
+
+/**
+ * The name of the property containing an identification of the vendor.
+ *
+ * @since 3.0.0
+ */
+#define OPENSLIDE_PROPERTY_NAME_VENDOR "openslide.vendor"
+
 //@}
 
 /**

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -307,6 +307,14 @@ const char *openslide_get_error(openslide_t *osr);
 #define OPENSLIDE_PROPERTY_NAME_COMMENT "openslide.comment"
 
 /**
+ * The name of the property containing the size of a slide's ICC profile,
+ * if any.
+ *
+ * @since 4.0.0
+ */
+#define OPENSLIDE_PROPERTY_NAME_ICC_SIZE "openslide.icc-size"
+
+/**
  * The name of the property containing the number of microns per pixel in
  * the X dimension of level 0, if known.
  *

--- a/test/cases/aperio/config.yaml
+++ b/test/cases/aperio/config.yaml
@@ -4,5 +4,6 @@ success: true
 vendor: aperio
 primary: true
 properties:
+  openslide.icc-size: "141992"
   openslide.quickhash-1: 30f1a38031fc0e21d81f9d01435ac4af848f6fe2bbf8f7768184336ee5d7e796
   openslide.vendor: aperio

--- a/test/cases/dicom-tiled-full-jp2k-rgb/config.yaml
+++ b/test/cases/dicom-tiled-full-jp2k-rgb/config.yaml
@@ -5,4 +5,5 @@ vendor: dicom
 primary: true
 requires: [dicom]
 properties:
+  openslide.icc-size: "3144"
   openslide.vendor: dicom

--- a/test/cases/dicom-tiled-full-jp2k-ycbcr/config.yaml
+++ b/test/cases/dicom-tiled-full-jp2k-ycbcr/config.yaml
@@ -5,4 +5,5 @@ vendor: dicom
 primary: true
 requires: [dicom]
 properties:
+  openslide.icc-size: "141992"
   openslide.vendor: dicom

--- a/test/cases/dicom-tiled-full-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-full-jpeg/config.yaml
@@ -5,4 +5,5 @@ vendor: dicom
 primary: true
 requires: [dicom]
 properties:
+  openslide.icc-size: "63928"
   openslide.vendor: dicom

--- a/test/cases/dicom-tiled-sparse-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-sparse-jpeg/config.yaml
@@ -5,4 +5,5 @@ vendor: dicom
 primary: true
 requires: [dicom]
 properties:
+  openslide.icc-size: "13113264"
   openslide.vendor: dicom


### PR DESCRIPTION
This makes it possible to tell whether an ICC profile was detected by looking at the property output, and also makes it easy for tests to check for a profile.