### PR TITLE
Add properties for associated image width, height, and ICC profile

### DIFF
--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -372,6 +372,9 @@ void _openslide_performance_warn_once(gint *warned_flag,
 #define _OPENSLIDE_PROPERTY_NAME_TEMPLATE_REGION_Y "openslide.region[%d].y"
 #define _OPENSLIDE_PROPERTY_NAME_TEMPLATE_REGION_WIDTH "openslide.region[%d].width"
 #define _OPENSLIDE_PROPERTY_NAME_TEMPLATE_REGION_HEIGHT "openslide.region[%d].height"
+#define _OPENSLIDE_PROPERTY_NAME_TEMPLATE_ASSOCIATED_WIDTH "openslide.associated.%s.width"
+#define _OPENSLIDE_PROPERTY_NAME_TEMPLATE_ASSOCIATED_HEIGHT "openslide.associated.%s.height"
+#define _OPENSLIDE_PROPERTY_NAME_TEMPLATE_ASSOCIATED_ICC_SIZE "openslide.associated.%s.icc-size"
 
 /* Tables */
 // YCbCr -> RGB chroma contributions

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -322,8 +322,25 @@ openslide_t *openslide_open(const char *filename) {
     }
   }
 
-  // fill in names
+  // fill in associated image names and set properties
   osr->associated_image_names = strv_from_hashtable_keys(osr->associated_images);
+  for (const char **name = osr->associated_image_names; *name != NULL; name++) {
+    struct _openslide_associated_image *img =
+      g_hash_table_lookup(osr->associated_images, *name);
+    g_hash_table_insert(osr->properties,
+			g_strdup_printf(_OPENSLIDE_PROPERTY_NAME_TEMPLATE_ASSOCIATED_WIDTH, *name),
+			g_strdup_printf("%"PRId64, img->w));
+    g_hash_table_insert(osr->properties,
+			g_strdup_printf(_OPENSLIDE_PROPERTY_NAME_TEMPLATE_ASSOCIATED_HEIGHT, *name),
+			g_strdup_printf("%"PRId64, img->h));
+    if (img->icc_profile_size) {
+      g_hash_table_insert(osr->properties,
+                          g_strdup_printf(_OPENSLIDE_PROPERTY_NAME_TEMPLATE_ASSOCIATED_ICC_SIZE, *name),
+                          g_strdup_printf("%"PRId64, img->icc_profile_size));
+    }
+  }
+
+  // fill in property names
   osr->property_names = strv_from_hashtable_keys(osr->properties);
 
   // start cache

--- a/test/cases/dicom-tiled-full-jp2k-rgb/config.yaml
+++ b/test/cases/dicom-tiled-full-jp2k-rgb/config.yaml
@@ -5,5 +5,8 @@ vendor: dicom
 primary: true
 requires: [dicom]
 properties:
+  openslide.associated.label.icc-size: "3144"
+  openslide.associated.macro.icc-size: "3144"
+  openslide.associated.thumbnail.icc-size: "3144"
   openslide.icc-size: "3144"
   openslide.vendor: dicom

--- a/test/cases/dicom-tiled-full-jp2k-ycbcr/config.yaml
+++ b/test/cases/dicom-tiled-full-jp2k-ycbcr/config.yaml
@@ -5,5 +5,8 @@ vendor: dicom
 primary: true
 requires: [dicom]
 properties:
+  openslide.associated.label.icc-size: "141992"
+  openslide.associated.macro.icc-size: "141992"
+  openslide.associated.thumbnail.icc-size: "141992"
   openslide.icc-size: "141992"
   openslide.vendor: dicom

--- a/test/cases/dicom-tiled-full-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-full-jpeg/config.yaml
@@ -5,5 +5,7 @@ vendor: dicom
 primary: true
 requires: [dicom]
 properties:
+  openslide.associated.label.icc-size: "63928"
+  openslide.associated.macro.icc-size: "63928"
   openslide.icc-size: "63928"
   openslide.vendor: dicom

--- a/test/cases/dicom-tiled-sparse-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-sparse-jpeg/config.yaml
@@ -5,5 +5,6 @@ vendor: dicom
 primary: true
 requires: [dicom]
 properties:
+  openslide.associated.thumbnail.icc-size: "13113264"
   openslide.icc-size: "13113264"
   openslide.vendor: dicom


### PR DESCRIPTION
Associated images currently aren't represented in properties at all, which isn't entirely helpful for debugging.  Add the width, height, and ICC profile size of each associated image in the form `openslide.associated.$name.{width,height,icc-size}`.

For the prefix, I also considered `openslide.associated-image`.  That would be consistent with OpenSlide's standard terminology, e.g. in C API function names, but in a property listing it'd make the names longer (and arguably less readable) for little actual value.  `associated.label` could be read as "the associated label" so there's some logic to the shorter names.

For the image names I also considered `openslide.associated[$name]`, `openslide.associated["$name"]`, and `openslide.$name`.  We've only used brackets for array indexes, and anyway the set of image names is controlled by OpenSlide, so it seemed cleanest to use a separate hierarchy element for the name.  `openslide.$name` is compelling, but makes it harder to tell which properties correspond to associated images; namespacing them makes e.g. `grep ^openslide.associated` possible.

As with the other templated properties, leave them undocumented for now.