### PR TITLE
Add API for reading associated image ICC profiles

### DIFF
--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -42,6 +42,9 @@ struct _openslide_associated_image {
 
   int64_t w;
   int64_t h;
+
+  // the size in bytes of the ICC profile, or 0 for no profile available
+  int64_t icc_profile_size;
 };
 
 /* associated image operations */
@@ -50,6 +53,9 @@ struct _openslide_associated_image_ops {
   bool (*get_argb_data)(struct _openslide_associated_image *img,
                         uint32_t *dest,
                         GError **err);
+  // must fail if img->icc_profile_size doesn't match the profile
+  bool (*read_icc_profile)(struct _openslide_associated_image *img,
+                           void *dest, GError **err);
   void (*destroy)(struct _openslide_associated_image *img);
 };
 

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -97,6 +97,7 @@ struct _openslide_ops {
                        struct _openslide_level *level,
                        int32_t w, int32_t h,
                        GError **err);
+  // must fail if osr->icc_profile_size doesn't match the profile
   bool (*read_icc_profile)(openslide_t *osr, void *dest, GError **err);
   void (*destroy)(openslide_t *osr);
 };

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -577,8 +577,8 @@ static bool paint_region(openslide_t *osr G_GNUC_UNUSED,
                                       err);
 }
 
-static const void *get_icc_profile(struct dicom_level *level, int64_t *len) {
-  const DcmDataSet *metadata = level->file->metadata;
+static const void *get_icc_profile(struct dicom_file *file, int64_t *len) {
+  const DcmDataSet *metadata = file->metadata;
 
   DcmDataSet *optical_path;
   const void *icc_profile;
@@ -594,7 +594,7 @@ static bool read_icc_profile(openslide_t *osr, void *dest,
                              GError **err) {
   struct dicom_level *l = (struct dicom_level *) osr->levels[0];
   int64_t icc_profile_size;
-  const void *icc_profile = get_icc_profile(l, &icc_profile_size);
+  const void *icc_profile = get_icc_profile(l->file, &icc_profile_size);
   if (!icc_profile) {
     g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                 "No ICC profile");
@@ -1105,9 +1105,10 @@ static bool dicom_open(openslide_t *osr,
     print_level(l);
   }
 
-  add_properties(osr, level_array->pdata[0]);
+  struct dicom_level *level0 = level_array->pdata[0];
+  add_properties(osr, level0);
 
-  (void) get_icc_profile(level_array->pdata[0], &osr->icc_profile_size);
+  (void) get_icc_profile(level0->file, &osr->icc_profile_size);
 
   // no quickhash yet; disable
   _openslide_hash_disable(quickhash1);

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -487,6 +487,11 @@ void openslide_get_associated_image_dimensions(openslide_t *osr,
  * will be cleared. In versions prior to 4.0.0, this function did nothing
  * if an error occurred.
  *
+ * The returned pixel data is in the color space of the associated image,
+ * which may or may not be sRGB.  You can get the ICC profile for the
+ * associated image's color space, if available, with
+ * openslide_read_associated_image_icc_profile().
+ *
  * For more information about processing pre-multiplied pixel data, see
  * the [OpenSlide website](https://openslide.org/docs/premultiplied-argb/).
  *
@@ -499,6 +504,43 @@ OPENSLIDE_PUBLIC()
 void openslide_read_associated_image(openslide_t *osr,
 				     const char *name,
 				     uint32_t *dest);
+
+
+/**
+ * Get the size in bytes of the ICC profile for an associated image.
+ *
+ * @param osr The OpenSlide object.
+ * @param name The name of the desired associated image. Must be
+ *             a valid name as given by openslide_get_associated_image_names().
+ * @return -1 on error, 0 if no profile is available, otherwise the profile
+ * size in bytes.
+ */
+OPENSLIDE_PUBLIC()
+int64_t openslide_get_associated_image_icc_profile_size(openslide_t *osr,
+                                                        const char *name);
+
+
+/**
+ * Copy the ICC profile from an associated image.
+ *
+ * This function reads the ICC profile from an associated image into the
+ * specified memory location.  @p dest must be a valid pointer to enough
+ * memory to hold the profile.  Get the profile size with
+ * openslide_get_associated_image_icc_profile_size().
+ *
+ * If an error occurs or has occurred, then the memory pointed to by @p dest
+ * will be cleared.
+ *
+ * @param osr The OpenSlide object.
+ * @param name The name of the desired associated image. Must be
+ *             a valid name as given by openslide_get_associated_image_names().
+ * @param dest The destination buffer for the ICC profile.
+ */
+OPENSLIDE_PUBLIC()
+void openslide_read_associated_image_icc_profile(openslide_t *osr,
+                                                 const char *name,
+                                                 void *dest);
+
 //@}
 
 /**

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -202,6 +202,35 @@ void openslide_read_region(openslide_t *osr,
 
 
 /**
+ * Get the size in bytes of the ICC profile for the whole slide image.
+ *
+ * @param osr The OpenSlide object.
+ * @return -1 on error, 0 if no profile is available, otherwise the profile
+ * size in bytes.
+ */
+OPENSLIDE_PUBLIC()
+int64_t openslide_get_icc_profile_size(openslide_t *osr);
+
+
+/**
+ * Copy the ICC profile from a whole slide image.
+ *
+ * This function reads the ICC profile from the slide into the specified
+ * memory location.  @p dest must be a valid pointer to enough memory
+ * to hold the profile.  Get the profile size with
+ * openslide_get_icc_profile_size().
+ *
+ * If an error occurs or has occurred, then the memory pointed to by @p dest
+ * will be cleared.
+ *
+ * @param osr The OpenSlide object.
+ * @param dest The destination buffer for the ICC profile.
+ */
+OPENSLIDE_PUBLIC()
+void openslide_read_icc_profile(openslide_t *osr, void *dest);
+
+
+/**
  * Close an OpenSlide object.
  * No other threads may be using the object.
  * After this function returns, the object cannot be used anymore.
@@ -399,44 +428,6 @@ const char * const *openslide_get_property_names(openslide_t *osr);
  */
 OPENSLIDE_PUBLIC()
 const char *openslide_get_property_value(openslide_t *osr, const char *name);
-
-//@}
-
-/**
- * @name ICC profiles
- * Reading ICC profiles.
- *
- * Some slides contain embedded ICC profiles which can be used to transform
- * pixel colors for display. These functions allow reading ICC profile data.
- */
-//@{
-
-/**
- * Get the size in bytes of the ICC profile for the whole slide image.
- *
- * @param osr The OpenSlide object.
- * @return -1 on error, 0 if no profile is available, otherwise the profile
- * size in bytes.
- */
-OPENSLIDE_PUBLIC()
-int64_t openslide_get_icc_profile_size(openslide_t *osr);
-
-/**
- * Copy the ICC profile from a whole slide image.
- *
- * This function reads the ICC profile from the slide into the specified
- * memory location.  @p dest must be a valid pointer to enough memory
- * to hold the profile.  Get the profile size with
- * openslide_get_icc_profile_size().
- *
- * If an error occurs or has occurred, then the memory pointed to by @p dest
- * will be cleared.
- *
- * @param osr The OpenSlide object.
- * @param dest The destination buffer for the ICC profile.
- */
-OPENSLIDE_PUBLIC()
-void openslide_read_icc_profile(openslide_t *osr, void *dest);
 
 //@}
 

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -178,6 +178,10 @@ int32_t openslide_get_best_level_for_downsample(openslide_t *osr,
  * bytes in length. If an error occurs or has occurred, then the memory
  * pointed to by @p dest will be cleared.
  *
+ * The returned pixel data is in the color space of the whole slide image,
+ * which may or may not be sRGB.  You can get the ICC profile for the
+ * slide's color space, if available, with openslide_read_icc_profile().
+ *
  * For more information about processing pre-multiplied pixel data, see
  * the [OpenSlide website](https://openslide.org/docs/premultiplied-argb/).
  *

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -496,9 +496,9 @@ void openslide_get_associated_image_dimensions(openslide_t *osr,
  * the [OpenSlide website](https://openslide.org/docs/premultiplied-argb/).
  *
  * @param osr The OpenSlide object.
- * @param dest The destination buffer for the ARGB data.
  * @param name The name of the desired associated image. Must be
  *             a valid name as given by openslide_get_associated_image_names().
+ * @param dest The destination buffer for the ARGB data.
  */
 OPENSLIDE_PUBLIC()
 void openslide_read_associated_image(openslide_t *osr,

--- a/test/extended.c
+++ b/test/extended.c
@@ -280,6 +280,13 @@ int main(int argc, char **argv) {
     g_autofree uint32_t *buf = g_new(uint32_t, w * h);
     openslide_read_associated_image(osr, name, buf);
 
+    int64_t icc_len =
+      openslide_get_associated_image_icc_profile_size(osr, name);
+    if (icc_len >= 0) {
+      g_autofree void *buf = g_malloc(icc_len);
+      openslide_read_associated_image_icc_profile(osr, name, buf);
+    }
+
     common_fail_on_error(osr, "Reading associated image \"%s\" failed", name);
     associated_image_names++;
   }

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -119,6 +119,7 @@ static void check_api_failures(openslide_t *osr) {
   CHECK_EMPTY_PTR_ARRAY(openslide_get_property_names(osr));
   CHECK_RET(openslide_get_property_value(osr, OPENSLIDE_PROPERTY_NAME_VENDOR),
             NULL);
+  CHECK_RET(openslide_get_icc_profile_size(osr), -1);
   CHECK_EMPTY_PTR_ARRAY(openslide_get_associated_image_names(osr));
   CHECK_W_H(openslide_get_associated_image_dimensions(osr, "label", &w, &h),
             -1, -1);

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -125,6 +125,8 @@ static void check_api_failures(openslide_t *osr) {
             -1, -1);
   CHECK_W_H(openslide_get_associated_image_dimensions(osr, "macro", &w, &h),
             -1, -1);
+  CHECK_RET(openslide_get_associated_image_icc_profile_size(osr, "label"), -1);
+  CHECK_RET(openslide_get_associated_image_icc_profile_size(osr, "macro"), -1);
 
   openslide_read_region(osr, NULL, 0, 0, 0, 10, 10);
 }


### PR DESCRIPTION
There's no requirement that a format uses the same ICC profile for the main image and all associated images.  Add separate APIs for getting associated image ICC profiles, to at least prevent applications from assuming that the main ICC profile can be used everywhere.

When the profile for an associated image is known, drivers should return it, even if it's the same as for the main image.  Do this for DICOM slides, which generally provide the ICC profile in each individual file.  For other formats where we currently support profiles, it's not obvious whether the main profile should also apply to associated images, so return nothing for now.

Also, some ICC docs cleanups and other small fixes.

Fixes https://github.com/openslide/openslide/issues/139.