### PR TITLE
Revert "test: Disable aperio-filename-utf8"

### DIFF
--- a/test/cases/aperio-filename-utf8/config.yaml
+++ b/test/cases/aperio-filename-utf8/config.yaml
@@ -1,6 +1,3 @@
-# Disabled pending libtool wrapper exe command-line fix
-# https://bugzilla.redhat.com/show_bug.cgi?id=1124436
-
 base: Aperio/CMU-1.svs
 slide: 我的氣墊船裝滿了鱔魚.svs
 success: true


### PR DESCRIPTION
We no longer run tests via libtool and we no longer support testing from Cygwin, so this can be re-enabled.  At the moment we don't run tests at all on Windows, so this won't actually prove anything yet, but in due course it will.

This reverts commit 98b0e80507fb89fb37fb8be74a394a8dae11ef7e.