### PR TITLE
Revert "grid: avoid CAIRO_OPERATOR_SATURATE in simple grid"

### DIFF
--- a/src/openslide-grid.c
+++ b/src/openslide-grid.c
@@ -495,11 +495,7 @@ static bool tilemap_paint_region(struct _openslide_grid *_grid,
   //g_debug("start tile: %"PRId64" %"PRId64", end tile: %"PRId64" %"PRId64, start_tile_x, start_tile_y, end_tile_x, end_tile_y);
 
   // save
-  g_auto(cairo_state) state G_GNUC_UNUSED = state_save(cr);
-
-  // saturate (3x-5x total slowdown, including JPEG decompression) to avoid
-  // seams
-  cairo_set_operator(cr, CAIRO_OPERATOR_SATURATE);
+  g_auto(cairo_matrix) matrix G_GNUC_UNUSED = matrix_save(cr);
 
   // accommodate extra tiles being drawn
   region.start_tile_x -= grid->extra_tiles_left;
@@ -675,12 +671,7 @@ static bool range_paint_region(struct _openslide_grid *_grid,
   g_assert(grid->bins_runtime);
 
   // save
-  g_auto(cairo_state) state G_GNUC_UNUSED = state_save(cr);
   g_auto(cairo_matrix) matrix = matrix_save(cr);
-
-  // saturate (3x-5x total slowdown, including JPEG decompression) to avoid
-  // seams
-  cairo_set_operator(cr, CAIRO_OPERATOR_SATURATE);
 
   // accumulate relevant tiles
   struct range_bin_address addr;

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -456,6 +456,9 @@ static bool read_region_area(openslide_t *osr,
   // create the cairo context
   g_autoptr(cairo_t) cr = cairo_create(surface);
 
+  // saturate those seams away!
+  cairo_set_operator(cr, CAIRO_OPERATOR_SATURATE);
+
   if (level_in_range(osr, level)) {
     struct _openslide_level *l = osr->levels[level];
 


### PR DESCRIPTION
It turns out that it introduces seams after all.  Revert it for now.

Fixes https://github.com/openslide/openslide/issues/483.

This reverts commit 241a82751d1ba3cc62f01c4ff68f518d8bf18d02.