### PR TITLE
Add `slidetool slide {open,vendor}`; move `icc` and `quickhash1` out of top level

### DIFF
--- a/tools/meson.build
+++ b/tools/meson.build
@@ -30,6 +30,7 @@ foreach target : tools_binaries
       'slidetool-icc.c',
       'slidetool-image.c',
       'slidetool-prop.c',
+      'slidetool-slide.c',
       'slidetool-util.c',
     ],
     include_directories : config_h_include,

--- a/tools/openslide-quickhash1sum.1.in
+++ b/tools/openslide-quickhash1sum.1.in
@@ -64,7 +64,7 @@ could not be calculated, or 2 if the arguments are invalid.
 .B openslide-quickhash1sum
 is a legacy command and no new features will be added.
 Its replacement is the
-.B quickhash1
+.B slide quickhash1
 subcommand of
 .BR slidetool (1).
 

--- a/tools/slidetool-icc.c
+++ b/tools/slidetool-icc.c
@@ -80,11 +80,11 @@ static int do_assoc_icc_read(int narg, char **args) {
   return 0;
 }
 
-static const struct command icc_subcmds[] = {
+static const struct command region_icc_subcmds[] = {
   {
     .name = "read",
     .parameter_string = "<FILE> [OUTPUT-FILE]",
-    .summary = "Write an ICC profile to a file",
+    .summary = "Write ICC profile to a file",
     .description = "Copy a slide's ICC profile to a file.",
     .min_positional = 1,
     .max_positional = 2,
@@ -93,10 +93,10 @@ static const struct command icc_subcmds[] = {
   {}
 };
 
-const struct command icc_cmd = {
+const struct command region_icc_cmd = {
   .name = "icc",
-  .summary = "Commands related to ICC profiles",
-  .subcommands = icc_subcmds,
+  .summary = "Commands related to slide region ICC profiles",
+  .subcommands = region_icc_subcmds,
 };
 
 static const struct command assoc_icc_subcmds[] = {

--- a/tools/slidetool-image.c
+++ b/tools/slidetool-image.c
@@ -333,6 +333,9 @@ const struct command write_png_cmd = {
 
 static const struct command region_subcmds[] = {
   {
+    .command = &region_icc_cmd,
+  },
+  {
     .name = "read",
     .parameter_string = "<SLIDE> <X> <Y> <LEVEL> <WIDTH> <HEIGHT> [OUTPUT-PNG]",
     .summary = "Write a virtual slide region to a PNG",

--- a/tools/slidetool-prop.c
+++ b/tools/slidetool-prop.c
@@ -114,33 +114,6 @@ static int do_prop_list(int narg, char **args) {
   return successes != narg;
 }
 
-static bool quickhash1sum(const char *file) {
-  g_autoptr(openslide_t) osr = openslide_open(file);
-  if (common_warn_on_error(osr, "%s", file)) {
-    return false;
-  }
-
-  const char *hash =
-    openslide_get_property_value(osr, OPENSLIDE_PROPERTY_NAME_QUICKHASH1);
-  if (hash == NULL) {
-    common_warn("%s: No quickhash-1 available", file);
-    return false;
-  }
-
-  printf("%s  %s\n", hash, file);
-  return true;
-}
-
-static int do_quickhash1sum(int narg, char **args) {
-  int ret = 0;
-  for (int i = 0; i < narg; i++) {
-    if (!quickhash1sum(args[i])) {
-      ret = 1;
-    }
-  }
-  return ret;
-}
-
 const struct command show_properties_cmd = {
   .parameter_string = "<FILE...>",
   .description = "Print OpenSlide properties for a slide.",
@@ -179,21 +152,4 @@ const struct command prop_cmd = {
   .name = "prop",
   .summary = "Commands related to properties",
   .subcommands = prop_subcmds,
-};
-
-const struct command quickhash1sum_cmd = {
-  .parameter_string = "<FILE...>",
-  .description = "Print OpenSlide quickhash-1 (256-bit) checksums.",
-  .options = legacy_opts,
-  .min_positional = 1,
-  .handler = do_quickhash1sum,
-};
-
-const struct command quickhash1_cmd = {
-  .name = "quickhash1",
-  .parameter_string = "<FILE...>",
-  .summary = "Print quickhash-1 checksums",
-  .description = "Print OpenSlide quickhash-1 (256-bit) checksums.",
-  .min_positional = 1,
-  .handler = do_quickhash1sum,
 };

--- a/tools/slidetool-slide.c
+++ b/tools/slidetool-slide.c
@@ -57,6 +57,41 @@ static int do_vendor(int narg, char **args) {
   return ret;
 }
 
+static bool quickhash1sum(const char *file) {
+  g_autoptr(openslide_t) osr = openslide_open(file);
+  if (common_warn_on_error(osr, "%s", file)) {
+    return false;
+  }
+
+  const char *hash =
+    openslide_get_property_value(osr, OPENSLIDE_PROPERTY_NAME_QUICKHASH1);
+  if (hash == NULL) {
+    common_warn("%s: No quickhash-1 available", file);
+    return false;
+  }
+
+  printf("%s  %s\n", hash, file);
+  return true;
+}
+
+static int do_quickhash1sum(int narg, char **args) {
+  int ret = 0;
+  for (int i = 0; i < narg; i++) {
+    if (!quickhash1sum(args[i])) {
+      ret = 1;
+    }
+  }
+  return ret;
+}
+
+const struct command quickhash1sum_cmd = {
+  .parameter_string = "<FILE...>",
+  .description = "Print OpenSlide quickhash-1 (256-bit) checksums.",
+  .options = legacy_opts,
+  .min_positional = 1,
+  .handler = do_quickhash1sum,
+};
+
 static const struct command slide_subcmds[] = {
   {
     .name = "open",
@@ -65,6 +100,14 @@ static const struct command slide_subcmds[] = {
     .description = "Check whether OpenSlide can open a slide.",
     .min_positional = 1,
     .handler = do_open,
+  },
+  {
+    .name = "quickhash1",
+    .parameter_string = "<FILE...>",
+    .summary = "Print quickhash-1 checksum",
+    .description = "Print OpenSlide quickhash-1 (256-bit) checksums.",
+    .min_positional = 1,
+    .handler = do_quickhash1sum,
   },
   {
     .name = "vendor",

--- a/tools/slidetool-slide.c
+++ b/tools/slidetool-slide.c
@@ -1,0 +1,84 @@
+/*
+ *  OpenSlide, a library for reading whole slide image files
+ *
+ *  Copyright (c) 2007-2012 Carnegie Mellon University
+ *  Copyright (c) 2023      Benjamin Gilbert
+ *  All rights reserved.
+ *
+ *  OpenSlide is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, version 2.1.
+ *
+ *  OpenSlide is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with OpenSlide. If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdio.h>
+#include <glib.h>
+#include "openslide.h"
+#include "openslide-common.h"
+#include "slidetool.h"
+
+static int do_open(int narg, char **args) {
+  int ret = 0;
+  for (int i = 0; i < narg; i++) {
+    const char *file = args[i];
+    g_autoptr(openslide_t) osr = openslide_open(file);
+    if (common_warn_on_error(osr, "%s", file)) {
+      ret = 1;
+    }
+  }
+  return ret;
+}
+
+static int do_vendor(int narg, char **args) {
+  int ret = 0;
+  for (int i = 0; i < narg; i++) {
+    const char *file = args[i];
+    const char *vendor = openslide_detect_vendor(file);
+    if (vendor) {
+      if (narg > 1) {
+        printf("%s: %s\n", file, vendor);
+      } else {
+        printf("%s\n", vendor);
+      }
+    } else {
+      common_warn("%s: No vendor detected", file);
+      ret = 1;
+    }
+  }
+  return ret;
+}
+
+static const struct command slide_subcmds[] = {
+  {
+    .name = "open",
+    .parameter_string = "<FILE...>",
+    .summary = "Try opening a slide",
+    .description = "Check whether OpenSlide can open a slide.",
+    .min_positional = 1,
+    .handler = do_open,
+  },
+  {
+    .name = "vendor",
+    .parameter_string = "<FILE...>",
+    .summary = "Get slide vendor",
+    .description = "Print the detected OpenSlide vendor name for a slide.",
+    .min_positional = 1,
+    .handler = do_vendor,
+  },
+  {}
+};
+
+const struct command slide_cmd = {
+  .name = "slide",
+  .summary = "Commands related to slide files",
+  .subcommands = slide_subcmds,
+};

--- a/tools/slidetool.1.in
+++ b/tools/slidetool.1.in
@@ -42,14 +42,14 @@ slidetool \- Retrieve data from whole slide images
 .B slidetool assoc read
 .IR "file name" " [" output-file ]
 .br
-.B slidetool icc read
-.IR file " [" output-file ]
-.br
 .B slidetool prop get
 .IR "property file" ...
 .br
 .BR "slidetool prop list" " [" --names ]
 .IR file ...
+.br
+.B slidetool region icc read
+.IR file " [" output-file ]
 .br
 .B slidetool region read
 .IR "file x y level width height" " [" output-file ]
@@ -87,12 +87,6 @@ If
 .I output-file
 is not specified, the image will be written to standard output.
 
-.SS slidetool icc read
-Write the slide's ICC color profile to
-.I output-file
-if specified, and otherwise to standard output.
-If no ICC color profile is available, fail.
-
 .SS slidetool prop get
 Print a single OpenSlide property value for one or more slides.
 Properties are individual pieces of textual metadata about the slide.
@@ -103,6 +97,12 @@ others are defined by the individual slide format.
 
 .SS slidetool prop list
 Print all OpenSlide properties for one or more slides.
+
+.SS slidetool region icc read
+Write the slide's ICC color profile to
+.I output-file
+if specified, and otherwise to standard output.
+If no ICC color profile is available, fail.
 
 .SS slidetool region read
 Write a region of the specified

--- a/tools/slidetool.1.in
+++ b/tools/slidetool.1.in
@@ -23,7 +23,7 @@
 .\" See man-pages(7) for formatting conventions.
 
 
-.TH SLIDETOOL 1 2023-07-12 "OpenSlide @SUFFIXED_VERSION@" "User Commands"
+.TH SLIDETOOL 1 2023-07-27 "OpenSlide @SUFFIXED_VERSION@" "User Commands"
 
 .mso www.tmac
 
@@ -56,6 +56,12 @@ slidetool \- Retrieve data from whole slide images
 .br
 .B slidetool region read
 .IR "file x y level width height" " [" output-file ]
+.br
+.B slidetool slide open
+.IR file ...
+.br
+.B slidetool slide vendor
+.IR file ...
 
 .SH DESCRIPTION
 .B slidetool
@@ -134,6 +140,12 @@ is not specified, the image will be written to standard output.
 
 The dimensions of each level of a slide can be obtained with
 .BR "slidetool prop list" .
+
+.SS slidetool slide open
+Check whether OpenSlide can open one or more slide files.
+
+.SS slidetool slide vendor
+Report the detected OpenSlide vendor name for one or more slide files.
 
 .SH OPTIONS
 .TP

--- a/tools/slidetool.1.in
+++ b/tools/slidetool.1.in
@@ -51,13 +51,13 @@ slidetool \- Retrieve data from whole slide images
 .BR "slidetool prop list" " [" --names ]
 .IR file ...
 .br
-.B slidetool quickhash1
-.IR file ...
-.br
 .B slidetool region read
 .IR "file x y level width height" " [" output-file ]
 .br
 .B slidetool slide open
+.IR file ...
+.br
+.B slidetool slide quickhash1
 .IR file ...
 .br
 .B slidetool slide vendor
@@ -104,23 +104,6 @@ others are defined by the individual slide format.
 .SS slidetool prop list
 Print all OpenSlide properties for one or more slides.
 
-.SS slidetool quickhash1
-Print OpenSlide
-.I quickhash-1
-checksums for one or more slides, in a format similar to
-.BR sha256sum (1).
-.PP
-.I quickhash-1
-is a non-cryptographic, 256-bit hash of a subset of a slide's data.
-It uniquely identifies a particular slide,
-but cannot be used to detect corruption or modification of the slide file.
-.PP
-.I quickhash-1
-is not defined for all slide files supported by OpenSlide.
-If a slide does not have a
-.IR quickhash-1 ,
-"No quickhash-1 available" will be printed.
-
 .SS slidetool region read
 Write a region of the specified
 .I level
@@ -143,6 +126,23 @@ The dimensions of each level of a slide can be obtained with
 
 .SS slidetool slide open
 Check whether OpenSlide can open one or more slide files.
+
+.SS slidetool slide quickhash1
+Print OpenSlide
+.I quickhash-1
+checksums for one or more slides, in a format similar to
+.BR sha256sum (1).
+.PP
+.I quickhash-1
+is a non-cryptographic, 256-bit hash of a subset of a slide's data.
+It uniquely identifies a particular slide,
+but cannot be used to detect corruption or modification of the slide file.
+.PP
+.I quickhash-1
+is not defined for all slide files supported by OpenSlide.
+If a slide does not have a
+.IR quickhash-1 ,
+"No quickhash-1 available" will be printed.
 
 .SS slidetool slide vendor
 Report the detected OpenSlide vendor name for one or more slide files.

--- a/tools/slidetool.c
+++ b/tools/slidetool.c
@@ -53,9 +53,6 @@ static const struct command root_subcmds[] = {
     .command = &assoc_cmd,
   },
   {
-    .command = &icc_cmd,
-  },
-  {
     .command = &prop_cmd,
   },
   {

--- a/tools/slidetool.c
+++ b/tools/slidetool.c
@@ -64,6 +64,9 @@ static const struct command root_subcmds[] = {
   {
     .command = &region_cmd,
   },
+  {
+    .command = &slide_cmd,
+  },
   {}
 };
 

--- a/tools/slidetool.c
+++ b/tools/slidetool.c
@@ -59,9 +59,6 @@ static const struct command root_subcmds[] = {
     .command = &prop_cmd,
   },
   {
-    .command = &quickhash1_cmd,
-  },
-  {
     .command = &region_cmd,
   },
   {

--- a/tools/slidetool.h
+++ b/tools/slidetool.h
@@ -49,7 +49,6 @@ extern const struct command assoc_cmd;
 extern const struct command assoc_icc_cmd;
 extern const struct command icc_cmd;
 extern const struct command prop_cmd;
-extern const struct command quickhash1_cmd;
 extern const struct command region_cmd;
 extern const struct command slide_cmd;
 

--- a/tools/slidetool.h
+++ b/tools/slidetool.h
@@ -47,9 +47,9 @@ extern const GOptionEntry legacy_opts[];
 
 extern const struct command assoc_cmd;
 extern const struct command assoc_icc_cmd;
-extern const struct command icc_cmd;
 extern const struct command prop_cmd;
 extern const struct command region_cmd;
+extern const struct command region_icc_cmd;
 extern const struct command slide_cmd;
 
 extern const struct command quickhash1sum_cmd;

--- a/tools/slidetool.h
+++ b/tools/slidetool.h
@@ -51,6 +51,7 @@ extern const struct command icc_cmd;
 extern const struct command prop_cmd;
 extern const struct command quickhash1_cmd;
 extern const struct command region_cmd;
+extern const struct command slide_cmd;
 
 extern const struct command quickhash1sum_cmd;
 extern const struct command show_properties_cmd;


### PR DESCRIPTION
We haven't had a stable release with `slidetool`, so we can still do some reorganization.