### PR TITLE
test/driver: add `CACHEDIR.TAG` file to cache directory

### DIFF
--- a/test/driver.in
+++ b/test/driver.in
@@ -3,7 +3,7 @@
 # OpenSlide, a library for reading whole slide image files
 #
 # Copyright (c) 2012-2015 Carnegie Mellon University
-# Copyright (c) 2015-2021 Benjamin Gilbert
+# Copyright (c) 2015-2023 Benjamin Gilbert
 # All rights reserved.
 #
 # OpenSlide is free software: you can redistribute it and/or modify
@@ -62,6 +62,7 @@ SLIDELIST = '@SRCDIR@/cases/slides.yaml'
 FROZENLIST = '@SRCDIR@/cases/frozen.yaml'
 MOSAICLIST = '@SRCDIR@/cases/mosaic.ini'
 CACHE = os.getenv('OPENSLIDE_TEST_CACHE', '@BUILDDIR@/_slidedata')
+CACHE_TAG = f'{CACHE}/CACHEDIR.TAG'
 WORKROOT = f'{CACHE}/unpacked'
 PRISTINE = f'{CACHE}/pristine'
 FUSEMOUNT = f'{CACHE}/fuse'
@@ -1287,6 +1288,14 @@ def _main():
     argc = len(sys.argv) - 2
     if argc < len(args) or argc > len(args) + len(optargs):
         _usage()
+    if not os.path.exists(CACHE_TAG):
+        os.makedirs(CACHE, exist_ok=True)
+        with open(CACHE_TAG, 'w') as fh:
+            fh.writelines([
+                'Signature: 8a477f597d28d172789f06886806bc55\n',
+                "# This file is a cache directory tag created by OpenSlide's test suite.\n",
+                '# For information about cache directory tags, see https://bford.info/cachedir/\n',
+            ])
     f(*sys.argv[2:])
 
 


### PR DESCRIPTION
[Tell backup software](https://bford.info/cachedir/) that the cache directory doesn't need to be backed up.