### PR TITLE
Add missing <io.h> for '_get_osfhandle'.

### DIFF
--- a/common/openslide-common-fd.c
+++ b/common/openslide-common-fd.c
@@ -22,6 +22,7 @@
 #ifdef _WIN32
 #define _WIN32_WINNT 0x0600
 #include <windows.h>
+#include <io.h>
 #endif
 
 #include <sys/types.h>


### PR DESCRIPTION
First detected in https://github.com/microsoft/vcpkg/pull/33088

Documented to come from `<io.h>` in https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/get-osfhandle?view=msvc-170

```
D:\buildtrees\openslide\src\v3.4.1-a70eeb2621.clean\test\test-common.c(51,25): error: call to undeclared function '_get_osfhandle'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  HANDLE hdl = (HANDLE) _get_osfhandle(fd);
```