### PR TITLE
Require `stdbool.h` in `openslide.h`

### DIFF
--- a/src/openslide-features.h
+++ b/src/openslide-features.h
@@ -23,26 +23,6 @@
 #define OPENSLIDE_OPENSLIDE_FEATURES_H_
 
 
-#ifndef __cplusplus
-#  ifdef _MSC_VER
-#    ifndef bool
-#      define bool unsigned char
-#    endif
-#    ifndef true
-#      define true 1
-#    endif
-#    ifndef false
-#      define false 0
-#    endif
-#    ifndef __bool_true_false_are_defined
-#      define __bool_true_false_are_defined 1
-#    endif
-#  else
-#    include <stdbool.h>
-#  endif
-#endif
-
-
 // for exporting from shared libraries or DLLs
 #if defined _WIN32
 #  ifdef _OPENSLIDE_BUILDING_DLL

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -35,6 +35,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
1cae453a33 conditionalized use of `stdbool.h` so the public headers could be included from MSVC, which didn't support `stdbool.h` at the time. However, VS 2013 added support.  Assume the user has a compiler at least that new, and drop the conditional.