### PR TITLE
Ensure that the RT_MANIFEST value is quoted

### DIFF
--- a/src/openslide-dll.rc.in
+++ b/src/openslide-dll.rc.in
@@ -1,7 +1,7 @@
 #include "winuser.h"
 #include "winver.h"
 
-2 RT_MANIFEST openslide-dll.manifest
+2 RT_MANIFEST "openslide-dll.manifest"
 
 1 VERSIONINFO
 FILEVERSION @WINDOWS_VERSIONINFO@


### PR DESCRIPTION
GNU windres does not treat hyphens as separators. However, llvm-rc or MSVC's rc.exe treats them as separators, causing a build error on these toolchains if the value is not quoted.

See: https://github.com/mstorsjo/llvm-mingw/issues/67