### PR TITLE
Prevent pseudo modifiers from being defined

### DIFF
--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -410,4 +410,9 @@ extern const int16_t _openslide_B_Cb[256];
 #define ftello _OPENSLIDE_POISON(_openslide_ftell_)
 #endif
 
+#ifdef _WIN32
+// Prevent windows.h from defining the IN/OUT macro
+#define _NO_W32_PSEUDO_MODIFIERS
+#endif
+
 #endif


### PR DESCRIPTION
Add a definition for `_NO_W32_PSEUDO_MODIFIERS` so that `windows.h` will not define the `IN`/`OUT` macro. Resolves a compilation error with a patched libjpeg-turbo header carried in MSYS2.

<details>
  <summary>Details</summary>

```
FAILED: src/libopenslide-0.dll.p/openslide-vendor-mirax.c.obj 
/data/mxe/usr/bin/x86_64-w64-mingw32.shared.posix.all-clang -Isrc/libopenslide-0.dll.p -Isrc -I../openslide-openslide-e3908b0/src -I. -I../openslide-openslide-e3908b0 -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/glib-2.0 -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/lib/glib-2.0/include -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/gdk-pixbuf-2.0 -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/libpng16 -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/webp -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/cairo -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/freetype2 -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/harfbuzz -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/pixman-1 -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/libxml2 -I/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/openjpeg-2.5 -fvisibility=hidden -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -O3 -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wnested-externs -fno-common -DG_DISABLE_SINGLE_INCLUDES -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_MIN_REQUIRED -Os -g -gcodeview -fdata-sections -ffunction-sections -mms-bitfields -mms-bitfields -mms-bitfields -mms-bitfields -mms-bitfields -D_OPENSLIDE_BUILDING_DLL '-DG_LOG_DOMAIN="OpenSlide"' -MD -MQ src/libopenslide-0.dll.p/openslide-vendor-mirax.c.obj -MF src/libopenslide-0.dll.p/openslide-vendor-mirax.c.obj.d -o src/libopenslide-0.dll.p/openslide-vendor-mirax.c.obj -c ../openslide-openslide-e3908b0/src/openslide-vendor-mirax.c
../openslide-openslide-e3908b0/src/openslide-vendor-mirax.c:425:61: warning: omitting the parameter name in a function definition is a C2x extension [-Wc2x-extensions]
  425 |                                                 int32_t *OUT) {
      |                                                             ^
../openslide-openslide-e3908b0/src/openslide-vendor-mirax.c:426:30: error: expected expression
  426 |   if (_openslide_fread(f, OUT, 4) != 4) {
      |                              ^
../openslide-openslide-e3908b0/src/openslide-vendor-mirax.c:430:8: error: expected expression
  430 |   *OUT = GINT32_FROM_LE(*OUT);
      |        ^
../openslide-openslide-e3908b0/src/openslide-vendor-mirax.c:430:10: error: expected expression
  430 |   *OUT = GINT32_FROM_LE(*OUT);
      |          ^
/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/include/glib-2.0/glib/gtypes.h:416:30: note: expanded from macro 'GINT32_FROM_LE'
  416 | #define GINT32_FROM_LE(val)     (GINT32_TO_LE (val))
      |                                  ^
/data/mxe/usr/x86_64-w64-mingw32.shared.posix.all/lib/glib-2.0/include/glibconfig.h:161:41: note: expanded from macro 'GINT32_TO_LE'
  161 | #define GINT32_TO_LE(val)       ((gint32) (val))
      |                                               ^
1 warning and 3 errors generated.
```
</details>

(Tested using commit https://github.com/libvips/build-win64-mxe/commit/fc0cb6567c2515429158c63ae9466667b1752a81)