### PR TITLE
Revert "workflows: install EL8 pixman from Copr"

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -76,8 +76,6 @@ jobs:
                 8)
                     dnf install -y 'dnf-command(config-manager)'
                     dnf config-manager --set-enabled powertools
-                    # https://bugzilla.redhat.com/show_bug.cgi?id=2124013
-                    dnf copr enable -y bgilbert/el8-pixman-openslide
                     pyver=38
                     pydotver=3.8
                     python=python38


### PR DESCRIPTION
`pixman-0.38.4-3.el8` fixes the rendering issue.

This reverts commit 0fd396e4a33452adb0e534b04f057a0158b5252b.