### PR TITLE
Update to libdicom 1.0.1 from wrapdb and make it mandatory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -113,7 +113,6 @@ dicom_dep      = dependency(
   # avoid 'check' dependency
   default_options : ['tests=false'],
   fallback : ['libdicom', 'libdicom_dep'],
-  required : get_option('dicom'),
   version : '>=1.0.0',
 )
 valgrind_dep   = dependency('valgrind', required : false)
@@ -125,10 +124,6 @@ doxygen = find_program(
 )
 
 # Dependency checks
-if dicom_dep.found()
-  conf.set('HAVE_LIBDICOM', 1)
-  feature_flags += 'dicom'
-endif
 if valgrind_dep.found()
   conf.set('HAVE_VALGRIND', 1)
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,10 +1,4 @@
 option(
-  'dicom',
-  type : 'feature',
-  value : 'auto',
-  description : 'Support DICOM format',
-)
-option(
   'version_suffix',
   type : 'string',
   description : 'Suffix to append to the package version string',

--- a/src/openslide-vendor-synthetic.c
+++ b/src/openslide-vendor-synthetic.c
@@ -32,6 +32,7 @@
 #include <config.h>
 
 #include "openslide-private.h"
+#include "openslide-decode-dicom.h"
 #include "openslide-decode-gdkpixbuf.h"
 #include "openslide-decode-jp2k.h"
 #include "openslide-decode-jpeg.h"
@@ -44,10 +45,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <tiffio.h>
-
-#ifdef HAVE_LIBDICOM
-#include "openslide-decode-dicom.h"
-#endif
 
 #define IMAGE_PIXELS 16
 #define IMAGE_BUFSIZE (4 * IMAGE_PIXELS * IMAGE_PIXELS)
@@ -76,7 +73,6 @@ static bool decode_bmp(const void *data, uint32_t len,
                                             IMAGE_PIXELS, IMAGE_PIXELS, err);
 }
 
-#ifdef HAVE_LIBDICOM
 static bool decode_dicom(const void *data, uint32_t len,
                          uint32_t *dest, GError **err) {
   DcmError *dcm_error = NULL;
@@ -139,7 +135,6 @@ static bool decode_dicom(const void *data, uint32_t len,
                                        dcm_frame_get_length(frame),
                                        dest, w, h, err);
 }
-#endif
 
 static bool decode_j2k(const void *data, uint32_t len,
                         uint32_t *dest, GError **err) {
@@ -477,7 +472,6 @@ static const struct synthetic_item **synthetic_items = (const struct synthetic_i
        0x07, 0xec, 0xa8, 0x70, 0xb8, 0xcb, 0x03, 0x00, 0x5d, 0x29, 0xd1, 0x3c,
     }
   },
-#ifdef HAVE_LIBDICOM
   &(const struct synthetic_item){
     .name = "dicom.jpeg",
     .description = "YCbCr JPEG DICOM",
@@ -539,7 +533,6 @@ static const struct synthetic_item **synthetic_items = (const struct synthetic_i
        0x6f, 0xed, 0x55, 0xb3, 0x98,
     }
   },
-#endif
   &(const struct synthetic_item){
     .name = "j2k",
     .description = "J2K",

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -42,9 +42,7 @@ static const char * const EMPTY_STRING_ARRAY[] = { NULL };
 static const struct _openslide_format *formats[] = {
   &_openslide_format_synthetic,
   &_openslide_format_mirax,
-#ifdef HAVE_LIBDICOM
   &_openslide_format_dicom,
-#endif
   &_openslide_format_hamamatsu_vms_vmu,
   &_openslide_format_hamamatsu_ndpi,
   &_openslide_format_sakura,

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,4 +1,4 @@
-/libdicom
+/libdicom-*
 /uthash-*
 
 /packagecache

--- a/subprojects/libdicom.wrap
+++ b/subprojects/libdicom.wrap
@@ -1,12 +1,10 @@
-# not from wrapdb
-
 [wrap-file]
-directory = libdicom-1.0.0-rc2
-
-source_url = https://github.com/ImagingDataCommons/libdicom/releases/download/v1.0-rc2/libdicom-1.0.0-rc2.tar.xz
-source_filename = libdicom-1.0.0-rc2.tar.xz
-source_hash = 0fd44774037f36e4bf275f1fd9ee4e2b50af4cf0fbbc7ba1a56f0bdff67d1d58
+directory = libdicom-1.0.1
+source_url = https://github.com/ImagingDataCommons/libdicom/releases/download/v1.0.1/libdicom-1.0.1.tar.xz
+source_filename = libdicom-1.0.1.tar.xz
+source_hash = 45edf650e214fa4dc905660aa25970210fe851d51fec5145dc369d447af4f3e1
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libdicom_1.0.1-1/libdicom-1.0.1.tar.xz
+wrapdb_version = 1.0.1-1
 
 [provide]
 dependency_names = libdicom
-program_names = dcm-dump, dcm-getframe

--- a/test/cases/dicom-tiled-full-jp2k-rgb/config.yaml
+++ b/test/cases/dicom-tiled-full-jp2k-rgb/config.yaml
@@ -4,7 +4,6 @@ slide: DCM_0.dcm
 success: true
 vendor: dicom
 primary: true
-requires: [dicom]
 properties:
   openslide.associated.label.icc-size: "3144"
   openslide.associated.macro.icc-size: "3144"

--- a/test/cases/dicom-tiled-full-jp2k-ycbcr/config.yaml
+++ b/test/cases/dicom-tiled-full-jp2k-ycbcr/config.yaml
@@ -4,7 +4,6 @@ slide: DCM_4.dcm
 success: true
 vendor: dicom
 primary: true
-requires: [dicom]
 properties:
   openslide.associated.label.icc-size: "141992"
   openslide.associated.macro.icc-size: "141992"

--- a/test/cases/dicom-tiled-full-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-full-jpeg/config.yaml
@@ -4,7 +4,6 @@ slide: 000005.dcm
 success: true
 vendor: dicom
 primary: true
-requires: [dicom]
 properties:
   openslide.associated.label.icc-size: "63928"
   openslide.associated.macro.icc-size: "63928"

--- a/test/cases/dicom-tiled-sparse-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-sparse-jpeg/config.yaml
@@ -4,7 +4,6 @@ slide: 1.3.6.1.4.1.36533.1881662823325113479691652532302192524914036.dcm
 success: true
 vendor: dicom
 primary: true
-requires: [dicom]
 properties:
   openslide.associated.thumbnail.icc-size: "13113264"
   openslide.icc-size: "13113264"


### PR DESCRIPTION
Now that the libdicom API has stabilized and DICOM support is no longer under rapid development, require libdicom, so every OpenSlide installation will support the same formats.

For now, we'll continue shipping the Meson wrap as a convenience; we can drop it once libdicom is broadly available in package managers.