### PR TITLE
Support copying files in test cases; minor improvements for test development

### DIFF
--- a/misc/bulk-testcase-helper.sh
+++ b/misc/bulk-testcase-helper.sh
@@ -14,7 +14,7 @@ function start() {
     fi
 
     ./driver create "$slide" "$testcase"
-    pushd "cases/$testcase"
+    pushd "../../test/cases/$testcase"
     [ -n "$EDITOR" ] && $EDITOR config.yaml
 }
 

--- a/misc/bulk-testcase-helper.sh
+++ b/misc/bulk-testcase-helper.sh
@@ -22,6 +22,7 @@ function finish() {
     if [ -n "$testcase" ] ; then
         popd
         ./driver pack $testcase
+        ./driver run $testcase
     fi
     testcase=
 }

--- a/test/driver.in
+++ b/test/driver.in
@@ -1065,9 +1065,10 @@ def coverage(outfile):
             if paths:
                 subprocess.check_call(['gcov', '-o', dirpath] + paths)
 
-        # Record unexecuted lines
+        # Record unexecuted lines; ignore glib headers
         proc = subprocess.Popen(['grep', '-FC', '2', '#####'] +
-                fnmatch.filter(sorted(os.listdir('.')), '*.gcov'),
+                [f for f in fnmatch.filter(sorted(os.listdir('.')), '*.gcov')
+                if not fnmatch.fnmatch(f, 'g*.h.gcov')],
                 stdout=subprocess.PIPE)
         report, _ = proc.communicate()
         if proc.returncode:

--- a/test/driver.in
+++ b/test/driver.in
@@ -373,10 +373,11 @@ def pack(testname):
     print(f'Packing {testname}...')
     conf = _load_test_config(testname)
     slide = conf['base']
+    copies = conf.get('copy', {})
 
     total_size = 0
-    for relpath in _list_slide_files(slide):
-        origpath = os.path.join(PRISTINE, slide, relpath)
+    for relpath in _list_slide_files(slide) + list(copies):
+        origpath = os.path.join(PRISTINE, slide, copies.get(relpath, relpath))
         newpath = os.path.join(CASEROOT, testname, 'slide', relpath)
         deltapath = os.path.join(CASEROOT, testname,
                 os.path.basename(relpath) + '.xdelta')
@@ -504,13 +505,14 @@ def _unpack_one(testname):
 
     conf = _load_test_config(testname)
     slide = conf['base']
+    copies = conf.get('copy', {})
     renames = conf.get('rename', {})
     generators = conf.get('generate', {})
     printed = False
     _fetch_one(slide)
 
-    for relpath in _list_slide_files(slide):
-        origpath = os.path.join(PRISTINE, slide, relpath)
+    for relpath in _list_slide_files(slide) + list(copies):
+        origpath = os.path.join(PRISTINE, slide, copies.get(relpath, relpath))
         newpath = os.path.join(WORKROOT, testname,
                 renames.get(os.path.basename(relpath), relpath))
         deltapath = os.path.join(CASEROOT, testname,


### PR DESCRIPTION
A file can be duplicated multiple times and each copy can have its own delta.  The `config.yaml` syntax is:

    copy:
      ? DCM_0_copy.dcm
      : DCM_0.dcm

Also omit coverage reports for glib headers from `coverage` output, and make some improvements to the bulk testcase helper.