### PR TITLE
aperio: allow floating-point objective power

### DIFF
--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -309,8 +309,8 @@ static void add_properties(openslide_t *osr, char **props) {
     }
   }
 
-  _openslide_duplicate_int_prop(osr, "aperio.AppMag",
-                                OPENSLIDE_PROPERTY_NAME_OBJECTIVE_POWER);
+  _openslide_duplicate_double_prop(osr, "aperio.AppMag",
+                                   OPENSLIDE_PROPERTY_NAME_OBJECTIVE_POWER);
   _openslide_duplicate_double_prop(osr, "aperio.MPP",
                                    OPENSLIDE_PROPERTY_NAME_MPP_X);
   _openslide_duplicate_double_prop(osr, "aperio.MPP",


### PR DESCRIPTION
Some Aperio slides have a floating-point `AppMag` such as `40.000000`. In the samples I've seen, the `ImageDescription` mentions both `Aperio Image Library` and `Leica SCN`.  One such file is [TCGA-3C-AALI-01Z-00-DX2.CF4496E0-AB52-4F3E-BDF5-C34833B91B7C.svs](https://portal.gdc.cancer.gov/files/6a7477b1-86f3-473f-9bf1-174a758142e9).

Support transcribing such `AppMag`s to `openslide.objective-power`.  The value will still be stored as an integer if it can be represented in one.

Fixes: https://github.com/openslide/openslide/issues/247
Fixes: https://github.com/openslide/openslide/issues/332