### PR TITLE
tools: escape dashes in man pages that need escaping

### DIFF
--- a/tools/openslide-quickhash1sum.1.in
+++ b/tools/openslide-quickhash1sum.1.in
@@ -23,15 +23,15 @@
 .\" See man-pages(7) for formatting conventions.
 
 
-.TH OPENSLIDE-QUICKHASH1SUM 1 2023-06-30 "OpenSlide @SUFFIXED_VERSION@" "User Commands"
+.TH OPENSLIDE\-QUICKHASH1SUM 1 2023-06-30 "OpenSlide @SUFFIXED_VERSION@" "User Commands"
 
 .mso www.tmac
 
 .SH NAME
-openslide-quickhash1sum \- Print OpenSlide quickhash-1 checksums
+openslide\-quickhash1sum \- Print OpenSlide quickhash-1 checksums
 
 .SH SYNOPSIS
-.BR "openslide-quickhash1sum " [ --help "] [" --version ]
+.BR "openslide\-quickhash1sum " [ \-\-help "] [" \-\-version ]
 .IR slide ...
 
 .SH DESCRIPTION
@@ -47,21 +47,21 @@ but cannot be used to detect corruption or modification of the slide file.
 
 .SH OPTIONS
 .TP
-.B --help
+.B \-\-help
 Display usage summary.
 
 .TP
-.B --version
+.B \-\-version
 Display version and copyright information.
 
 .SH EXIT STATUS
-.B openslide-quickhash1sum
+.B openslide\-quickhash1sum
 returns 0 on success, 1 if a
 .I quickhash-1
 could not be calculated, or 2 if the arguments are invalid.
 
 .SH NOTES
-.B openslide-quickhash1sum
+.B openslide\-quickhash1sum
 is a legacy command and no new features will be added.
 Its replacement is the
 .B slide quickhash1
@@ -73,7 +73,7 @@ subcommand of
 is not defined for all slide files supported by OpenSlide.
 If a slide does not have a
 .IR quickhash-1 ,
-"No quickhash-1 available" will be printed.
+"No quickhash\-1 available" will be printed.
 
 .SH COPYRIGHT
 Copyright \(co 2007-2023 Carnegie Mellon University and others

--- a/tools/openslide-show-properties.1.in
+++ b/tools/openslide-show-properties.1.in
@@ -23,15 +23,15 @@
 .\" See man-pages(7) for formatting conventions.
 
 
-.TH OPENSLIDE-SHOW-PROPERTIES 1 2023-06-30 "OpenSlide @SUFFIXED_VERSION@" "User Commands"
+.TH OPENSLIDE\-SHOW\-PROPERTIES 1 2023-06-30 "OpenSlide @SUFFIXED_VERSION@" "User Commands"
 
 .mso www.tmac
 
 .SH NAME
-openslide-show-properties \- Print OpenSlide properties for a slide
+openslide\-show\-properties \- Print OpenSlide properties for a slide
 
 .SH SYNOPSIS
-.BR "openslide-show-properties " [ --help "] [" --version ]
+.BR "openslide\-show\-properties " [ \-\-help "] [" \-\-version ]
 .IR slide ...
 
 .SH DESCRIPTION
@@ -39,20 +39,20 @@ Print OpenSlide properties for one or more virtual slide files.
 
 .SH OPTIONS
 .TP
-.B --help
+.B \-\-help
 Display usage summary.
 
 .TP
-.B --version
+.B \-\-version
 Display version and copyright information.
 
 .SH EXIT STATUS
-.B openslide-show-properties
+.B openslide\-show\-properties
 returns 0 on success, 1 if a slide file could not be read,
 or 2 if the arguments are invalid.
 
 .SH NOTES
-.B openslide-show-properties
+.B openslide\-show\-properties
 is a legacy command and no new features will be added.
 Its replacement is the
 .B prop list

--- a/tools/openslide-write-png.1.in
+++ b/tools/openslide-write-png.1.in
@@ -23,15 +23,15 @@
 .\" See man-pages(7) for formatting conventions.
 
 
-.TH OPENSLIDE-WRITE-PNG 1 2023-06-30 "OpenSlide @SUFFIXED_VERSION@" "User Commands"
+.TH OPENSLIDE\-WRITE\-PNG 1 2023-06-30 "OpenSlide @SUFFIXED_VERSION@" "User Commands"
 
 .mso www.tmac
 
 .SH NAME
-openslide-write-png \- Write a region of a virtual slide to a PNG
+openslide\-write\-png \- Write a region of a virtual slide to a PNG
 
 .SH SYNOPSIS
-.BR "openslide-write-png " [ --help "] [" --version ]
+.BR "openslide\-write\-png " [ \-\-help "] [" \-\-version ]
 .I slide-file x y level width height output-file
 
 .SH DESCRIPTION
@@ -49,24 +49,24 @@ are pixel dimensions in the specified
 .IR level .
 
 The dimensions of each level of a slide can be obtained with
-.BR openslide-show-properties (1).
+.BR openslide\-show\-properties (1).
 
 .SH OPTIONS
 .TP
-.B --help
+.B \-\-help
 Display usage summary.
 
 .TP
-.B --version
+.B \-\-version
 Display version and copyright information.
 
 .SH EXIT STATUS
-.B openslide-write-png
+.B openslide\-write\-png
 returns 0 on success, 1 if an error occurred,
 or 2 if the arguments are invalid.
 
 .SH NOTES
-.B openslide-write-png
+.B openslide\-write\-png
 is a legacy command and no new features will be added.
 Its replacement is the
 .B region read
@@ -84,5 +84,5 @@ OpenSlide comes with NO WARRANTY, to the extent permitted by law.
 See the GNU Lesser General Public License for more details.
 
 .SH SEE ALSO
-.BR openslide-show-properties (1),
+.BR openslide\-show\-properties (1),
 .BR slidetool (1)

--- a/tools/slidetool.1.in
+++ b/tools/slidetool.1.in
@@ -31,7 +31,7 @@
 slidetool \- Retrieve data from whole slide images
 
 .SH SYNOPSIS
-.BR "slidetool " [ --help "] [" --version ]
+.BR "slidetool " [ \-\-help "] [" \-\-version ]
 .br
 .B slidetool assoc icc read
 .IR "file name" " [" output-file ]
@@ -45,7 +45,7 @@ slidetool \- Retrieve data from whole slide images
 .B slidetool prop get
 .IR "property file" ...
 .br
-.BR "slidetool prop list" " [" --names ]
+.BR "slidetool prop list" " [" \-\-names ]
 .IR file ...
 .br
 .B slidetool region icc read
@@ -142,24 +142,24 @@ but cannot be used to detect corruption or modification of the slide file.
 is not defined for all slide files supported by OpenSlide.
 If a slide does not have a
 .IR quickhash-1 ,
-"No quickhash-1 available" will be printed.
+"No quickhash\-1 available" will be printed.
 
 .SS slidetool slide vendor
 Report the detected OpenSlide vendor name for one or more slide files.
 
 .SH OPTIONS
 .TP
-.B --help
+.B \-\-help
 Display usage summary.
 
 .TP
-.B --names
+.B \-\-names
 For
 .BR "slidetool prop list" ,
 omit property values.
 
 .TP
-.B --version
+.B \-\-version
 Display version and copyright information.
 
 .SH EXIT STATUS
@@ -178,7 +178,7 @@ OpenSlide comes with NO WARRANTY, to the extent permitted by law.
 See the GNU Lesser General Public License for more details.
 
 .SH SEE ALSO
-.BR openslide-quickhash1sum (1),
-.BR openslide-show-properties (1),
-.BR openslide-write-png (1),
+.BR openslide\-quickhash1sum (1),
+.BR openslide\-show\-properties (1),
+.BR openslide\-write\-png (1),
 .BR sha256sum (1)


### PR DESCRIPTION
groff &ge; 1.23.0 remaps unescaped `-` characters to Unicode HYPHEN, not ASCII dash.  For dashes that are part of command-line arguments, this causes misbehavior if the arguments are pasted into a shell.  Escape all affected dashes.

See [article](https://lwn.net/Articles/947941/).