### PR TITLE
workflows: explicitly request Windows container

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -271,6 +271,8 @@ jobs:
       - name: Find builder container digest
         id: find
         uses: openslide/openslide-winbuild/.github/find-container-digest@main
+        with:
+          builder_image: windows
       - name: Calculate parameters
         id: params
         run: |


### PR DESCRIPTION
Use API introduced in openslide/openslide-winbuild#164.