### PR TITLE
meson: allow parent project to find executables and public headers

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -46,6 +46,7 @@ openslide_sources = [
   'openslide.c',
   'openslide-cache.c',
   openslide_dll_o,
+  'openslide-decode-dicom.c',
   'openslide-decode-gdkpixbuf.c',
   'openslide-decode-jp2k.c',
   'openslide-decode-jpeg.c',
@@ -62,6 +63,7 @@ openslide_sources = [
   openslide_tables_c,
   'openslide-util.c',
   'openslide-vendor-aperio.c',
+  'openslide-vendor-dicom.c',
   'openslide-vendor-generic-tiff.c',
   'openslide-vendor-hamamatsu.c',
   'openslide-vendor-leica.c',
@@ -72,12 +74,6 @@ openslide_sources = [
   'openslide-vendor-trestle.c',
   'openslide-vendor-ventana.c',
 ]
-if dicom_dep.found()
-  openslide_sources += [
-    'openslide-decode-dicom.c',
-    'openslide-vendor-dicom.c',
-  ]
-endif
 libopenslide = library('openslide',
   openslide_sources,
   version : soversion,

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,10 +31,10 @@ else
 endif
 
 # Public headers
-openslide_headers = [
+openslide_headers = files(
   'openslide.h',
   'openslide-features.h',
-]
+)
 include_subdir = 'openslide'
 install_headers(
   openslide_headers,

--- a/src/openslide-decode-jp2k.c
+++ b/src/openslide-decode-jp2k.c
@@ -225,8 +225,6 @@ bool _openslide_jp2k_decode_buffer(uint32_t *dest,
   g_assert(datalen >= 0);
 
   // init stream
-  // avoid tracking stream offset (and implementing skip callback) by having
-  // OpenJPEG read the whole buffer at once
   g_autoptr(opj_stream_t) stream = opj_stream_create(datalen, true);
   struct buffer_state state = {
     .data = data,

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -23,7 +23,7 @@ else
   ]
 endif
 foreach target : tools_binaries
-  executable(
+  exe = executable(
     target,
     [
       'slidetool.c',
@@ -43,6 +43,7 @@ foreach target : tools_binaries
     install : true,
     install_tag : 'bin',
   )
+  set_variable(target.underscorify(), exe)
 endforeach
 
 mans = [


### PR DESCRIPTION
openslide-bin can use this to package a bdist ZIP from Meson.