### PR TITLE
meson: add a private option to filter out non-OpenSlide symbols

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -161,6 +161,16 @@ endif
 
 # Test suite options
 visibility = get_option('_export_internal_symbols') ? '' : 'hidden'
+libopenslide_link_args = (
+  # On macOS, openslide-bin needs to keep non-OpenSlide symbols out of the
+  # combined dylib, but it can't do it via global link options without
+  # breaking the exports of the OpenSlide Java JNI library.  Until Meson
+  # allows passing compiler flags to individual subprojects, provide a
+  # workaround here.
+  # https://github.com/mesonbuild/meson/issues/11002
+  get_option('_filter_external_symbols') and host_machine.system() == 'darwin'
+  ? ['-Wl,-exported_symbol,_openslide_*'] : []
+)
 if get_option('_gcov')
   add_project_arguments(
     '-O0',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -30,6 +30,12 @@ option(
   description : 'For test suite; do not use',
 )
 option(
+  '_filter_external_symbols',
+  type : 'boolean',
+  value : false,
+  description : 'For openslide-bin; do not use',
+)
+option(
   '_gcov',
   type : 'boolean',
   value : false,

--- a/src/meson.build
+++ b/src/meson.build
@@ -78,6 +78,7 @@ libopenslide = library('openslide',
   openslide_sources,
   version : soversion,
   c_args : ['-D_OPENSLIDE_BUILDING_DLL', '-DG_LOG_DOMAIN="OpenSlide"'],
+  link_args : libopenslide_link_args,
   gnu_symbol_visibility : visibility,
   include_directories : config_h_include,
   dependencies : [


### PR DESCRIPTION
On macOS, openslide-bin needs to use a linker option to filter out non-OpenSlide exported symbols.  It can't set the option globally because that would break OpenSlide Java, and can't set a per-project option because Meson doesn't support that.  Add a private option to do the filtering until Meson provides syntax for this.