### PR TITLE
meson: fix detection of `g_autoptr` support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -131,11 +131,9 @@ if glib_dep.type_name() != 'internal'
   # Courtesy check that the compiler supports the cleanup attribute.  If
   # glib is another subpackage, we can't check, so fail at build time if not.
   # glib only offers autoptr macros when the compiler supports them.
-  cc.has_header_symbol(
-    'glib.h', 'G_DEFINE_AUTOPTR_CLEANUP_FUNC',
-    dependencies : glib_dep,
-    required : true,
-  )
+  if not cc.has_header_symbol('glib.h', 'g_autofree', dependencies : glib_dep)
+    error('OpenSlide requires the GNU C "cleanup" attribute.')
+  endif
 endif
 
 # Test configuration


### PR DESCRIPTION
`G_DEFINE_AUTOPTR_CLEANUP_FUNC` is always defined, since omitting it is harmless.  `g_autofree` is conditionally defined, since omitting it would cause leaks.  Check for that instead, and produce a somewhat clearer error if the check fails.

Closes https://github.com/openslide/openslide/issues/536.