### PR TITLE
Add basic pre-commit checks; move some existing CI checks into pre-commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,10 @@
 # Shell scripts can't have CRLF line endings
-*.sh		eol=lf
+*.sh				eol=lf
 
 # Omit from release tarball
-.gitattributes	export-ignore
-.gitignore	export-ignore
-/.github	export-ignore
-/misc		export-ignore
-/test/cases	export-ignore
+.gitattributes			export-ignore
+.gitignore			export-ignore
+/.github			export-ignore
+/.pre-commit-config.yaml	export-ignore
+/misc				export-ignore
+/test/cases			export-ignore

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -14,6 +14,18 @@ env:
   PYTHONUNBUFFERED: 1
 
 jobs:
+  pre-commit:
+    name: Rerun pre-commit checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.0
   tests:
     name: Build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -167,14 +167,6 @@ jobs:
         esac
     - name: Check out repo
       uses: actions/checkout@v4
-    - name: Check for uninitialized g_auto variables
-      if: matrix.extra
-      run: |
-        git config --global --add safe.directory $GITHUB_WORKSPACE
-        if git grep -En 'g_auto\(|g_autoptr\(|g_autofree ' | grep -v = ; then
-            echo "Found g_auto* declarations without initializers"
-            exit 1
-        fi
     - name: Build
       run: |
         args=

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -236,21 +236,6 @@ jobs:
       with:
         key: pristine
         path: builddir/test/_slidedata/pristine
-    - name: Check for overlarge tests
-      if: matrix.extra
-      run: |
-        # We don't want to allow arbitrarily large binary diffs into the
-        # repo, where they'll live in the Git history forever.  At the time
-        # of writing, our largest xdelta diff is 4881 bytes.  Arbitrarily
-        # set the cutoff at 6000.
-        # https://openslide.org/docs/testsuite/#tips
-        THRESHOLD=6000
-        large=$(find test/cases -type f -size +${THRESHOLD}c)
-        if [ -n "$large" ]; then
-            echo "Found test case files larger than $THRESHOLD bytes:"
-            echo "$large"
-            exit 1
-        fi
     # Can't cache frozen tests because cache doesn't handle sparse files
     - name: Unpack tests
       run: |

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -91,14 +91,14 @@ jobs:
                     dnf install -y epel-release epel-next-release
                     ;;
                 *)
-                    extra="git-core clang doxygen llvm valgrind valgrind-devel"
+                    extra="clang doxygen llvm valgrind valgrind-devel"
                     extra="$extra dnf-plugins-core"
                     debuginfo=1
                     ;;
                 esac
 
                 dnf install -y \
-                    gcc git meson pkg-config \
+                    gcc git-core meson pkg-config \
                     $python python${pyver}-requests python${pyver}-pyyaml \
                     diffutils \
                     zlib-devel \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# exclude vendored files
+exclude: '^(COPYING\.LESSER|subprojects/.*)$'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+        args: [--maxkb=200]
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-vcs-permalinks
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,11 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+
+  - repo: local
+    hooks:
+      - id: autoptr
+        name: Check for g_auto* declarations without initializers
+        language: pygrep
+        types: [c]
+        entry: "(g_auto\\(|g_autoptr\\(|g_autofree )(?!.+=)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,15 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
+      # We don't want to allow arbitrarily large binary diffs into the
+      # repo, where they'll live in the Git history forever.  At the time
+      # of writing, our largest xdelta diff is 4881 bytes.  Arbitrarily
+      # set the cutoff at 6000.
+      # https://openslide.org/docs/testsuite/#tips
+      - id: check-added-large-files
+        name: Check for overlarge tests
+        args: [--maxkb=6]
+        files: ^test/cases/
       - id: check-added-large-files
         args: [--maxkb=200]
       - id: check-case-conflict

--- a/misc/decode-trestle-tile-position.py
+++ b/misc/decode-trestle-tile-position.py
@@ -36,4 +36,3 @@ while True:
     print "%12d:" % (i) + (int_format * 2) % (a0, a1) + "   " + "".join(map(bin, d0)) + (int_format * 2) % (b0, b1) + "   " + "".join(map(bin, d1))
 
     i = i + 1
-

--- a/misc/reconstruct.m
+++ b/misc/reconstruct.m
@@ -7,16 +7,16 @@ function reconstructed_image = reconstruct(files,cvt_to_int)
     % Check whether there is a specific rounding mode requested.
     if (nargin==1)
         cvt_to_int = @(x)round(x);
-    end    
-    
+    end
+
     % Define how many tile images there are and read them.
     num_images = length(files);
-    tile_images = cell(num_images,1);    
-    
+    tile_images = cell(num_images,1);
+
     for img_idx=1:num_images
         tile_images{img_idx} = imread(files{img_idx});
     end
-    
+
     % Store the size of the tile images.
     [height width channels] = size(tile_images{1});
 
@@ -29,27 +29,27 @@ function reconstructed_image = reconstruct(files,cvt_to_int)
     tiles.width = width/num_tiles_per_dim;
     % float tile height in pixels
     tiles.height = height/num_tiles_per_dim;
-    
+
     % If we do not ceil but floor here, we get missing data!
-    
-    % ceiled tile indices, i.e. 2.65... => 3 and the indices [1 2 3]    
+
+    % ceiled tile indices, i.e. 2.65... => 3 and the indices [1 2 3]
     tiles.indices_x = 1:ceil(tiles.width);
     % ceiled tile indices, i.e. 1.23... => 2 and the indices [1 2]
     tiles.indices_y = 1:ceil(tiles.height);
-    
+
     % compute the tile overlap for the current level
     tiles.overlap = level_0_overlap / 2^pyramid_level;
-    
+
     % allocate memory for the output image
     reconstructed_image = 255*ones(512,256,3,'uint8');
-    
+
     for img_idx=1:2
         for tile_idx_y=1:num_tiles_per_dim
             for tile_idx_x=1:num_tiles_per_dim
-                
+
                 % The jpeg image containing all tiles
-                tile_image = tile_images{img_idx};                
-                
+                tile_image = tile_images{img_idx};
+
                 % - We iterate over all tiles in the jpeg image and need to
                 % compute their pixel offsets, i.e. the pixel index of the
                 % upper left corner of a tile.
@@ -60,18 +60,18 @@ function reconstructed_image = reconstruct(files,cvt_to_int)
                 % should be C compatible (zero based indices)
                 tile_off_x = cvt_to_int((tile_idx_x-1)*tiles.width);
                 tile_off_y = cvt_to_int((tile_idx_y-1)*tiles.height);
-                
+
                 % Here, we are just computing the actual pixel indices.
                 % These indices are now Matlab style (one based)
                 tile_indices_x = tile_off_x + tiles.indices_x;
-                tile_indices_y = tile_off_y + tiles.indices_y;                                
-                
+                tile_indices_y = tile_off_y + tiles.indices_y;
+
                 % Next, we need to compute where to paste the tile in the
                 % image. We do this in three steps.
                 % 1. Compute the numerical correct values in one image.
                 img_off_x = (tile_idx_x-1)*(tiles.width-tiles.overlap);
                 img_off_y = (tile_idx_y-1)*(tiles.height-tiles.overlap);
-                
+
                 % 2. Add the vertical offset for JPEG images above and left
                 % to the current image. In this particular example, there
                 % are only images above.
@@ -81,22 +81,22 @@ function reconstructed_image = reconstruct(files,cvt_to_int)
                 jpeg_height = num_tiles_per_dim*(tiles.height) - ...
                     (num_tiles_per_dim-1)*tiles.overlap;
                 img_off_y = img_off_y + (img_idx-1)*jpeg_height;
-                
+
                 % 3. Again, we need some rounding
                 img_off_x = cvt_to_int(img_off_x);
                 img_off_y = cvt_to_int(img_off_y);
-                
+
                 % ... and again, we need the actual Matlab compatible image
                 % indices.
                 img_indices_x = img_off_x + tiles.indices_x;
                 img_indices_y = img_off_y + tiles.indices_y;
-                
+
                 if (max(tile_indices_x(:)) > width), continue; end
                 if (max(tile_indices_y(:)) > height), continue; end
-                
+
                 % extract the current tile
                 tile = tile_image(tile_indices_y, tile_indices_x, :);
-                
+
                 % and paste it to the destination image
                 reconstructed_image(img_indices_y, img_indices_x, :) = tile;
 

--- a/test/parallel.c
+++ b/test/parallel.c
@@ -46,7 +46,7 @@ static struct tile sentinel;
 
 static void *thread_func(void *data) {
   struct state *state = data;
-  struct tile *tile;	
+  struct tile *tile;
   g_autofree uint32_t *buf = g_malloc(TILE_SIZE * TILE_SIZE * sizeof(uint32_t));
 
   g_async_queue_push(state->completions, &sentinel);


### PR DESCRIPTION
OpenSlide Python and now openslide-bin already use [pre-commit](https://pre-commit.com/).  Most of those checks are Python-focused, but there are some useful language-independent ones.  Enable the latter, and convert the existing CI checks for overlarge test cases and for uninitialized autoptrs to pre-commit checks.