### PR TITLE
workflows: don't relink Brew installations of random Python packages

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -61,7 +61,7 @@ jobs:
         macos-*)
             # https://github.com/actions/setup-python/issues/577
             # https://github.com/q3aiml/ledger/commit/f53b35ae
-            brew list -1 | grep python | while read formula; do
+            brew list -1 | grep python@ | while read formula; do
                 brew unlink $formula
                 brew link --overwrite $formula
             done


### PR DESCRIPTION
We only need to unlink and relink installations of Python, not other packages with `python` in their names.