### PR TITLE
gdkpixbuf: add hint to error message on context creation failure

### DIFF
--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -136,6 +136,12 @@ static bool gdkpixbuf_read(const char *format,
   // create loader
   g_autoptr(gdkpixbuf_ctx) ctx = gdkpixbuf_ctx_new(format, w, h, err);
   if (!ctx) {
+    if (err) {
+      g_autofree char *msg = (*err)->message;
+      (*err)->message =
+        g_strdup_printf("%s. Is the gdk-pixbuf \"%s\" decoder installed?",
+                        msg, format);
+    }
     return false;
   }
 


### PR DESCRIPTION
The failure can occur if the requested gdk-pixbuf decoder (currently we only use BMP) is built as a loadable module, packaged separately, and not installed.  Give the user a hint that they may need to install it.

Closes: https://github.com/openslide/openslide/issues/544