### PR TITLE
test/driver: re-add valgrind command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -114,6 +114,7 @@ dicom_dep      = dependency(
   fallback : ['libdicom', 'libdicom_dep'],
   version : '>=1.0.0',
 )
+valgrind_dep   = dependency('valgrind', required : false)
 
 doxygen = find_program(
   'doxygen',
@@ -122,6 +123,10 @@ doxygen = find_program(
 )
 
 # Dependency checks
+if valgrind_dep.found()
+  conf.set('HAVE_VALGRIND', 1)
+endif
+
 if glib_dep.type_name() != 'internal'
   # Courtesy check that the compiler supports the cleanup attribute.  If
   # glib is another subpackage, we can't check, so fail at build time if not.

--- a/test/driver.in
+++ b/test/driver.in
@@ -77,6 +77,10 @@ DEFAULT_FROZEN_BUCKET = 'openslide-frozen-testdata'
 SRCDIR = Path('@SRCDIR@')
 BUILDDIR = Path('@BUILDDIR@')
 CLANG_LSAN_SUPPRESSIONS = SRCDIR / 'clang-lsan.supp'
+VALGRIND_SUPPRESSIONS = SRCDIR / 'valgrind.supp'
+VALGRIND_SUPPRESSIONS_GLIB = Path(
+    '@GLIB2_DATADIR@/glib-2.0/valgrind/glib.supp'
+)
 CASEROOT = SRCDIR / 'cases'
 SLIDELIST = CASEROOT / 'slides.yaml'
 FROZENLIST = CASEROOT / 'frozen.yaml'
@@ -237,6 +241,7 @@ class UnpackedSlide:
     def run_prog(
         self,
         prog: str,
+        valgrind: bool = False,
         extra_checks: bool = True,
         progdir: Path | None = None,
         debug: Iterable[str] | None = None,
@@ -244,11 +249,11 @@ class UnpackedSlide:
         **kwargs: Any,
     ) -> subprocess.Popen[str]:
         '''Start the specified test program from the progdir directory
-        against the slide.  If extra_checks is False, turn off debug
-        instrumentation that would invalidate benchmark results.  debug
-        options are passed in OPENSLIDE_DEBUG.  args are appended to the
-        command line.  kwargs are passed to the Popen constructor.  Return
-        the Popen instance.'''
+        against the slide, running under Valgrind if requested.  If
+        extra_checks is False, turn off debug instrumentation that would
+        invalidate benchmark results.  debug options are passed in
+        OPENSLIDE_DEBUG.  args are appended to the command line.  kwargs are
+        passed to the Popen constructor.  Return the Popen instance.'''
 
         if progdir is None:
             progdir = BUILDDIR
@@ -265,26 +270,46 @@ class UnpackedSlide:
                 G_DEBUG='gc-friendly',
                 MALLOC_CHECK_='1',
             )
-        args_: list[str | Path] = [progdir / prog, self.path_str]
+        args_: list[str | Path] = []
+        if valgrind:
+            args_.extend(
+                [
+                    'valgrind',
+                    '--quiet',
+                    '--error-exitcode=3',
+                    '--suppressions=' + VALGRIND_SUPPRESSIONS.as_posix(),
+                    '--suppressions=' + VALGRIND_SUPPRESSIONS_GLIB.as_posix(),
+                    '--leak-check=full',
+                    '--num-callers=30',
+                ]
+            )
+            env.update(
+                # Valgrind has known issues detecting memory initialization by
+                # libjpeg-turbo SIMD code.  Disable SIMD support.
+                # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/277
+                JSIMD_FORCENONE='1',
+            )
+        args_.extend([progdir / prog, self.path_str])
         if args:
             args_.extend(args)
         return subprocess.Popen(args_, env=env, text=True, **kwargs)
 
     def try_open(
         self,
+        valgrind: bool = False,
         progdir: Path | None = None,
         debug: Iterable[str] | None = None,
         vendor: str | None | type[Skip] = Skip,
         properties: dict[str, str] | None = None,
         regions: Iterable[Iterable[int]] | None = None,
     ) -> str | None:
-        '''Try opening the slide file using the test program in the progdir
-        directory.  Return None on success, error message on failure.
-        vendor is the vendor string that should be returned by
-        openslide_detect_vendor(), None for NULL, or Skip to omit the test.
-        properties is a map of slide properties and their expected values.
-        regions is a list of region tuples (x, y, level, w, h).  debug is a
-        list of OPENSLIDE_DEBUG options.'''
+        '''Try opening the slide file, under Valgrind if specified, using
+        the test program in the progdir directory.  Return None on success,
+        error message on failure.  vendor is the vendor string that should
+        be returned by openslide_detect_vendor(), None for NULL, or Skip to
+        omit the test.  properties is a map of slide properties and their
+        expected values.  regions is a list of region tuples (x, y, level,
+        w, h).  debug is a list of OPENSLIDE_DEBUG options.'''
 
         args = []
         if vendor is not Skip:
@@ -298,6 +323,7 @@ class UnpackedSlide:
                 args.extend(['-r', ' '.join(str(d) for d in region)])
         proc = self.run_prog(
             'try_open',
+            valgrind=valgrind,
             args=args,
             progdir=progdir,
             debug=debug or [],
@@ -314,15 +340,17 @@ class UnpackedSlide:
 
     def try_extended(
         self,
+        valgrind: bool = False,
         progdir: Path | None = None,
         debug: Iterable[str] | None = None,
     ) -> str | None:
-        '''Run the extended test program against the slide file using the
-        test program in the progdir directory.  Return None on success,
-        error message on failure.'''
+        '''Run the extended test program against the slide file, under
+        Valgrind if specified, using the test program in the progdir
+        directory.  Return None on success, error message on failure.'''
 
         proc = self.run_prog(
             'extended',
+            valgrind=valgrind,
             progdir=progdir,
             debug=debug or [],
             stdout=subprocess.PIPE,
@@ -641,13 +669,15 @@ class TestCase:
 
     def run(
         self,
+        valgrind: bool = False,
         xfail: bool = False,
         progdir: Path | None = None,
         workdir: Path = WORKROOT,
     ) -> tuple[bool, str]:
-        '''Run the test.  Also execute extended tests against cases which 1)
-        are marked primary, 2) are expected to succeed, and 3) do in fact
-        succeed.  If xfail is specified, invert the sense of the result.'''
+        '''Run the test, under Valgrind if specified.  Also execute extended
+        tests against cases which 1) are marked primary, 2) are expected to
+        succeed, and 3) do in fact succeed.  If xfail is specified, invert
+        the sense of the result.'''
 
         conf = self.conf
         if not conf.features_available:
@@ -658,6 +688,7 @@ class TestCase:
         else:
             unpacked = UnpackedSlide(workdir / self.name / conf.filename)
         result = unpacked.try_open(
+            valgrind,
             progdir,
             vendor=conf.vendor,
             properties=conf.properties,
@@ -677,7 +708,7 @@ class TestCase:
             msg = _color(RED, f'{self}: incorrect error: {result}')
             ok = False
         elif conf.primary and conf.success:
-            result = unpacked.try_extended(progdir, debug=conf.debug)
+            result = unpacked.try_extended(valgrind, progdir, debug=conf.debug)
             if result:
                 msg = _color(RED, f'{self}: extended test failed: {result}')
                 ok = False
@@ -1243,13 +1274,14 @@ def unfreeze() -> None:
 
 def _run_all(
     pattern: str = '*',
+    valgrind: bool = False,
     xfail: Iterable[str] | None = None,
     progdir: Path | None = None,
     parallel: bool = True,
 ) -> int:
-    '''Run all tests matching the specified pattern.  xfail specifies a list
-    of tests which are expected to fail.  Return the number of tests
-    producing unexpected results.'''
+    '''Run all tests matching the specified pattern, under Valgrind if
+    specified.  xfail specifies a list of tests which are expected to fail.
+    Return the number of tests producing unexpected results.'''
     tests = TestCase.list(pattern)
     for test in tests:
         if not (FROZEN / test.name).exists():
@@ -1272,6 +1304,7 @@ def _run_all(
             futures.append(
                 executor.submit(
                     test.run,
+                    valgrind,
                     test.name in xfail,
                     progdir,
                     workdir=workdir,
@@ -1373,6 +1406,17 @@ def coverage(outfile: str) -> None:
         )
         with open(basedir / outfile, 'w') as fh:
             fh.write(report)
+
+
+@_command
+def valgrind(pattern: str = '*') -> None:
+    '''Unpack and Valgrind all tests matching the specified pattern.
+    Ignore failures of test cases listed in the OPENSLIDE_VALGRIND_XFAIL
+    environment variable.'''
+    xfail_env = os.environ.get('OPENSLIDE_VALGRIND_XFAIL')
+    xfail = xfail_env.split(',') if xfail_env else []
+    if _run_all(pattern, valgrind=True, xfail=xfail):
+        sys.exit(1)
 
 
 @_command

--- a/test/meson.build
+++ b/test/meson.build
@@ -35,7 +35,7 @@ test_synth = executable(
 )
 executable(
   'try_open', 'try_open.c',
-  dependencies : test_deps,
+  dependencies : [test_deps, valgrind_dep],
   c_args : ['-Wno-deprecated-declarations'],
 )
 
@@ -49,6 +49,11 @@ configure_file(
   configuration : {
     'SRCDIR': meson.current_source_dir(),
     'BUILDDIR': meson.current_build_dir(),
+    # Path prefix for glib Valgrind suppressions
+    'GLIB2_DATADIR': gio_dep.get_variable(
+      default_value : '',
+      pkgconfig : 'datadir'
+    ),
     'FEATURES': ' '.join(feature_flags),
   },
 )

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -29,6 +29,11 @@
 #include <glib.h>
 #include "openslide.h"
 #include "openslide-common.h"
+#include "config.h"
+
+#ifdef HAVE_VALGRIND
+#include <valgrind.h>
+#endif
 
 #define MAX_FDS 128
 #define TIME_ITERATIONS 5
@@ -64,6 +69,14 @@ static void check_error(openslide_t *osr) {
   if (error != NULL) {
     fail("%s", error);
   }
+}
+
+static bool in_valgrind(void) {
+#ifdef HAVE_VALGRIND
+  return RUNNING_ON_VALGRIND;
+#else
+  return false;
+#endif
 }
 
 #define CHECK_RET(call, result)			\
@@ -252,6 +265,10 @@ int main(int argc, char **argv) {
     if (!g_hash_table_lookup(fds, GINT_TO_POINTER(i))) {
       g_autofree char *path = common_get_fd_path(i);
       if (path != NULL) {
+        if (in_valgrind() && g_str_has_prefix(path, "pipe:")) {
+          // valgrind likes to open pipes
+          continue;
+        }
         // leaked
         fprintf(stderr, "Leaked file descriptor to %s\n", path);
         have_error = true;

--- a/test/valgrind.supp
+++ b/test/valgrind.supp
@@ -1,0 +1,10 @@
+# Valgrind suppressions
+
+# fontconfig
+{
+    fontconfig leak through cairo_text_extents()
+    Memcheck:Leak
+    ...
+    fun:FcPatternObjectInsertElt
+    fun:FcPatternObjectAddWithBinding
+}


### PR DESCRIPTION
We still use it for the nightly s390x big-endian run.  Don't run it in GitHub Actions, though, to save runtime.

Partially reverts #554.