### PR TITLE
workflows: update actions/cache to v4

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -223,10 +223,11 @@ jobs:
         name: ${{ env.docroot }}
         path: builddir/doc-artifact
     - name: Cache pristine slides
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: pristine
         path: builddir/test/_slidedata/pristine
+        save-always: true
     # Can't cache frozen tests because cache doesn't handle sparse files
     - name: Unpack tests
       run: |


### PR DESCRIPTION
Use the new `save-always` option to save pristine slides even after a CI failure.