### PR TITLE
dicom: set JPEG decode colorspace from DICOM metadata

### DIFF
--- a/src/openslide-decode-jpeg.h
+++ b/src/openslide-decode-jpeg.h
@@ -48,6 +48,12 @@ bool _openslide_jpeg_decode_buffer(const void *buf, uint32_t len,
                                    int32_t w, int32_t h,
                                    GError **err);
 
+bool _openslide_jpeg_decode_buffer_colorspace(const void *buf, uint32_t len,
+                                              J_COLOR_SPACE space,
+                                              uint32_t *dest,
+                                              int32_t w, int32_t h,
+                                              GError **err);
+
 bool _openslide_jpeg_decode_buffer_gray(const void *buf, uint32_t len,
                                         uint8_t *dest,
                                         int32_t w, int32_t h,


### PR DESCRIPTION
Hello everyone, this is a strange PR, here's the referring issue:

https://github.com/ImagingDataCommons/libdicom/issues/80

SVS doesn't set the component ids correctly in their JPEG tiles and readers are supposed to override the JPEG colorspace with the photometric interpretation of the enclosing container.  openslide does this in `decode_jpeg()` in `openslide-decode-tiff.c`.

When bioformats converts SVS to DICOM, it just copies the JPEG tiles over directly and does not fix the component ids. When openslide reads the DICOM file, libjpeg guesses YCbCr for the file encoding (it's really RGB), does the YcbCr -> RGB conversion when it should not, and you get crazy colours.

This PR adds a check for JPEG tiles with unknown component ids and only in this case overrides the `jpeg_color_space` guessed by libjpeg with the photometricinterpretation from the enclosing container.

To reproduce the issue:

```shell
bfconvert -tilex 256 -tiley 256 -compression JPEG -noflat -precompressed CMU-2.svs CMU-2.dcm
```

Then view with openslide. You'll see something like:

![image](https://github.com/openslide/openslide/assets/580843/e9ed8cd8-2164-48e5-9671-987cf57c53de)

Check layer `CMU-2_0_3.dcm` (the smallest pyr layer, with 40 tiles). Extract a tile:

```shell
dcm-getframe -o x.jpg CMU-2_0_3.dcm 1
```

To make:

![x](https://github.com/openslide/openslide/assets/580843/aa1b3031-2af9-43ad-a8da-8433f2567486)

`dcm-getframe` just reads the JPEG from the file, it does no processing. If you check the component ids you'll see 0, 1, 2. It's really 4:4:4 RGB. libjpeg has this code to guess the `color_space`:

```C
    cid0 = cinfo->comp_info[0].component_id;
    cid1 = cinfo->comp_info[1].component_id;
    cid2 = cinfo->comp_info[2].component_id;

    /* First try to guess from the component IDs */
    if      (cid0 == 0x01 && cid1 == 0x02 && cid2 == 0x03)
      cinfo->jpeg_color_space = JCS_YCbCr;
    else if (cid0 == 0x01 && cid1 == 0x22 && cid2 == 0x23)
      cinfo->jpeg_color_space = JCS_BG_YCC;
    else if (cid0 == 0x52 && cid1 == 0x47 && cid2 == 0x42)
      cinfo->jpeg_color_space = JCS_RGB;    /* ASCII 'R', 'G', 'B' */
    else if (cid0 == 0x72 && cid1 == 0x67 && cid2 == 0x62)
      cinfo->jpeg_color_space = JCS_BG_RGB; /* ASCII 'r', 'g', 'b' */
    else if (cinfo->saw_JFIF_marker)
      cinfo->jpeg_color_space = JCS_YCbCr;  /* assume it's YCbCr */
    else if (cinfo->saw_Adobe_marker) {
      switch (cinfo->Adobe_transform) {
      case 0:
    cinfo->jpeg_color_space = JCS_RGB;
    break;
      case 1:
    cinfo->jpeg_color_space = JCS_YCbCr;
    break;
      default:
    WARNMS1(cinfo, JWRN_ADOBE_XFORM, cinfo->Adobe_transform);
    cinfo->jpeg_color_space = JCS_YCbCr;    /* assume it's YCbCr */
    break;
      }
    } else {
      TRACEMS3(cinfo, 1, JTRC_UNKNOWN_IDS, cid0, cid1, cid2);
      cinfo->jpeg_color_space = JCS_YCbCr;  /* assume it's YCbCr */
    }
```

So that code will guess the incorrect YCbCr for this tile, causing the incorrect colours.

If you convert the file with:

```shell
bfconvert -tilex 256 -tiley 256 -compression JPEG -noflat CMU-2.svs CMU-2.dcm
```

It works, since that will reencode all the JPEGs as 4:2:0 YCbCr and set the component ids correctly. Although the DICOM photometricinterpretation will remain RGB, which might or might not be a bug, I'm unclear.