### PR TITLE
dicom: ignore dual-personality TIFF files with `.tif`/`.tiff` file extension

### DIFF
--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -558,11 +558,17 @@ static const struct _openslide_ops dicom_ops = {
   .destroy = destroy,
 };
 
-static bool dicom_detect(const char *filename,
-                         struct _openslide_tifflike *tl G_GNUC_UNUSED,
+static bool dicom_detect(const char *filename, struct _openslide_tifflike *tl,
                          GError **err) {
-  // some vendors use dual-personality TIFF/DCM files, so we can't just reject
-  // tifflike files
+  if (tl && (g_str_has_suffix(filename, ".tif") ||
+             g_str_has_suffix(filename, ".tiff"))) {
+    // let the generic-tiff driver handle it
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Dual-personality DICOM-TIFF with TIFF filename extension");
+    return false;
+  }
+  // otherwise, ignore any TIFF metadata
+
   g_autoptr(dicom_file) f = dicom_file_new(filename, false, err);
   return f != NULL;
 }

--- a/test/cases/dicom-dual-bigtiff-file-extension/config.yaml
+++ b/test/cases/dicom-dual-bigtiff-file-extension/config.yaml
@@ -1,0 +1,10 @@
+# Dual-personality BigTIFF with .tif file extension should be read as TIFF
+base: DICOM/CMU-1-JP2K-33005.zip
+# generic-tiff driver doesn't support converted Aperio JP2K images
+error: "^Unsupported TIFF compression: 33005$"
+slide: DCM_0.tif
+success: false
+vendor: generic-tiff
+rename:
+  ? DCM_0.dcm
+  : DCM_0.tif


### PR DESCRIPTION
If the specified slide file has a TIFF filename extension, assume the user wants to read it as TIFF, and have the DICOM driver ignore it.