### PR TITLE
workflows: install Requests and PyYAML from Homebrew on macOS

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -79,9 +79,9 @@ jobs:
                 sqlite \
                 cairo \
                 glib \
-                xdelta
-            python3 -m pip install --upgrade pip
-            python3 -m pip install requests PyYAML
+                xdelta \
+                python-requests \
+                pyyaml
             ;;
         ubuntu-*)
             case "${{ matrix.container }}" in


### PR DESCRIPTION
pip has started throwing `This environment is externally managed` errors when installing system-wide.  These days the macOS build uses Python from Homebrew, so switch to installing these packages from Homebrew too.