### PR TITLE
Don't hold DICOM file descriptors open; add tests for stray FDs

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -10,7 +10,9 @@ openslide_common = static_library(
   dependencies : [
     openslide_dep,
     glib_dep,
+    valgrind_dep,
   ],
+  include_directories : config_h_include,
 )
 
 openslide_common_dep = declare_dependency(

--- a/common/openslide-common-fd.c
+++ b/common/openslide-common-fd.c
@@ -37,8 +37,21 @@
 #endif
 
 #include "openslide-common.h"
+#include "config.h"
 
-char *common_get_fd_path(int fd) {
+#ifdef HAVE_VALGRIND
+#include <valgrind.h>
+#endif
+
+static bool in_valgrind(void) {
+#ifdef HAVE_VALGRIND
+  return RUNNING_ON_VALGRIND;
+#else
+  return false;
+#endif
+}
+
+static char *get_fd_path(int fd) {
   struct stat st;
   if (fstat(fd, &st)) {
     return NULL;
@@ -77,4 +90,35 @@ char *common_get_fd_path(int fd) {
 #endif
 
   return g_strdup("<unknown>");
+}
+
+GHashTable *common_get_open_fds(void) {
+  GHashTable *fds = g_hash_table_new(g_direct_hash, g_direct_equal);
+  for (int i = 3; i < COMMON_MAX_FD; i++) {
+    struct stat st;
+    if (!fstat(i, &st)) {
+      g_hash_table_insert(fds, GINT_TO_POINTER(i), GINT_TO_POINTER(1));
+    }
+  }
+  return fds;
+}
+
+bool common_check_open_fds(GHashTable *ignore, const char *msg) {
+  bool ret = true;
+  for (int i = 3; i < COMMON_MAX_FD; i++) {
+    if (ignore && g_hash_table_lookup(ignore, GINT_TO_POINTER(i))) {
+      continue;
+    }
+    g_autofree char *path = get_fd_path(i);
+    if (path) {
+      if (in_valgrind() && g_str_has_prefix(path, "pipe:")) {
+        // valgrind likes to open pipes
+        continue;
+      }
+      // leaked
+      common_warn("%s: %s", msg, path);
+      ret = false;
+    }
+  }
+  return ret;
 }

--- a/common/openslide-common.h
+++ b/common/openslide-common.h
@@ -47,6 +47,9 @@ void common_fail_on_error(openslide_t *osr, const char *fmt, ...);
 
 // fd
 
-char *common_get_fd_path(int fd);
+#define COMMON_MAX_FD 128
+
+GHashTable *common_get_open_fds(void);
+bool common_check_open_fds(GHashTable *ignore, const char *msg);
 
 #endif

--- a/src/openslide-decode-dicom.c
+++ b/src/openslide-decode-dicom.c
@@ -25,7 +25,7 @@
 #include "openslide-decode-dicom.h"
 
 // implements DcmIO
-struct _dicom_io {
+struct _openslide_dicom_io {
   DcmIOMethods *methods;
   struct _openslide_file *file;
 };
@@ -48,7 +48,7 @@ static void propagate_gerror(DcmError **dcm_error, GError *err) {
 
 static DcmIO *vfs_open(DcmError **dcm_error, void *client) {
   const char *filename = (const char *) client;
-  struct _dicom_io *dio = g_new0(struct _dicom_io, 1);
+  struct _openslide_dicom_io *dio = g_new0(struct _openslide_dicom_io, 1);
 
   GError *tmp_err = NULL;
   dio->file = _openslide_fopen(filename, &tmp_err);
@@ -62,7 +62,7 @@ static DcmIO *vfs_open(DcmError **dcm_error, void *client) {
 }
 
 static void vfs_close(DcmIO *io) {
-  struct _dicom_io *dio = (struct _dicom_io *) io;
+  struct _openslide_dicom_io *dio = (struct _openslide_dicom_io *) io;
 
   _openslide_fclose(dio->file);
   g_free(dio);
@@ -70,7 +70,7 @@ static void vfs_close(DcmIO *io) {
 
 static int64_t vfs_read(DcmError **dcm_error G_GNUC_UNUSED, DcmIO *io,
                         char *buffer, int64_t length) {
-  struct _dicom_io *dio = (struct _dicom_io *) io;
+  struct _openslide_dicom_io *dio = (struct _openslide_dicom_io *) io;
 
   // openslide VFS has no error return for read()
   return _openslide_fread(dio->file, buffer, length);
@@ -78,7 +78,7 @@ static int64_t vfs_read(DcmError **dcm_error G_GNUC_UNUSED, DcmIO *io,
 
 static int64_t vfs_seek(DcmError **dcm_error, DcmIO *io,
                         int64_t offset, int whence) {
-  struct _dicom_io *dio = (struct _dicom_io *) io;
+  struct _openslide_dicom_io *dio = (struct _openslide_dicom_io *) io;
 
   GError *tmp_err = NULL;
   if (!_openslide_fseek(dio->file, offset, whence, &tmp_err)) {

--- a/src/openslide-decode-dicom.c
+++ b/src/openslide-decode-dicom.c
@@ -3,7 +3,7 @@
  *
  *  Copyright (c) 2007-2015 Carnegie Mellon University
  *  Copyright (c) 2011 Google, Inc.
- *  Copyright (c) 2022-2023 Benjamin Gilbert
+ *  Copyright (c) 2022-2024 Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -27,7 +27,10 @@
 // implements DcmIO
 struct _openslide_dicom_io {
   DcmIOMethods *methods;
-  struct _openslide_file *file;
+  char *filename;
+  struct _openslide_file *file;  // may not be present without ensure_file()
+  int64_t offset;
+  int64_t size;
 };
 
 void _openslide_dicom_propagate_error(GError **err, DcmError *dcm_error) {
@@ -46,54 +49,82 @@ static void propagate_gerror(DcmError **dcm_error, GError *err) {
   g_error_free(err);
 }
 
+static void dicom_io_free(struct _openslide_dicom_io *dio) {
+  if (dio->file) {
+    _openslide_fclose(dio->file);
+  }
+  g_free(dio->filename);
+  g_free(dio);
+}
+typedef struct _openslide_dicom_io _openslide_dicom_io;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_dicom_io, dicom_io_free);
+
+// ensure dcm->file is available
+static bool ensure_file(struct _openslide_dicom_io *dio, GError **err) {
+  if (dio->file) {
+    return true;
+  }
+  g_autoptr(_openslide_file) f = _openslide_fopen(dio->filename, err);
+  if (!f) {
+    return false;
+  }
+  if (dio->offset && !_openslide_fseek(f, dio->offset, SEEK_SET, err)) {
+    return false;
+  }
+  dio->file = g_steal_pointer(&f);
+  return true;
+}
+
 static DcmIO *vfs_open(DcmError **dcm_error, void *client) {
-  const char *filename = (const char *) client;
-  struct _openslide_dicom_io *dio = g_new0(struct _openslide_dicom_io, 1);
+  g_autoptr(_openslide_dicom_io) dio = g_new0(struct _openslide_dicom_io, 1);
+  dio->filename = g_strdup(client);
 
   GError *tmp_err = NULL;
-  dio->file = _openslide_fopen(filename, &tmp_err);
-  if (!dio->file) {
-    g_free(dio);
+  if (!ensure_file(dio, &tmp_err)) {
+    propagate_gerror(dcm_error, tmp_err);
+    return NULL;
+  }
+  dio->size = _openslide_fsize(dio->file, &tmp_err);
+  if (dio->size == -1) {
     propagate_gerror(dcm_error, tmp_err);
     return NULL;
   }
 
-  return (DcmIO *) dio;
+  return (DcmIO *) g_steal_pointer(&dio);
 }
 
 static void vfs_close(DcmIO *io) {
-  struct _openslide_dicom_io *dio = (struct _openslide_dicom_io *) io;
-
-  _openslide_fclose(dio->file);
-  g_free(dio);
+  dicom_io_free((struct _openslide_dicom_io *) io);
 }
 
-static int64_t vfs_read(DcmError **dcm_error G_GNUC_UNUSED, DcmIO *io,
+static int64_t vfs_read(DcmError **dcm_error, DcmIO *io,
                         char *buffer, int64_t length) {
   struct _openslide_dicom_io *dio = (struct _openslide_dicom_io *) io;
-
+  GError *tmp_err = NULL;
+  if (!ensure_file(dio, &tmp_err)) {
+    propagate_gerror(dcm_error, tmp_err);
+    return 0;
+  }
   // openslide VFS has no error return for read()
-  return _openslide_fread(dio->file, buffer, length);
+  int64_t count = _openslide_fread(dio->file, buffer, length);
+  dio->offset += count;
+  return count;
 }
 
 static int64_t vfs_seek(DcmError **dcm_error, DcmIO *io,
                         int64_t offset, int whence) {
   struct _openslide_dicom_io *dio = (struct _openslide_dicom_io *) io;
-
-  GError *tmp_err = NULL;
-  if (!_openslide_fseek(dio->file, offset, whence, &tmp_err)) {
-    propagate_gerror(dcm_error, tmp_err);
-    return -1;
+  int64_t new_offset =
+    _openslide_compute_seek(dio->offset, dio->size, offset, whence);
+  if (dio->file) {
+    GError *tmp_err = NULL;
+    if (!_openslide_fseek(dio->file, new_offset, SEEK_SET, &tmp_err)) {
+      propagate_gerror(dcm_error, tmp_err);
+      return -1;
+    }
   }
-
-  // libdicom uses lseek(2) semantics, so it must always return the new file
-  // pointer
-  off_t new_position = _openslide_ftell(dio->file, &tmp_err);
-  if (new_position < 0) {
-    propagate_gerror(dcm_error, tmp_err);
-  }
-
-  return new_position;
+  dio->offset = new_offset;
+  return new_offset;
 }
 
 static const DcmIOMethods dicom_open_methods = {
@@ -103,7 +134,10 @@ static const DcmIOMethods dicom_open_methods = {
   .seek = vfs_seek,
 };
 
-DcmFilehandle *_openslide_dicom_open(const char *filename, GError **err) {
+// returns a borrowed reference in *dio_OUT
+DcmFilehandle *_openslide_dicom_open(const char *filename,
+                                     struct _openslide_dicom_io **dio_OUT,
+                                     GError **err) {
   DcmError *dcm_error = NULL;
   DcmIO *io = dcm_io_create(&dcm_error, &dicom_open_methods, (void *) filename);
   if (!io) {
@@ -118,5 +152,12 @@ DcmFilehandle *_openslide_dicom_open(const char *filename, GError **err) {
     return NULL;
   }
 
+  *dio_OUT = (struct _openslide_dicom_io *) io;
   return filehandle;
+}
+
+void _openslide_dicom_io_suspend(struct _openslide_dicom_io *dio) {
+  if (dio->file) {
+    _openslide_fclose(g_steal_pointer(&dio->file));
+  }
 }

--- a/src/openslide-decode-dicom.h
+++ b/src/openslide-decode-dicom.h
@@ -27,10 +27,18 @@
 #include <glib.h>
 #include <dicom/dicom.h>
 
+struct _openslide_dicom_io;
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(DcmFilehandle, dcm_filehandle_destroy)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(DcmFrame, dcm_frame_destroy)
 
-DcmFilehandle *_openslide_dicom_open(const char *filename, GError **err);
+DcmFilehandle *_openslide_dicom_open(const char *filename,
+                                     struct _openslide_dicom_io **dio_OUT,
+                                     GError **err);
+
+// close the underlying file; further I/O will reopen it
+void _openslide_dicom_io_suspend(struct _openslide_dicom_io *dio);
+
 void _openslide_dicom_propagate_error(GError **err, DcmError *dcm_error);
 
 #endif

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -3,7 +3,7 @@
  *
  *  Copyright (c) 2007-2015 Carnegie Mellon University
  *  Copyright (c) 2011 Google, Inc.
- *  Copyright (c) 2022 Benjamin Gilbert
+ *  Copyright (c) 2022-2024 Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -57,11 +57,18 @@ struct dicom_file {
 
   GMutex lock;
   DcmFilehandle *filehandle;
+  struct _openslide_dicom_io *dio;
+  uint64_t dio_users;
   const DcmDataSet *file_meta;
   const DcmDataSet *metadata;
   const char *slide_id;
   enum image_format format;
   enum _openslide_jp2k_colorspace jp2k_colorspace;
+};
+
+// g_auto wrapper struct with reference for runtime I/O
+struct dicom_file_io {
+  struct dicom_file *file;
 };
 
 struct dicom_level {
@@ -201,6 +208,30 @@ static void dicom_file_destroy(struct dicom_file *f) {
 typedef struct dicom_file dicom_file;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(dicom_file, dicom_file_destroy)
 
+// get a dicom_file reference for I/O
+static struct dicom_file_io dicom_file_io_get(struct dicom_file *f) {
+  g_mutex_lock(&f->lock);
+  f->dio_users++;
+  g_mutex_unlock(&f->lock);
+
+  struct dicom_file_io fio = {
+    .file = f,
+  };
+  return fio;
+}
+
+// put a dicom_file reference, and close the underlying _openslide_file if idle
+static void dicom_file_io_put(struct dicom_file_io *fio) {
+  g_mutex_lock(&fio->file->lock);
+  if (!--fio->file->dio_users) {
+    _openslide_dicom_io_suspend(fio->file->dio);
+  }
+  g_mutex_unlock(&fio->file->lock);
+}
+
+typedef struct dicom_file_io dicom_file_io;
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(dicom_file_io, dicom_file_io_put)
+
 static bool get_tag_int(const DcmDataSet *dataset,
                         const char *keyword,
                         int64_t *result) {
@@ -326,7 +357,7 @@ static struct dicom_file *dicom_file_new(const char *filename,
   g_autoptr(dicom_file) f = g_new0(struct dicom_file, 1);
   g_mutex_init(&f->lock);
 
-  f->filehandle = _openslide_dicom_open(filename, err);
+  f->filehandle = _openslide_dicom_open(filename, &f->dio, err);
   if (!f->filehandle) {
     return NULL;
   }
@@ -360,6 +391,9 @@ static struct dicom_file *dicom_file_new(const char *filename,
       return NULL;
     }
   }
+
+  // done with I/O for now
+  _openslide_dicom_io_suspend(f->dio);
 
   return g_steal_pointer(&f);
 }
@@ -511,6 +545,7 @@ static bool paint_region(openslide_t *osr G_GNUC_UNUSED,
                          GError **err) {
   struct dicom_level *l = (struct dicom_level *) level;
 
+  g_auto(dicom_file_io) fio G_GNUC_UNUSED = dicom_file_io_get(l->file);
   return _openslide_grid_paint_region(l->grid, cr, NULL,
                                       x / l->base.downsample,
                                       y / l->base.downsample,
@@ -601,6 +636,7 @@ static bool associated_get_argb_data(struct _openslide_associated_image *img,
                                      uint32_t *dest,
                                      GError **err) {
   struct associated *a = (struct associated *) img;
+  g_auto(dicom_file_io) fio G_GNUC_UNUSED = dicom_file_io_get(a->file);
   return decode_frame(a->file, 0, 0, dest, a->base.w, a->base.h, err);
 }
 

--- a/test/extended.c
+++ b/test/extended.c
@@ -194,6 +194,8 @@ int main(int argc, char **argv) {
     return 0;
   }
 
+  g_autoptr(GHashTable) fds = common_get_open_fds();
+
   openslide_get_version();
 
   if (!openslide_detect_vendor(path)) {
@@ -202,6 +204,7 @@ int main(int argc, char **argv) {
 
   openslide_t *osr = openslide_open(path);
   common_fail_on_error(osr, "Couldn't open %s", path);
+  common_check_open_fds(fds, "Open file descriptor after openslide_open()");
   openslide_close(osr);
 
   osr = openslide_open(path);
@@ -298,6 +301,8 @@ int main(int argc, char **argv) {
     bounds_yy = g_ascii_strtoll(bounds_y, NULL, 10);
     test_image_fetch(osr, bounds_xx, bounds_yy, 200, 200);
   }
+
+  common_check_open_fds(fds, "Open file descriptor after reading pixel data");
 
   openslide_close(osr);
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -35,7 +35,7 @@ test_synth = executable(
 )
 executable(
   'try_open', 'try_open.c',
-  dependencies : [test_deps, valgrind_dep],
+  dependencies : test_deps,
   c_args : ['-Wno-deprecated-declarations'],
 )
 


### PR DESCRIPTION
OpenSlide generally avoids holding file descriptors open when idle, allowing the application to cache OpenSlide handles without consuming FDs.  Have the DICOM driver close FDs when not using them.  Add tests to ensure FDs aren't left open after opening a slide or reading regions or associated images.