### PR TITLE
workflows: update to macOS 14

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -52,7 +52,7 @@ jobs:
           - os: ubuntu-20.04
             ignore-cloexec-leaks: ignore CLOEXEC leaks
           - os: ubuntu-22.04
-          - os: macos-12
+          - os: macos-14
             sanitize: sanitize
     steps:
     - name: Install dependencies


### PR DESCRIPTION
This implicitly switches the build host to ARM64, which gets us some ARM-based testing.