### PR TITLE
workflows: automatically create draft GitHub release when tagged

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,9 +2,8 @@
 
 - [ ] Update `CHANGELOG.md` and `version` and `soversion` in `meson.build`
 - [ ] Create and push signed tag
-- [ ] Ensure Meson version is at least 0.60
-- [ ] `git clean -dxf && meson setup builddir && meson dist -C builddir`
-- [ ] Attach release notes to [GitHub release](https://github.com/openslide/openslide/releases/new) and upload tarball
+- [ ] Verify that GitHub Actions created a draft [GitHub release](https://github.com/openslide/openslide/releases) with release notes and a source tarball
+- [ ] Add a long-form release description to the GitHub release; publish
 - [ ] [Update openslide-bin](https://github.com/openslide/openslide-bin/issues/new?labels=release&template=release.md)
 - [ ] Update website: `_data/releases.yaml`, `_includes/news.md`, `api/`
 - [ ] Start a [CI build](https://github.com/openslide/openslide.github.io/actions/workflows/retile.yml) of the demo site

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -208,6 +208,7 @@ jobs:
         trap "cat builddir/meson-logs/testlog.txt" EXIT
         meson test -C builddir
     - name: Docs
+      id: docs
       if: matrix.extra
       run: |
         cd builddir
@@ -215,12 +216,12 @@ jobs:
         docroot=openslide-docs-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)
         mkdir doc-artifact
         mv doc/html doc-artifact/${docroot}
-        echo "docroot=${docroot}" >> $GITHUB_ENV
+        echo "doc-base=${docroot}" >> $GITHUB_OUTPUT
     - name: Archive docs
       if: matrix.extra
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.docroot }}
+        name: ${{ steps.docs.outputs.doc-base }}
         path: builddir/doc-artifact
     - name: Cache pristine slides
       uses: actions/cache@v4

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -214,15 +214,15 @@ jobs:
         cd builddir
         ninja doc/html
         docroot=openslide-docs-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)
-        mkdir doc-artifact
-        mv doc/html doc-artifact/${docroot}
+        mkdir -p ../artifacts/docs
+        mv doc/html ../artifacts/docs/${docroot}
         echo "doc-base=${docroot}" >> $GITHUB_OUTPUT
     - name: Archive docs
       if: matrix.extra
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.docs.outputs.doc-base }}
-        path: builddir/doc-artifact
+        path: artifacts/docs
     - name: Cache pristine slides
       uses: actions/cache@v4
       with:

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -263,7 +263,9 @@ jobs:
               echo "suffix=$(date +%Y%m%d).pr.${{ github.event.number }}.${{ github.run_number }}.${{ github.run_attempt }}.$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT
               ;;
           push)
-              echo "suffix=$(date +%Y%m%d).${GITHUB_REF#refs/heads/}.$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT
+              ref="${GITHUB_REF#refs/heads/}"
+              ref="${ref#refs/tags/}"
+              echo "suffix=$(date +%Y%m%d).${ref}.$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT
               ;;
           *)
               echo "Unknown event type ${{ github.event_name }}"

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -26,10 +26,13 @@ jobs:
           python-version: '3.12'
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
-  tests:
+
+  build:
     name: Build
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+    outputs:
+      dist-base: ${{ steps.dist.outputs.dist-base }}
     strategy:
       matrix:
         include:
@@ -223,6 +226,23 @@ jobs:
       with:
         name: ${{ steps.docs.outputs.doc-base }}
         path: artifacts/docs
+    - name: Dist
+      id: dist
+      if: matrix.extra
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        meson dist -C builddir
+        dist="openslide-dist-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)"
+        mkdir -p "artifacts/dist/$dist"
+        mv builddir/meson-dist/*.tar.xz "artifacts/dist/$dist"
+        echo "dist-base=$dist" >> $GITHUB_OUTPUT
+    - name: Archive dist
+      if: matrix.extra
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.dist.outputs.dist-base }}
+        path: artifacts/dist
+        compression-level: 0
     - name: Cache pristine slides
       uses: actions/cache@v4
       with:
@@ -283,3 +303,35 @@ jobs:
       suffix: ${{ needs.windows_setup.outputs.suffix }}
       werror: true
       windows_builder_repo_and_digest: ${{ needs.windows_setup.outputs.windows_builder_repo_and_digest }}
+
+  release:
+    name: Release
+    if: github.ref_type == 'tag'
+    needs: [build, windows_build]
+    runs-on: ubuntu-latest
+    concurrency: release-${{ github.ref }}
+    permissions:
+      contents: write
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: ${{ needs.build.outputs.dist-base }}
+        merge-multiple: true
+    - name: Release to GitHub
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        version=$(echo "${{ github.ref_name }}" | sed "s/^v//")
+        tar xf "${{ needs.build.outputs.dist-base }}/openslide-${version}.tar.xz"
+        echo -e "## Full changelog\n" > changes
+        awk -e '/^## / && ok {exit}' \
+            -e '/^## / {ok=1; next}' \
+            -e 'ok {print}' \
+            "openslide-${version}/CHANGELOG.md" >> changes
+        gh release create --draft --latest --verify-tag \
+            --repo "${{ github.repository }}" \
+            --title "OpenSlide $version" \
+            --notes-file changes \
+            "${{ github.ref_name }}" \
+            "${{ needs.build.outputs.dist-base }}/"*


### PR DESCRIPTION
Run `meson dist` alongside the extra checks in every build, because it's a good idea to test this and because the build job already installs the dependencies for `meson setup`.  Archive the artifact, then conditionally run a second job to create the release.  Leave the release in draft state so a longer-form release description can be added before publishing.

This uses the same release-job pattern as OpenSlide Python, rather than starting a second workflow upon completion of the build workflow.  This results in a skipped job in every PR's job list, but allows the passing of output variables between jobs.

Also fix Windows CI builds from a tag.  This was already broken in 4.0.0, but the CI failure wasn't noticed at the time.