### PR TITLE
pre-commit: check all C code for prohibited funcs without wrappers; prohibit more funcs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,14 +87,20 @@ repos:
         types: [c]
         entry: "(g_auto\\(|g_autoptr\\(|g_autofree )(?!.+=)"
 
-      # Prevent use of dangerous functions.
+      # Prevent use of dangerous or deprecated functions.
       #
       # Deprecated function   Replacement
       # atoi                  g_ascii_strtoll
       # atol                  g_ascii_strtoll
       # atoll                 g_ascii_strtoll
+      # calloc                g_new0
+      # free                  g_free
+      # malloc                g_malloc
+      # realloc               g_realloc
+      # strdup                g_strdup
       # strerror              g_strerror
       # strerror_l            g_strerror
+      # strndup               g_strndup
       # strtoimax             g_ascii_strtoll
       # strtol                g_ascii_strtoll
       # strtoll               g_ascii_strtoll
@@ -106,7 +112,7 @@ repos:
         language: pygrep
         exclude: ^misc/
         types: [c]
-        entry: "(^|\\W)(atoi|atol|atoll|strerror|strerror_l|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax)\\s*\\("
+        entry: "(^|\\W)(atoi|atol|atoll|calloc|free|malloc|realloc|strdup|strerror|strerror_l|strndup|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax)\\s*\\("
 
       # Prevent use of functions with mandatory wrappers in OpenSlide.
       # Wrapper implementations can add "// ci-allow" on the same line to

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,15 +87,31 @@ repos:
         types: [c]
         entry: "(g_auto\\(|g_autoptr\\(|g_autofree )(?!.+=)"
 
-      # Prevent use of dangerous functions and functions with mandatory
-      # wrappers.  Wrapper implementations can add "// ci-allow" on the same
-      # line to skip the check.
+      # Prevent use of dangerous functions.
       #
       # Deprecated function   Replacement
-      # atof                  _openslide_parse_double
       # atoi                  g_ascii_strtoll
       # atol                  g_ascii_strtoll
       # atoll                 g_ascii_strtoll
+      # strtoimax             g_ascii_strtoll
+      # strtol                g_ascii_strtoll
+      # strtoll               g_ascii_strtoll
+      # strtoul               g_ascii_strtoull
+      # strtoull              g_ascii_strtoull
+      # strtoumax             g_ascii_strtoull
+      - id: deny-prohibited
+        name: Check for calls to prohibited functions
+        language: pygrep
+        exclude: ^misc/
+        types: [c]
+        entry: "(^|\\W)(atoi|atol|atoll|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax)\\s*\\("
+
+      # Prevent use of functions with mandatory wrappers in OpenSlide.
+      # Wrapper implementations can add "// ci-allow" on the same line to
+      # skip the check.
+      #
+      # Deprecated function   Replacement
+      # atof                  _openslide_parse_double
       # fclose                _openslide_fclose
       # fopen                 _openslide_fopen
       # fread                 _openslide_fread
@@ -109,12 +125,6 @@ repos:
       # sqlite3_open          _openslide_sqlite_open
       # sqlite3_open_v2       _openslide_sqlite_open
       # strtod                _openslide_parse_double
-      # strtoimax             g_ascii_strtoll
-      # strtol                g_ascii_strtoll
-      # strtoll               g_ascii_strtoll
-      # strtoul               g_ascii_strtoull
-      # strtoull              g_ascii_strtoull
-      # strtoumax             g_ascii_strtoull
       # TIFFClientOpenExt     _openslide_tiffcache_get
       # TIFFClientOpen        _openslide_tiffcache_get
       # TIFFFdOpenExt         _openslide_tiffcache_get
@@ -122,9 +132,9 @@ repos:
       # TIFFOpenExt           _openslide_tiffcache_get
       # TIFFOpen              _openslide_tiffcache_get
       # TIFFSetDirectory      _openslide_tiff_set_dir
-      - id: deny-functions
-        name: Check for calls to prohibited functions
+      - id: deny-wrapped
+        name: Check for calls to wrapped functions
         language: pygrep
         files: ^src/openslide
         types: [c]
-        entry: "(^|\\W)(atof|atoi|atol|atoll|fclose|fopen|fread|fseeko|fseek|ftello|ftell|g_ascii_strtod|g_file_test|sqlite3_close|sqlite3_open|sqlite3_open_v2|strtod|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax|TIFFClientOpenExt|TIFFClientOpen|TIFFFdOpenExt|TIFFFdOpen|TIFFOpenExt|TIFFOpen|TIFFSetDirectory)\\s*\\((?!.+ci-allow)"
+        entry: "(^|\\W)(atof|fclose|fopen|fread|fseeko|fseek|ftello|ftell|g_ascii_strtod|g_file_test|sqlite3_close|sqlite3_open|sqlite3_open_v2|strtod|TIFFClientOpenExt|TIFFClientOpen|TIFFFdOpenExt|TIFFFdOpen|TIFFOpenExt|TIFFOpen|TIFFSetDirectory)\\s*\\((?!.+ci-allow)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,8 @@ repos:
       # atoi                  g_ascii_strtoll
       # atol                  g_ascii_strtoll
       # atoll                 g_ascii_strtoll
+      # strerror              g_strerror
+      # strerror_l            g_strerror
       # strtoimax             g_ascii_strtoll
       # strtol                g_ascii_strtoll
       # strtoll               g_ascii_strtoll
@@ -104,7 +106,7 @@ repos:
         language: pygrep
         exclude: ^misc/
         types: [c]
-        entry: "(^|\\W)(atoi|atol|atoll|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax)\\s*\\("
+        entry: "(^|\\W)(atoi|atol|atoll|strerror|strerror_l|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax)\\s*\\("
 
       # Prevent use of functions with mandatory wrappers in OpenSlide.
       # Wrapper implementations can add "// ci-allow" on the same line to

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,14 @@ repos:
       # atoll                 g_ascii_strtoll
       # calloc                g_new0
       # free                  g_free
+      # g_slice_alloc0        g_malloc0
+      # g_slice_alloc         g_malloc
+      # g_slice_copy          g_memdup
+      # g_slice_dup           g_memdup
+      # g_slice_free1         g_free
+      # g_slice_free          g_free
+      # g_slice_new0          g_new0
+      # g_slice_new           g_new0
       # malloc                g_malloc
       # realloc               g_realloc
       # strdup                g_strdup
@@ -112,7 +120,7 @@ repos:
         language: pygrep
         exclude: ^misc/
         types: [c]
-        entry: "(^|\\W)(atoi|atol|atoll|calloc|free|malloc|realloc|strdup|strerror|strerror_l|strndup|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax)\\s*\\("
+        entry: "(^|\\W)(atoi|atol|atoll|calloc|free|g_slice_alloc0|g_slice_alloc|g_slice_copy|g_slice_dup|g_slice_free1|g_slice_free|g_slice_new0|g_slice_new|malloc|realloc|strdup|strerror|strerror_l|strndup|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax)\\s*\\("
 
       # Prevent use of functions with mandatory wrappers in OpenSlide.
       # Wrapper implementations can add "// ci-allow" on the same line to

--- a/test/parallel.c
+++ b/test/parallel.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     return 2;
   }
 
-  int threads = atoi(argv[2]);
+  int threads = g_ascii_strtoll(argv[2], NULL, 10);
   if (threads < 1) {
     printf("Invalid thread count\n");
     return 1;

--- a/test/profile.c
+++ b/test/profile.c
@@ -37,11 +37,11 @@ int main(int argc, char **argv) {
     common_fail("Usage: %s <slide> <level>", argv[0]);
   }
   const char *path = argv[1];
-  int level = atoi(argv[2]);
+  int level = g_ascii_strtoll(argv[2], NULL, 10);
 
   g_autoptr(openslide_t) osr = openslide_open(path);
   common_fail_on_error(osr, "Couldn't open %s", path);
-  if (level >= openslide_get_level_count(osr)) {
+  if (level < 0 || level >= openslide_get_level_count(osr)) {
     common_fail("No such level: %d", level);
   }
 

--- a/tools/slidetool-icc.c
+++ b/tools/slidetool-icc.c
@@ -46,7 +46,7 @@ static int do_icc_read(int narg, char **args) {
 
   g_auto(output) out = open_output(outfile);
   if (fwrite(icc, icc_size, 1, out.fp) < 1) {
-    common_fail("Can't write %s: %s", outfile, strerror(errno));
+    common_fail("Can't write %s: %s", outfile, g_strerror(errno));
   }
 
   return 0;
@@ -74,7 +74,7 @@ static int do_assoc_icc_read(int narg, char **args) {
 
   g_auto(output) out = open_output(outfile);
   if (fwrite(icc, icc_size, 1, out.fp) < 1) {
-    common_fail("Can't write %s: %s", outfile, strerror(errno));
+    common_fail("Can't write %s: %s", outfile, g_strerror(errno));
   }
 
   return 0;

--- a/tools/slidetool-image.c
+++ b/tools/slidetool-image.c
@@ -214,7 +214,7 @@ static int do_write_png(int narg, char **args) {
   const char *slide = args[0];
   int64_t x = g_ascii_strtoll(args[1], NULL, 10);
   int64_t y = g_ascii_strtoll(args[2], NULL, 10);
-  int32_t level = strtol(args[3], NULL, 10);
+  int32_t level = g_ascii_strtoll(args[3], NULL, 10);
   int64_t width = g_ascii_strtoll(args[4], NULL, 10);
   int64_t height = g_ascii_strtoll(args[5], NULL, 10);
   const char *output = args[6];
@@ -228,7 +228,7 @@ static int do_region_read(int narg, char **args) {
   const char *slide = args[0];
   int64_t x = g_ascii_strtoll(args[1], NULL, 10);
   int64_t y = g_ascii_strtoll(args[2], NULL, 10);
-  int32_t level = strtol(args[3], NULL, 10);
+  int32_t level = g_ascii_strtoll(args[3], NULL, 10);
   int64_t width = g_ascii_strtoll(args[4], NULL, 10);
   int64_t height = g_ascii_strtoll(args[5], NULL, 10);
   const char *output = narg >= 7 ? args[6] : NULL;

--- a/tools/slidetool-util.c
+++ b/tools/slidetool-util.c
@@ -30,7 +30,7 @@ struct output open_output(const char *filename) {
   if (filename) {
     FILE *fp = fopen(filename, "wb");
     if (!fp) {
-      common_fail("Can't open %s for writing: %s", filename, strerror(errno));
+      common_fail("Can't open %s for writing: %s", filename, g_strerror(errno));
     }
     out.fp = fp;
   } else {
@@ -45,11 +45,11 @@ struct output open_output(const char *filename) {
 void _close_output(struct output *out) {
   if (out->fp != stdout) {
     if (fclose(out->fp)) {
-      common_fail("Can't close output: %s", strerror(errno));
+      common_fail("Can't close output: %s", g_strerror(errno));
     }
   } else {
     if (fflush(out->fp)) {
-      common_fail("Can't flush stdout: %s", strerror(errno));
+      common_fail("Can't flush stdout: %s", g_strerror(errno));
     }
   }
 }


### PR DESCRIPTION
Some prohibited functions have replacements provided by glib, not by OpenSlide, so we can enforce the prohibition outside of OpenSlide proper.  Split the prohibited-function test into two pieces, and enforce the generic part everywhere except `misc/`, which contains one-off development scripts.

Prohibit `strerror()` and `strerror_l()`, which are not thread-safe; the libc memory allocator, since we use glib; and the glib slice allocator, which is deprecated upstream.