### PR TITLE
workflows: install Requests with pip on macOS

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -80,8 +80,12 @@ jobs:
                 cairo \
                 glib \
                 xdelta \
-                python-requests \
                 pyyaml
+            # Install Python packages that Homebrew does not wish to maintain.
+            # Use --break-system-packages so pip doesn't refuse to install
+            # outside a virtualenv.
+            python3 -m pip install --break-system-packages \
+                requests
             ;;
         ubuntu-*)
             case "${{ matrix.container }}" in


### PR DESCRIPTION
Avoids deprecation warnings:

    Warning: python-requests has been deprecated because it does not meet homebrew/core's requirements for Python library formulae!
    Warning: python-charset-normalizer has been deprecated because it does not meet homebrew/core's requirements for Python library formulae!
    Warning: python-idna has been deprecated because it does not meet homebrew/core's requirements for Python library formulae!
    Warning: python-urllib3 has been deprecated because it does not meet homebrew/core's requirements for Python library formulae!