### PR TITLE
misc/imhex/mirax-position: support StitchingIntensityLevel

### DIFF
--- a/misc/imhex/hamamatsu-vms-opt.hexpat
+++ b/misc/imhex/hamamatsu-vms-opt.hexpat
@@ -1,8 +1,8 @@
 #pragma description Hamamatsu VMS .opt files
 
-#include <std/core.pat>
-#include <std/io.pat>
-#include <std/mem.pat>
+import std.core;
+import std.io;
+import std.mem;
 
 #pragma endian little
 

--- a/misc/imhex/mirax-index.hexpat
+++ b/misc/imhex/mirax-index.hexpat
@@ -1,7 +1,7 @@
 #pragma description MIRAX Index.dat
 
-#include <std/io.pat>
-#include <std/mem.pat>
+import std.io;
+import std.mem;
 
 #pragma endian little
 #pragma eval_depth 1024

--- a/misc/imhex/mirax-position.hexpat
+++ b/misc/imhex/mirax-position.hexpat
@@ -3,8 +3,8 @@
 // TODO: support StitchingIntensityLevel, automatically inflating with
 // https://github.com/Jusb3/ImHex-Zlib-Plugin
 
-#include <std/io.pat>
-#include <std/mem.pat>
+import std.io;
+import std.mem;
 
 #pragma endian little
 

--- a/misc/imhex/mirax-position.hexpat
+++ b/misc/imhex/mirax-position.hexpat
@@ -1,8 +1,6 @@
 #pragma description MIRAX VIMSLIDE_POSITION_BUFFER non-hierarchical section
 
-// TODO: support StitchingIntensityLevel, automatically inflating with
-// https://github.com/Jusb3/ImHex-Zlib-Plugin
-
+import hex.dec;
 import std.io;
 import std.mem;
 
@@ -26,7 +24,20 @@ struct File {
     char slide_id[32];
     char file[3];
     padding[256];
-    Position positions[while(!std::mem::eof())];
+
+    u8 cmf = std::mem::read_unsigned($, 1, std::mem::Endian::Little);
+    if ((cmf & 0xf) == 8) {
+        u8 cmp[while(!std::mem::eof())] [[hidden]];
+        auto decmp = std::mem::create_section("Decompressed");
+        if (!hex::dec::zlib_decompress(cmp, decmp, 0)) {
+            std::error("Decompression failed");
+        }
+        u32 count = std::mem::get_section_size(decmp) / sizeof(Position);
+        Position positions[count] @ 0 in decmp;
+        str _note = "See Sections tab for positions" [[export]];
+    } else {
+        Position positions[while(!std::mem::eof())];
+    }
 } [[inline]];
 
 File file @ 0;


### PR DESCRIPTION
Automatically decompress position array if needed.

Also switch all ImHex patterns from `#include` to the new `import` statement.