### PR TITLE
workflows: pin to Fedora 39 to avoid `ld` segfault during sanitize

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -37,7 +37,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            container: registry.fedoraproject.org/fedora:latest
+            # Pin to Fedora 39
+            # https://bugzilla.redhat.com/show_bug.cgi?id=2278106
+            container: registry.fedoraproject.org/fedora:39
             extra: extra checks
             sanitize: sanitize
           - os: ubuntu-latest


### PR DESCRIPTION
`test/driver sanitize` hits `ld.bfd` segfaults on Fedora 40 when linking executables.  This might have something to do with our specific build flags, so we might need to troubleshoot further if there's no upstream interest.  For now, just get CI working.

https://bugzilla.redhat.com/show_bug.cgi?id=2278106