### PR TITLE
workflows: link sanitize run with `lld` on Fedora to work around segfault

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -37,9 +37,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            # Pin to Fedora 39
-            # https://bugzilla.redhat.com/show_bug.cgi?id=2278106
-            container: registry.fedoraproject.org/fedora:39
+            container: registry.fedoraproject.org/fedora:latest
             extra: extra checks
             sanitize: sanitize
           - os: ubuntu-latest

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -111,6 +111,8 @@ jobs:
                     ;;
                 *)
                     extra="clang doxygen llvm dnf-plugins-core"
+                    # https://bugzilla.redhat.com/show_bug.cgi?id=2278106
+                    extra="$extra lld"
                     debuginfo=1
                     ;;
                 esac
@@ -263,7 +265,12 @@ jobs:
       run: cd builddir/test && ./driver run
     - name: Sanitize
       if: matrix.sanitize
-      run: cd builddir/test && ./driver sanitize
+      run: |
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2278106
+        if [[ "${{ matrix.container }}" = *fedora* ]]; then
+            export CC_LD=lld
+        fi
+        cd builddir/test && ./driver sanitize
     - name: Check exports
       if: matrix.extra
       run: cd builddir/test && ./driver exports


### PR DESCRIPTION
Pending a fix for [RHBZ 2278106](https://bugzilla.redhat.com/show_bug.cgi?id=2278106), link the sanitize binaries with `lld`.  This lets us switch back to Fedora 40.