### PR TITLE
misc/imhex: add VMU NGR; split VMS optimisations into a struct per JPEG

### DIFF
--- a/misc/imhex/hamamatsu-vms-opt.hexpat
+++ b/misc/imhex/hamamatsu-vms-opt.hexpat
@@ -5,14 +5,28 @@ import std.io;
 import std.mem;
 
 #pragma endian little
+#pragma pattern_limit 1000000
 
 struct Optimisation {
     u32 offset;
     padding[36];
+
+    u32 _next_offset [[hidden, no_unique_address]];
+    if (_next_offset < offset) {
+        break;
+    }
 } [[format_read("read_optimisation")]];
 
 fn read_optimisation(Optimisation v) {
     return std::format("{} (0x{:08X})", v.offset, v.offset);
 };
 
-Optimisation optimisations[while(!std::mem::eof())] @ 0;
+struct File {
+    Optimisation optimisations[while(true)] [[inline]];
+} [[format_read("read_file")]];
+
+fn read_file(File v) {
+    return std::format("{} optimisations", std::core::member_count(v.optimisations));
+};
+
+File files[while(!std::mem::eof())] @ 0;

--- a/misc/imhex/hamamatsu-vmu-ngr.hexpat
+++ b/misc/imhex/hamamatsu-vmu-ngr.hexpat
@@ -1,0 +1,38 @@
+#pragma description Hamamatsu VMU NGR files
+
+#pragma endian little
+#pragma pattern_limit 1000000
+
+import std.io;
+import type.magic;
+
+struct Header {
+    type::Magic<"GN"> magic;
+    padding[2];
+    u32 width;
+    u32 height;
+    u32 column_width;
+    padding[8];
+    u32 start;
+};
+
+struct Pixel {
+    u16 r;
+    u16 g;
+    u16 b;
+} [[format_read("format_pixel"), static]];
+
+fn format_pixel(Pixel p) {
+    return std::format("({}, {}, {})", p.r, p.g, p.b);
+};
+
+struct Row<auto width> {
+    Pixel pixels[width] [[inline]];
+};
+
+struct Column<auto width, auto height> {
+    Row<width> rows[height] [[inline]];
+};
+
+Header header @ 0;
+Column<header.column_width, header.height> columns[header.width / header.column_width] @ header.start;


### PR DESCRIPTION
Whenever the VMS optimisation offset decreases, we've switched to the next JPEG.  Make each JPEG a separate struct in the output.