### PR TITLE
Revert "workflows: install binutils from Fedora updates-testing"

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -138,10 +138,6 @@ jobs:
                 if [ -n "$pydotver" ]; then
                     alternatives --set python3 "/usr/bin/python${pydotver}"
                 fi
-                if [ "$ID" = fedora ]; then
-                    # https://bugzilla.redhat.com/show_bug.cgi?id=2278106
-                    dnf upgrade -y --enablerepo=updates-testing binutils
-                fi
                 ;;
             *debian*|"")
                 if [ -n "${{ matrix.container }}" ]; then


### PR DESCRIPTION
The fix has migrated to `updates`.

This reverts commit 476edad048a83b9018b6a4d0ecda983e178320aa.