### PR TITLE
meson: drop support for testing with 4-byte stack alignment on Win32

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -151,27 +151,6 @@ if glib_dep.type_name() != 'internal'
   endif
 endif
 
-# Test configuration
-test_cflags = declare_dependency()
-if not get_option('test').disabled() and not get_option('check_windows_abi_compat').disabled()
-  # gcc assumes Win32 stack frames are 16-byte-aligned by default, but the
-  # Win32 ABI only requires 4-byte alignment.  If gcc emits aligned SSE
-  # instructions that access the stack, this can cause GPFs if we're called by
-  # a program compiled by a different compiler such as MSVC.  The user is
-  # responsible for choosing compiler options appropriate for their desired
-  # ABI, but this is a sufficiently insidious error that it's worth checking
-  # in the test suite by default.  We do that by compiling the test programs
-  # with 4-byte stack alignment on Win32.  We allow the user to disable that
-  # behavior, however, in case they don't care about ABI compatibility with
-  # other compilers.
-  if host_machine.system() == 'windows' and host_machine.cpu_family() == 'x86'
-    message('Configuring tests with 4-byte stack alignment')
-    test_cflags = declare_dependency(
-      compile_args : cc.get_supported_arguments('-mpreferred-stack-boundary=2'),
-    )
-  endif
-endif
-
 # Test suite options
 visibility = get_option('_export_internal_symbols') ? '' : 'hidden'
 if get_option('_gcov')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,12 +18,6 @@ option(
   description : 'Enable building documentation (requires Doxygen)'
 )
 option(
-  'check_windows_abi_compat',
-  type : 'feature',
-  value : 'auto',
-  description : 'Test with 4-byte stack alignment on 32-bit Windows',
-)
-option(
   '_export_internal_symbols',
   type : 'boolean',
   value : false,

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,7 +2,6 @@ test_deps = [
   declare_dependency(
     include_directories : config_h_include,
   ),
-  test_cflags,
   openslide_dep,
   openslide_common_dep,
   glib_dep,


### PR DESCRIPTION
openslide-bin dropped support for 32-bit Windows, so we won't be running this check in CI.  In fact, we haven't run any Windows tests in a long time (https://github.com/openslide/openslide/issues/367) and probably no one else is either.