### PR TITLE
workflows: switch from `macos-14` to `macos-latest`

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -56,7 +56,7 @@ jobs:
             ignore-cloexec-leaks: ignore CLOEXEC leaks
           - os: ubuntu-22.04
           - os: ubuntu-24.04
-          - os: macos-14
+          - os: macos-latest
             sanitize: sanitize
     steps:
     - name: Install dependencies


### PR DESCRIPTION
The latter is now an alias for the former.  Switch back so we get future OS updates.