### PR TITLE
Add GError argument to `_openslide_fread()`; add `_openslide_fread_exact()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,7 +130,7 @@ repos:
       # atof                  _openslide_parse_double
       # fclose                _openslide_fclose
       # fopen                 _openslide_fopen
-      # fread                 _openslide_fread
+      # fread                 _openslide_fread or _openslide_fread_exact
       # fseeko                _openslide_fseek
       # fseek                 _openslide_fseek
       # ftello                _openslide_ftell

--- a/src/openslide-decode-dicom.c
+++ b/src/openslide-decode-dicom.c
@@ -103,7 +103,7 @@ static int64_t vfs_read(DcmError **dcm_error, DcmIO *io,
   GError *tmp_err = NULL;
   if (!ensure_file(dio, &tmp_err)) {
     propagate_gerror(dcm_error, tmp_err);
-    return 0;
+    return -1;
   }
   // openslide VFS has no error return for read()
   int64_t count = _openslide_fread(dio->file, buffer, length);

--- a/src/openslide-decode-dicom.c
+++ b/src/openslide-decode-dicom.c
@@ -105,8 +105,11 @@ static int64_t vfs_read(DcmError **dcm_error, DcmIO *io,
     propagate_gerror(dcm_error, tmp_err);
     return -1;
   }
-  // openslide VFS has no error return for read()
-  int64_t count = _openslide_fread(dio->file, buffer, length);
+  int64_t count = _openslide_fread(dio->file, buffer, length, &tmp_err);
+  if (tmp_err) {
+    propagate_gerror(dcm_error, tmp_err);
+    return -1;
+  }
   dio->offset += count;
   return count;
 }

--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -127,7 +127,7 @@ static struct gdkpixbuf_ctx *gdkpixbuf_ctx_new(const char *format,
 }
 
 static bool gdkpixbuf_read(const char *format,
-                           size_t (*read_callback)(void *out, void *in, size_t size),
+                           size_t (*read_callback)(void *out, void *in, size_t size, GError **err),
                            void *callback_data,
                            uint64_t length,
                            uint32_t *dest,
@@ -148,10 +148,15 @@ static bool gdkpixbuf_read(const char *format,
   // read data
   g_autofree void *buf = g_malloc(BUFSIZE);
   while (length) {
-    size_t count = read_callback(buf, callback_data, MIN(length, BUFSIZE));
-    if (!count) {
+    GError *tmp_err = NULL;
+    size_t count =
+      read_callback(buf, callback_data, MIN(length, BUFSIZE), &tmp_err);
+    if (tmp_err) {
+      g_propagate_prefixed_error(err, tmp_err, "Loading pixbuf: ");
+      return false;
+    } else if (!count) {
       g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                  "Short read loading pixbuf");
+                  "EOF loading pixbuf");
       return false;
     }
     if (!gdk_pixbuf_loader_write(ctx->loader, buf, count, err)) {
@@ -189,8 +194,9 @@ static bool gdkpixbuf_read(const char *format,
   return true;
 }
 
-static size_t file_read_callback(void *out, void *in, size_t size) {
-  return _openslide_fread(in, out, size);
+static size_t file_read_callback(void *out, void *in, size_t size,
+                                 GError **err) {
+  return _openslide_fread(in, out, size, err);
 }
 
 bool _openslide_gdkpixbuf_read(const char *format,
@@ -218,7 +224,8 @@ struct mem {
   size_t len;
 };
 
-static size_t mem_read_callback(void *out, void *in, size_t size) {
+static size_t mem_read_callback(void *out, void *in, size_t size,
+                                GError **err G_GNUC_UNUSED) {
   struct mem *mem = in;
   size_t count = MIN(size, mem->len - mem->off);
   memcpy(out, mem->buf + mem->off, count);

--- a/src/openslide-decode-gdkpixbuf.c
+++ b/src/openslide-decode-gdkpixbuf.c
@@ -211,7 +211,6 @@ bool _openslide_gdkpixbuf_read(const char *format,
     return false;
   }
   if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
-    g_prefix_error(err, "Couldn't fseek %s: ", filename);
     return false;
   }
   return gdkpixbuf_read(format, file_read_callback, f, length,

--- a/src/openslide-decode-jpeg.c
+++ b/src/openslide-decode-jpeg.c
@@ -311,7 +311,6 @@ bool _openslide_jpeg_read_file_dimensions(struct _openslide_file *f,
                                           int32_t *w, int32_t *h,
                                           GError **err) {
   if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
-    g_prefix_error(err, "Cannot seek to offset: ");
     return false;
   }
 
@@ -391,7 +390,6 @@ bool _openslide_jpeg_read_file(struct _openslide_file *f,
                                int32_t w, int32_t h,
                                GError **err) {
   if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
-    g_prefix_error(err, "Cannot seek to offset: ");
     return false;
   }
 

--- a/src/openslide-decode-png.c
+++ b/src/openslide-decode-png.c
@@ -203,7 +203,6 @@ bool _openslide_png_read(const char *filename,
     return false;
   }
   if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
-    g_prefix_error(err, "Couldn't fseek %s: ", filename);
     return false;
   }
   return png_read(file_read_callback, f, dest, w, h, err);

--- a/src/openslide-decode-png.c
+++ b/src/openslide-decode-png.c
@@ -187,7 +187,8 @@ static bool png_read(png_rw_ptr read_callback, void *callback_data,
 
 static void file_read_callback(png_struct *png, png_byte *buf, png_size_t len) {
   struct _openslide_file *f = png_get_io_ptr(png);
-  if (_openslide_fread(f, buf, len) != len) {
+  if (!_openslide_fread_exact(f, buf, len, NULL)) {
+    // passing a dynamic string would leak it
     png_error(png, "Read failed");
   }
 }

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -649,7 +649,6 @@ static TIFF *tiff_open(struct _openslide_tiffcache *tc, GError **err) {
   // get size
   int64_t size = _openslide_fsize(f, err);
   if (size == -1) {
-    g_prefix_error(err, "Couldn't get size of %s: ", tc->filename);
     return NULL;
   }
 

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -563,7 +563,7 @@ static tsize_t tiff_do_read(thandle_t th, tdata_t buf, tsize_t size) {
     }
     hdl->f = g_steal_pointer(&f);
   }
-  int64_t rsize = _openslide_fread(hdl->f, buf, size);
+  int64_t rsize = _openslide_fread(hdl->f, buf, size, NULL);
   hdl->offset += rsize;
   return rsize;
 }

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -100,7 +100,7 @@ static uint64_t read_uint(struct _openslide_file *f, int32_t size,
   g_assert(ok != NULL);
 
   uint8_t buf[size];
-  if (_openslide_fread(f, buf, size) != (size_t) size) {
+  if (!_openslide_fread_exact(f, buf, size, NULL)) {
     *ok = false;
     return 0;
   }
@@ -353,9 +353,8 @@ static bool populate_item(struct _openslide_tifflike *tl,
     g_prefix_error(err, "Couldn't seek to read TIFF value: ");
     return false;
   }
-  if (_openslide_fread(f, buf, len) != len) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Couldn't read TIFF value");
+  if (!_openslide_fread_exact(f, buf, len, err)) {
+    g_prefix_error(err, "Couldn't read TIFF value: ");
     return false;
   }
 
@@ -479,9 +478,8 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
 
     // read in the value/offset
     uint8_t value[bigtiff ? 8 : 4];
-    if (_openslide_fread(f, value, sizeof(value)) != sizeof(value)) {
-      g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                  "Cannot read value/offset");
+    if (!_openslide_fread_exact(f, value, sizeof(value), err)) {
+      g_prefix_error(err, "Cannot read value/offset: ");
       return NULL;
     }
 
@@ -544,9 +542,8 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
 
   // read and check magic
   uint16_t magic;
-  if (_openslide_fread(f, &magic, sizeof magic) != sizeof magic) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Can't read TIFF magic number");
+  if (!_openslide_fread_exact(f, &magic, sizeof magic, err)) {
+    g_prefix_error(err, "Can't read TIFF magic number: ");
     return NULL;
   }
   if (magic != TIFF_BIGENDIAN && magic != TIFF_LITTLEENDIAN) {

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -419,7 +419,6 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
 
   // no loop, let's seek
   if (!_openslide_fseek(f, off, SEEK_SET, err)) {
-    g_prefix_error(err, "Cannot seek to offset: ");
     return NULL;
   }
 

--- a/src/openslide-file.c
+++ b/src/openslide-file.c
@@ -135,6 +135,21 @@ size_t _openslide_fread(struct _openslide_file *file, void *buf, size_t size) {
   return total;
 }
 
+bool _openslide_fread_exact(struct _openslide_file *file,
+                            void *buf, size_t size, GError **err) {
+  size_t count = _openslide_fread(file, buf, size);
+  if (!count && ferror(file->fp)) {
+    g_set_error(err, G_FILE_ERROR, G_FILE_ERROR_IO, "I/O error");
+    return false;
+  } else if (count < size) {
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Short read: %"PRIu64" < %"PRIu64,
+                (uint64_t) count, (uint64_t) size);
+    return false;
+  }
+  return true;
+}
+
 bool _openslide_fseek(struct _openslide_file *file, off_t offset, int whence,
                       GError **err) {
   if (fseeko(file->fp, offset, whence)) {  // ci-allow

--- a/src/openslide-hash.c
+++ b/src/openslide-hash.c
@@ -70,7 +70,6 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
     // hash to end of file
     int64_t len = _openslide_fsize(f, err);
     if (len == -1) {
-      g_prefix_error(err, "Couldn't get size of %s: ", filename);
       return false;
     }
     size = len - offset;
@@ -80,7 +79,6 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
 
   if (offset != 0) {
     if (!_openslide_fseek(f, offset, SEEK_SET, err)) {
-      g_prefix_error(err, "Can't seek in %s: ", filename);
       return false;
     }
   }
@@ -89,7 +87,6 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
   while (bytes_left > 0) {
     int64_t bytes_to_read = MIN((int64_t) sizeof buf, bytes_left);
     if (!_openslide_fread_exact(f, buf, bytes_to_read, err)) {
-      g_prefix_error(err, "Can't read from %s: ", filename);
       return false;
     }
 

--- a/src/openslide-hash.c
+++ b/src/openslide-hash.c
@@ -88,19 +88,16 @@ bool _openslide_hash_file_part(struct _openslide_hash *hash,
   int64_t bytes_left = size;
   while (bytes_left > 0) {
     int64_t bytes_to_read = MIN((int64_t) sizeof buf, bytes_left);
-    int64_t bytes_read = _openslide_fread(f, buf, bytes_to_read);
-
-    if (bytes_read != bytes_to_read) {
-      g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                  "Can't read from %s", filename);
+    if (!_openslide_fread_exact(f, buf, bytes_to_read, err)) {
+      g_prefix_error(err, "Can't read from %s: ", filename);
       return false;
     }
 
     //    g_debug("hash '%s' %"PRId64" %d", filename, offset + (size - bytes_left), bytes_to_read);
 
-    bytes_left -= bytes_read;
+    bytes_left -= bytes_to_read;
 
-    _openslide_hash_data(hash, buf, bytes_read);
+    _openslide_hash_data(hash, buf, bytes_to_read);
   }
 
   return true;

--- a/src/openslide-jdatasrc.c
+++ b/src/openslide-jdatasrc.c
@@ -100,11 +100,15 @@ static void init_mem_source (j_decompress_ptr cinfo G_GNUC_UNUSED)
 static boolean fill_input_buffer (j_decompress_ptr cinfo)
 {
   my_src_ptr src = (my_src_ptr) cinfo->src;
-  size_t nbytes;
 
-  nbytes = _openslide_fread(src->infile, src->buffer, INPUT_BUF_SIZE);
-
-  if (nbytes <= 0) {
+  GError *tmp_err = NULL;
+  size_t nbytes =
+    _openslide_fread(src->infile, src->buffer, INPUT_BUF_SIZE, &tmp_err);
+  if (tmp_err) {
+    g_clear_error(&tmp_err);
+    ERREXIT(cinfo, JERR_FILE_READ);
+  }
+  if (!nbytes) {
     if (src->start_of_file)	/* Treat empty input file as fatal error */
       ERREXIT(cinfo, JERR_INPUT_EMPTY);
     WARNMS(cinfo, JWRN_JPEG_EOF);

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -201,7 +201,8 @@ bool _openslide_clip_tile(uint32_t *tiledata,
 struct _openslide_file;
 
 struct _openslide_file *_openslide_fopen(const char *path, GError **err);
-size_t _openslide_fread(struct _openslide_file *file, void *buf, size_t size);
+size_t _openslide_fread(struct _openslide_file *file, void *buf, size_t size,
+                        GError **err);
 bool _openslide_fread_exact(struct _openslide_file *file,
                             void *buf, size_t size, GError **err);
 bool _openslide_fseek(struct _openslide_file *file, off_t offset, int whence,

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -202,6 +202,8 @@ struct _openslide_file;
 
 struct _openslide_file *_openslide_fopen(const char *path, GError **err);
 size_t _openslide_fread(struct _openslide_file *file, void *buf, size_t size);
+bool _openslide_fread_exact(struct _openslide_file *file,
+                            void *buf, size_t size, GError **err);
 bool _openslide_fseek(struct _openslide_file *file, off_t offset, int whence,
                       GError **err);
 off_t _openslide_ftell(struct _openslide_file *file, GError **err);

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -98,16 +98,10 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
   }
 
   // read
-  // catch file size changes
-  g_autofree char *buf = g_malloc(size + 1);
-  int64_t total = 0;
-  size_t cur_len;
-  while ((cur_len = _openslide_fread(f, buf + total, size + 1 - total)) > 0) {
-    total += cur_len;
-  }
-  if (total != size) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Couldn't read key file %s", filename);
+  // ensure non-NULL pointer for zero-length file
+  g_autofree char *buf = g_malloc(size ?: 1);
+  if (!_openslide_fread_exact(f, buf, size, err)) {
+    g_prefix_error(err, "Reading key file %s: ", filename);
     return NULL;
   }
 

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -88,7 +88,6 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
   // get file size and check against maximum
   int64_t size = _openslide_fsize(f, err);
   if (size == -1) {
-    g_prefix_error(err, "Couldn't get size of %s: ", filename);
     return NULL;
   }
   if (size > max_size) {
@@ -101,7 +100,6 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
   // ensure non-NULL pointer for zero-length file
   g_autofree char *buf = g_malloc(size ?: 1);
   if (!_openslide_fread_exact(f, buf, size, err)) {
-    g_prefix_error(err, "Reading key file %s: ", filename);
     return NULL;
   }
 

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -402,7 +402,6 @@ static bool find_next_ff_marker(struct _openslide_file *f,
   //g_debug("bytes_in_buf: %d", *bytes_in_buf);
   int64_t file_pos = _openslide_ftell(f, err);
   if (file_pos == -1) {
-    g_prefix_error(err, "Couldn't get file position: ");
     return false;
   }
   bool last_was_ff = false;
@@ -1569,7 +1568,6 @@ static bool ngr_read_tile(openslide_t *osr,
     uint64_t len = tw * th * 6;
     g_autofree uint16_t *buf = g_malloc(len);
     if (!_openslide_fread_exact(f, buf, len, err)) {
-      g_prefix_error(err, "Cannot read file %s: ", l->filename);
       return false;
     }
 

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -415,7 +415,7 @@ static char *read_string_from_file(struct _openslide_file *f, int len) {
   g_autofree char *str = g_malloc(len + 1);
   str[len] = '\0';
 
-  if (_openslide_fread(f, str, len) != (size_t) len) {
+  if (!_openslide_fread_exact(f, str, len, NULL)) {
     return NULL;
   }
   return g_steal_pointer(&str);
@@ -423,7 +423,7 @@ static char *read_string_from_file(struct _openslide_file *f, int len) {
 
 static bool read_le_int32_from_file_with_result(struct _openslide_file *f,
                                                 int32_t *OUT) {
-  if (_openslide_fread(f, OUT, 4) != 4) {
+  if (!_openslide_fread_exact(f, OUT, 4, NULL)) {
     return false;
   }
 
@@ -911,9 +911,8 @@ static void *read_record_data(const char *path,
   }
 
   g_autofree void *buffer = g_malloc(size);
-  if (_openslide_fread(f, buffer, size) != (size_t) size) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Error while reading data");
+  if (!_openslide_fread_exact(f, buffer, size, err)) {
+    g_prefix_error(err, "Error while reading data: ");
     return NULL;
   }
 

--- a/src/openslide-vendor-zeiss.c
+++ b/src/openslide-vendor-zeiss.c
@@ -320,10 +320,8 @@ static bool freadn_to_buf(struct _openslide_file *f, off_t offset,
     g_prefix_error(err, "Couldn't seek to offset %"PRId64": ", offset);
     return false;
   }
-  if (_openslide_fread(f, buf, len) != len) {
-    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
-                "Short read: wanted %"PRIu64" bytes at offset %"PRId64,
-                (uint64_t) len, (int64_t) offset);
+  if (!_openslide_fread_exact(f, buf, len, err)) {
+    g_prefix_error(err, "At offset %"PRId64": ", (int64_t) offset);
     return false;
   }
   return true;

--- a/test/cases/aperio-truncated-top-level/config.yaml
+++ b/test/cases/aperio-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Aperio/CMU-1.svs
-error: "^Cannot hash TIFF tiles: Can't read from .*CMU-1.svs$"
+error: "^Cannot hash TIFF tiles: Can't read from .*CMU-1.svs: Short read: 0 < 4096$"
 slide: CMU-1.svs
 success: false
 vendor: aperio

--- a/test/cases/aperio-truncated-top-level/config.yaml
+++ b/test/cases/aperio-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Aperio/CMU-1.svs
-error: "^Cannot hash TIFF tiles: Can't read from .*CMU-1.svs: Short read: 0 < 4096$"
+error: "^Cannot hash TIFF tiles: Short read of file .*CMU-1.svs: 0 < 4096$"
 slide: CMU-1.svs
 success: false
 vendor: aperio

--- a/test/cases/generic-tiff-truncated-top-level/config.yaml
+++ b/test/cases/generic-tiff-truncated-top-level/config.yaml
@@ -1,6 +1,6 @@
 base: Generic-TIFF/CMU-1.tiff
 # Not anchored at head because libtiff prints some messages
-error: "Cannot hash TIFF tiles: Can't read from .*CMU-1.tiff$"
+error: "Cannot hash TIFF tiles: Can't read from .*CMU-1.tiff: Short read: 0 < 42$"
 slide: CMU-1.tiff
 success: false
 vendor: generic-tiff

--- a/test/cases/generic-tiff-truncated-top-level/config.yaml
+++ b/test/cases/generic-tiff-truncated-top-level/config.yaml
@@ -1,6 +1,6 @@
 base: Generic-TIFF/CMU-1.tiff
 # Not anchored at head because libtiff prints some messages
-error: "Cannot hash TIFF tiles: Can't read from .*CMU-1.tiff: Short read: 0 < 42$"
+error: "Cannot hash TIFF tiles: Short read of file .*CMU-1.tiff: 0 < 42$"
 slide: CMU-1.tiff
 success: false
 vendor: generic-tiff

--- a/test/cases/hamamatsu-ndpi-truncated-top-level/config.yaml
+++ b/test/cases/hamamatsu-ndpi-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu/CMU-1.ndpi
-error: "^Cannot hash TIFF tiles: Can't read from .*CMU-1.ndpi: Short read: 677 < 4096$"
+error: "^Cannot hash TIFF tiles: Short read of file .*CMU-1.ndpi: 677 < 4096$"
 slide: CMU-1.ndpi
 success: false
 vendor: hamamatsu

--- a/test/cases/hamamatsu-ndpi-truncated-top-level/config.yaml
+++ b/test/cases/hamamatsu-ndpi-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu/CMU-1.ndpi
-error: "^Cannot hash TIFF tiles: Can't read from .*CMU-1.ndpi$"
+error: "^Cannot hash TIFF tiles: Can't read from .*CMU-1.ndpi: Short read: 677 < 4096$"
 slide: CMU-1.ndpi
 success: false
 vendor: hamamatsu

--- a/test/cases/hamamatsu-vms-jpeg-no-marker-length/config.yaml
+++ b/test/cases/hamamatsu-vms-jpeg-no-marker-length/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu-vms/CMU-1.zip
-error: "^Can't validate JPEG 3: Couldn't read JPEG marker length at 20$"
+error: "^Can't validate JPEG 3: Couldn't read JPEG marker length at 20: Short read: 0 < 2$"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
 vendor: hamamatsu

--- a/test/cases/hamamatsu-vms-jpeg-no-marker-length/config.yaml
+++ b/test/cases/hamamatsu-vms-jpeg-no-marker-length/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu-vms/CMU-1.zip
-error: "^Can't validate JPEG 3: Couldn't read JPEG marker length at 20: Short read: 0 < 2$"
+error: "^Can't validate JPEG 3: Couldn't read JPEG marker length at 20: Short read of file .*\\(1,1\\).jpg: 0 < 2$"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
 vendor: hamamatsu

--- a/test/cases/hamamatsu-vms-jpeg-premature-eoi/config.yaml
+++ b/test/cases/hamamatsu-vms-jpeg-premature-eoi/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu-vms/CMU-1.zip
-error: ^Short read searching for JPEG marker at 22798062$
+error: ^EOF searching for JPEG marker at 22798062$
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
 vendor: hamamatsu

--- a/test/cases/hamamatsu-vms-jpeg-truncated-data/config.yaml
+++ b/test/cases/hamamatsu-vms-jpeg-truncated-data/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu-vms/CMU-1.zip
-error: ^Short read searching for JPEG marker at 64910$
+error: ^EOF searching for JPEG marker at 64910$
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
 vendor: hamamatsu

--- a/test/cases/hamamatsu-vms-jpeg-truncated-header-2/config.yaml
+++ b/test/cases/hamamatsu-vms-jpeg-truncated-header-2/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu-vms/CMU-1.zip
-error: "^Can't validate JPEG 0: Cannot read header in JPEG at 0$"
+error: "^Can't validate JPEG 0: Cannot read header in JPEG at 0: Short read: 652 < 660$"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
 vendor: hamamatsu

--- a/test/cases/hamamatsu-vms-jpeg-truncated-header-2/config.yaml
+++ b/test/cases/hamamatsu-vms-jpeg-truncated-header-2/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu-vms/CMU-1.zip
-error: "^Can't validate JPEG 0: Cannot read header in JPEG at 0: Short read: 652 < 660$"
+error: "^Can't validate JPEG 0: Cannot read header in JPEG at 0: Short read of file .*05.jpg: 652 < 660$"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
 vendor: hamamatsu

--- a/test/cases/hamamatsu-vms-jpeg-truncated-header/config.yaml
+++ b/test/cases/hamamatsu-vms-jpeg-truncated-header/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu-vms/CMU-1.zip
-error: "^Can't validate JPEG 0: Couldn't read JPEG marker at 63: Short read: 0 < 2$"
+error: "^Can't validate JPEG 0: Couldn't read JPEG marker at 63: Short read of file .*05.jpg: 0 < 2$"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
 vendor: hamamatsu

--- a/test/cases/hamamatsu-vms-jpeg-truncated-header/config.yaml
+++ b/test/cases/hamamatsu-vms-jpeg-truncated-header/config.yaml
@@ -1,5 +1,5 @@
 base: Hamamatsu-vms/CMU-1.zip
-error: "^Can't validate JPEG 0: Couldn't read JPEG marker at 63$"
+error: "^Can't validate JPEG 0: Couldn't read JPEG marker at 63: Short read: 0 < 2$"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
 vendor: hamamatsu

--- a/test/cases/leica-truncated-top-level/config.yaml
+++ b/test/cases/leica-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Leica/Leica-1.scn
-error: "^Cannot hash TIFF tiles: Can't read from .*Leica-1.scn: Short read: 0 < 160$"
+error: "^Cannot hash TIFF tiles: Short read of file .*Leica-1.scn: 0 < 160$"
 slide: Leica-1.scn
 success: false
 vendor: leica

--- a/test/cases/leica-truncated-top-level/config.yaml
+++ b/test/cases/leica-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Leica/Leica-1.scn
-error: "^Cannot hash TIFF tiles: Can't read from .*Leica-1.scn$"
+error: "^Cannot hash TIFF tiles: Can't read from .*Leica-1.scn: Short read: 0 < 160$"
 slide: Leica-1.scn
 success: false
 vendor: leica

--- a/test/cases/mirax-bmp-truncated-image/config.yaml
+++ b/test/cases/mirax-bmp-truncated-image/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/Mirax2.2-4-BMP.zip
-error: ^Short read loading pixbuf$
+error: ^EOF loading pixbuf$
 slide: Mirax2.2-4-BMP.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-data-truncated-top-level/config.yaml
+++ b/test/cases/mirax-data-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: "^Can't hash images: Can't read from .*Data0014.dat: Short read: 2 < 4096$"
+error: "^Can't hash images: Short read of file .*Data0014.dat: 2 < 4096$"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-data-truncated-top-level/config.yaml
+++ b/test/cases/mirax-data-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: "^Can't hash images: Can't read from .*Data0014.dat$"
+error: "^Can't hash images: Can't read from .*Data0014.dat: Short read: 2 < 4096$"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-index-nonhier-associated-bad-offset/config.yaml
+++ b/test/cases/mirax-index-nonhier-associated-bad-offset/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: "^Can't read macro associated image: Cannot seek to offset: Invalid argument$"
+error: "^Can't read macro associated image: Couldn't seek file .*Data0002.dat: Invalid argument$"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-slidepos-truncated/config.yaml
+++ b/test/cases/mirax-slidepos-truncated/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: "^Cannot read slide position record: Error while reading data: Short read: 193247 < 193248$"
+error: "^Cannot read slide position record: Error while reading data: Short read of file .*Data0019.dat: 193247 < 193248$"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/mirax-slidepos-truncated/config.yaml
+++ b/test/cases/mirax-slidepos-truncated/config.yaml
@@ -1,5 +1,5 @@
 base: Mirax/CMU-1.zip
-error: "^Cannot read slide position record: Error while reading data$"
+error: "^Cannot read slide position record: Error while reading data: Short read: 193247 < 193248$"
 slide: CMU-1.mrxs
 success: false
 vendor: mirax

--- a/test/cases/trestle-truncated-top-level/config.yaml
+++ b/test/cases/trestle-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Trestle/CMU-1.zip
-error: "^Cannot hash TIFF tiles: Can't read from .*CMU-1.tif: Short read: 0 < 4096$"
+error: "^Cannot hash TIFF tiles: Short read of file .*CMU-1.tif: 0 < 4096$"
 slide: CMU-1.tif
 success: false
 vendor: trestle

--- a/test/cases/trestle-truncated-top-level/config.yaml
+++ b/test/cases/trestle-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Trestle/CMU-1.zip
-error: "^Cannot hash TIFF tiles: Can't read from .*CMU-1.tif$"
+error: "^Cannot hash TIFF tiles: Can't read from .*CMU-1.tif: Short read: 0 < 4096$"
 slide: CMU-1.tif
 success: false
 vendor: trestle

--- a/test/cases/ventana-truncated-top-level/config.yaml
+++ b/test/cases/ventana-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Ventana/OS-2.bif
-error: "^Cannot hash TIFF tiles: Can't read from .*OS-2.bif$"
+error: "^Cannot hash TIFF tiles: Can't read from .*OS-2.bif: Short read: 0 < 16$"
 slide: OS-2.bif
 success: false
 vendor: ventana

--- a/test/cases/ventana-truncated-top-level/config.yaml
+++ b/test/cases/ventana-truncated-top-level/config.yaml
@@ -1,5 +1,5 @@
 base: Ventana/OS-2.bif
-error: "^Cannot hash TIFF tiles: Can't read from .*OS-2.bif: Short read: 0 < 16$"
+error: "^Cannot hash TIFF tiles: Short read of file .*OS-2.bif: 0 < 16$"
 slide: OS-2.bif
 success: false
 vendor: ventana


### PR DESCRIPTION
Many `_openslide_fread()` callers want to fail unless the specified number of bytes is read.  Add a helper for this.  For the remaining callers, add a `GError **` argument so the caller can detect the difference between EOF and an I/O error.

Add more detail to various VFS error messages, avoiding some `g_prefix_error()` calls in callers.