### PR TITLE
Add `GError **` argument to `_openslide_dir_next()`

### DIFF
--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -218,7 +218,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(_openslide_file, _openslide_fclose)
 struct _openslide_dir;
 
 struct _openslide_dir *_openslide_dir_open(const char *dirname, GError **err);
-const char *_openslide_dir_next(struct _openslide_dir *d);
+const char *_openslide_dir_next(struct _openslide_dir *d, GError **err);
 void _openslide_dir_close(struct _openslide_dir *d);
 
 typedef struct _openslide_dir _openslide_dir;

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -1100,7 +1100,8 @@ static bool dicom_open(openslide_t *osr,
 
   // scan for other DICOMs with this slide id
   const char *name;
-  while ((name = _openslide_dir_next(dir))) {
+  GError *dir_err = NULL;
+  while ((name = _openslide_dir_next(dir, &dir_err))) {
     // no need to add the start file again
     if (g_str_equal(name, basename)) {
       continue;
@@ -1130,6 +1131,10 @@ static bool dicom_open(openslide_t *osr,
       g_prefix_error(err, "Reading %s: ", path);
       return false;
     }
+  }
+  if (dir_err) {
+    g_propagate_error(err, dir_err);
+    return false;
   }
 
   if (level_array->len == 0) {


### PR DESCRIPTION
`g_dir_read_name()` can fail; we need to check `errno` for the error.