### PR TITLE
workflows: run Fedora job before other build jobs

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -27,19 +27,104 @@ jobs:
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
 
-  build:
-    name: Build
-    runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container }}
+  primary:
+    name: Primary tests (Fedora)
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:latest
     outputs:
       dist-base: ${{ steps.dist.outputs.dist-base }}
+    steps:
+    - name: Install dependencies
+      run: |
+        dnf install -y \
+            gcc git-core meson pkg-config \
+            python3-requests python3-pyyaml \
+            diffutils \
+            zlib-devel \
+            libzstd-devel \
+            libpng-devel \
+            libjpeg-turbo-devel \
+            libtiff-devel \
+            openjpeg2-devel \
+            gdk-pixbuf2-modules gdk-pixbuf2-devel \
+            libdicom-devel \
+            libxml2-devel \
+            sqlite-devel \
+            cairo-devel \
+            glib2-devel \
+            xdelta libjpeg-turbo-utils \
+            clang doxygen llvm dnf-plugins-core
+        dnf debuginfo-install -y cairo fontconfig glib2
+    - name: Check out repo
+      uses: actions/checkout@v4
+    - name: Build
+      run: |
+        if ! meson setup builddir --werror; then
+            cat builddir/meson-logs/meson-log.txt
+            exit 1
+        fi
+        ninja -C builddir
+    - name: Check
+      run: |
+        trap "cat builddir/meson-logs/testlog.txt" EXIT
+        meson test -C builddir
+    - name: Docs
+      id: docs
+      run: |
+        cd builddir
+        ninja doc/html
+        docroot=openslide-docs-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)
+        mkdir -p ../artifacts/docs
+        mv doc/html ../artifacts/docs/${docroot}
+        echo "doc-base=${docroot}" >> $GITHUB_OUTPUT
+    - name: Archive docs
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.docs.outputs.doc-base }}
+        path: artifacts/docs
+    - name: Dist
+      id: dist
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        meson dist -C builddir
+        dist="openslide-dist-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)"
+        mkdir -p "artifacts/dist/$dist"
+        mv builddir/meson-dist/*.tar.xz "artifacts/dist/$dist"
+        echo "dist-base=$dist" >> $GITHUB_OUTPUT
+    - name: Archive dist
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.dist.outputs.dist-base }}
+        path: artifacts/dist
+        compression-level: 0
+    - name: Cache pristine slides
+      uses: actions/cache@v4
+      with:
+        key: pristine
+        path: builddir/test/_slidedata/pristine
+        save-always: true
+    # Can't cache frozen tests because cache doesn't handle sparse files
+    - name: Unpack tests
+      run: |
+        cd builddir/test
+        ./driver unfreeze
+        ./driver unpack nonfrozen
+    - name: Test
+      run: cd builddir/test && ./driver run
+    - name: Sanitize
+      run: cd builddir/test && ./driver sanitize
+    - name: Check exports
+      run: cd builddir/test && ./driver exports
+
+  build:
+    name: Build
+    # wait for test data to be cached
+    needs: primary
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            container: registry.fedoraproject.org/fedora:latest
-            extra: extra checks
-            sanitize: sanitize
           - os: ubuntu-latest
             container: quay.io/almalinuxorg/almalinux:8
           - os: ubuntu-latest
@@ -94,7 +179,7 @@ jobs:
             ;;
         ubuntu-*)
             case "${{ matrix.container }}" in
-            *fedora*|*centos*|*almalinux*)
+            *centos*|*almalinux*)
                 pyver=3
                 . /etc/os-release
                 case "$VERSION_ID" in
@@ -111,12 +196,10 @@ jobs:
                     dnf config-manager --set-enabled crb
                     dnf install -y epel-release epel-next-release
                     ;;
-                *)
-                    extra="clang doxygen llvm dnf-plugins-core"
-                    debuginfo=1
-                    ;;
                 esac
 
+                # zstd command-line program needed to restore cache
+                # https://github.com/actions/cache/issues/1169
                 dnf install -y \
                     gcc git-core meson pkg-config \
                     $python python${pyver}-requests python${pyver}-pyyaml \
@@ -133,11 +216,9 @@ jobs:
                     sqlite-devel \
                     cairo-devel \
                     glib2-devel \
-                    xdelta libjpeg-turbo-utils $extra
+                    xdelta libjpeg-turbo-utils \
+                    zstd
 
-                if [ -n "$debuginfo" ]; then
-                    dnf debuginfo-install -y cairo fontconfig glib2
-                fi
                 if [ -n "$pydotver" ]; then
                     alternatives --set python3 "/usr/bin/python${pydotver}"
                 fi
@@ -157,6 +238,8 @@ jobs:
                     extra=gcc-multilib
                 fi
                 $sudo apt-get update
+                # zstd command-line program needed to restore cache
+                # https://github.com/actions/cache/issues/1169
                 $sudo apt-get -y install \
                     gcc git meson pkg-config \
                     python3-requests python3-yaml \
@@ -171,7 +254,8 @@ jobs:
                     libsqlite3-dev$arch \
                     libcairo2-dev$arch \
                     libglib2.0-dev$arch \
-                    xdelta3 libjpeg-turbo-progs $extra
+                    xdelta3 libjpeg-turbo-progs $extra \
+                    zstd
                 ;;
             esac
         esac
@@ -218,45 +302,12 @@ jobs:
       run: |
         trap "cat builddir/meson-logs/testlog.txt" EXIT
         meson test -C builddir
-    - name: Docs
-      id: docs
-      if: matrix.extra
-      run: |
-        cd builddir
-        ninja doc/html
-        docroot=openslide-docs-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)
-        mkdir -p ../artifacts/docs
-        mv doc/html ../artifacts/docs/${docroot}
-        echo "doc-base=${docroot}" >> $GITHUB_OUTPUT
-    - name: Archive docs
-      if: matrix.extra
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ steps.docs.outputs.doc-base }}
-        path: artifacts/docs
-    - name: Dist
-      id: dist
-      if: matrix.extra
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        meson dist -C builddir
-        dist="openslide-dist-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)"
-        mkdir -p "artifacts/dist/$dist"
-        mv builddir/meson-dist/*.tar.xz "artifacts/dist/$dist"
-        echo "dist-base=$dist" >> $GITHUB_OUTPUT
-    - name: Archive dist
-      if: matrix.extra
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ steps.dist.outputs.dist-base }}
-        path: artifacts/dist
-        compression-level: 0
     - name: Cache pristine slides
       uses: actions/cache@v4
       with:
         key: pristine
         path: builddir/test/_slidedata/pristine
-        save-always: true
+        fail-on-cache-miss: true
     # Can't cache frozen tests because cache doesn't handle sparse files
     - name: Unpack tests
       run: |
@@ -268,9 +319,6 @@ jobs:
     - name: Sanitize
       if: matrix.sanitize
       run: cd builddir/test && ./driver sanitize
-    - name: Check exports
-      if: matrix.extra
-      run: cd builddir/test && ./driver exports
 
   windows_setup:
     name: Set up Windows build
@@ -315,7 +363,7 @@ jobs:
   release:
     name: Release
     if: github.ref_type == 'tag'
-    needs: [build, windows_build]
+    needs: [primary, build, windows_build]
     runs-on: ubuntu-latest
     concurrency: release-${{ github.ref }}
     permissions:
@@ -324,14 +372,14 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: ${{ needs.build.outputs.dist-base }}
+        pattern: ${{ needs.primary.outputs.dist-base }}
         merge-multiple: true
     - name: Release to GitHub
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         version=$(echo "${{ github.ref_name }}" | sed "s/^v//")
-        tar xf "${{ needs.build.outputs.dist-base }}/openslide-${version}.tar.xz"
+        tar xf "${{ needs.primary.outputs.dist-base }}/openslide-${version}.tar.xz"
         echo -e "## Full changelog\n" > changes
         awk -e '/^## / && ok {exit}' \
             -e '/^## / {ok=1; next}' \
@@ -342,4 +390,4 @@ jobs:
             --title "OpenSlide $version" \
             --notes-file changes \
             "${{ github.ref_name }}" \
-            "${{ needs.build.outputs.dist-base }}/"*
+            "${{ needs.primary.outputs.dist-base }}/"*


### PR DESCRIPTION
The Fedora job runs a number of extra tests.  By declaring it separately, we duplicate some code (mainly dependency installation) but we also drop a number of conditionals.  More importantly, by sequencing the other jobs after the Fedora one, we can avoid building the pristine cache multiple times in parallel when missing.

Fail the subsequent jobs if the cache can't be restored.  Install the `zstd` command-line tool to avoid an obscure restore failure in `actions/cache`.