### PR TITLE
pre-commit: forbid `stpcpy`, `strcat`, `strcpy`, `sscanf`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,9 @@ repos:
       # g_slice_new           g_new0
       # malloc                g_malloc
       # realloc               g_realloc
+      # stpcpy                g_strdup
+      # strcat                g_string_append
+      # strcpy                g_strdup
       # strdup                g_strdup
       # strerror              g_strerror
       # strerror_l            g_strerror
@@ -120,7 +123,7 @@ repos:
         language: pygrep
         exclude: ^misc/
         types: [c]
-        entry: "(^|\\W)(atoi|atol|atoll|calloc|free|g_slice_alloc0|g_slice_alloc|g_slice_copy|g_slice_dup|g_slice_free1|g_slice_free|g_slice_new0|g_slice_new|malloc|realloc|strdup|strerror|strerror_l|strndup|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax)\\s*\\("
+        entry: "(^|\\W)(atoi|atol|atoll|calloc|free|g_slice_alloc0|g_slice_alloc|g_slice_copy|g_slice_dup|g_slice_free1|g_slice_free|g_slice_new0|g_slice_new|malloc|realloc|stpcpy|strcat|strcpy|strdup|strerror|strerror_l|strndup|strtoimax|strtol|strtoll|strtoul|strtoull|strtoumax)\\s*\\("
 
       # Prevent use of functions with mandatory wrappers in OpenSlide.
       # Wrapper implementations can add "// ci-allow" on the same line to
@@ -142,6 +145,7 @@ repos:
       # sqlite3_close         _openslide_sqlite_close
       # sqlite3_open          _openslide_sqlite_open
       # sqlite3_open_v2       _openslide_sqlite_open
+      # sscanf                _openslide_parse_{double,int64,uint64}
       # strtod                _openslide_parse_double
       # TIFFClientOpenExt     _openslide_tiffcache_get
       # TIFFClientOpen        _openslide_tiffcache_get
@@ -155,4 +159,4 @@ repos:
         language: pygrep
         files: ^src/openslide
         types: [c]
-        entry: "(^|\\W)(atof|fclose|fopen|fread|fseeko|fseek|ftello|ftell|g_ascii_strtod|g_ascii_strtoll|g_ascii_strtoull|g_file_test|sqlite3_close|sqlite3_open|sqlite3_open_v2|strtod|TIFFClientOpenExt|TIFFClientOpen|TIFFFdOpenExt|TIFFFdOpen|TIFFOpenExt|TIFFOpen|TIFFSetDirectory)\\s*\\((?!.+ci-allow)"
+        entry: "(^|\\W)(atof|fclose|fopen|fread|fseeko|fseek|ftello|ftell|g_ascii_strtod|g_ascii_strtoll|g_ascii_strtoull|g_file_test|sqlite3_close|sqlite3_open|sqlite3_open_v2|sscanf|strtod|TIFFClientOpenExt|TIFFClientOpen|TIFFFdOpenExt|TIFFFdOpen|TIFFOpenExt|TIFFOpen|TIFFSetDirectory)\\s*\\((?!.+ci-allow)"


### PR DESCRIPTION
Avoid manually copying strings to unbounded buffers.  Parse numbers with OpenSlide's existing parse functions, using their existing error checking conventions.

Prompted by #625; cc @peterchen183