### PR TITLE
workflows: drop `save-always` from `actions/cache` invocation

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -102,7 +102,6 @@ jobs:
       with:
         key: pristine
         path: builddir/test/_slidedata/pristine
-        save-always: true
     # Can't cache frozen tests because cache doesn't handle sparse files
     - name: Unpack tests
       run: |


### PR DESCRIPTION
The option never actually worked, and is being deprecated upstream.  We could implement it ourselves with separate `actions/cache/save` and `actions/cache/restore` invocations, but don't bother for now.