### PR TITLE
test/synth: move to `slidetool test deps`

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -28,10 +28,6 @@ executable(
   'query', 'query.c',
   dependencies : test_deps,
 )
-test_synth = executable(
-  'synth', 'synth.c',
-  dependencies : test_deps,
-)
 executable(
   'try_open', 'try_open.c',
   dependencies : test_deps,
@@ -39,7 +35,10 @@ executable(
 )
 
 # Tests
-test('synth', test_synth)
+test(
+  'synth', slidetool,
+  args : ['test', 'deps']
+)
 
 # Driver
 configure_file(

--- a/test/synth.c
+++ b/test/synth.c
@@ -29,17 +29,21 @@
 
 #include "openslide-common.h"
 
+static void set_synthetic_debug_flag(void *arg G_GNUC_UNUSED) {
+  putenv("OPENSLIDE_DEBUG=synthetic");
+}
+
 int main(int argc, char **argv) {
   common_fix_argv(&argc, &argv);
   if (argc < 2 || !g_str_equal(argv[1], "child")) {
-    putenv("OPENSLIDE_DEBUG=synthetic");
     // OpenSlide already evaluated debug flags, so we need to rerun
     // ourselves.  Do it in a cross-platform way.
     char *child_argv[] = {argv[0], "child", NULL};
     GError *tmp_err = NULL;
     int status;
     if (!g_spawn_sync(NULL, child_argv, NULL, G_SPAWN_SEARCH_PATH,
-                      NULL, NULL, NULL, NULL, &status, &tmp_err)) {
+                      set_synthetic_debug_flag, NULL, NULL, NULL, &status,
+                      &tmp_err)) {
       common_fail("Spawning child failed: %s", tmp_err->message);
     }
     if (!g_spawn_check_exit_status(status, NULL)) {

--- a/test/synth.c
+++ b/test/synth.c
@@ -36,11 +36,11 @@ int main(int argc, char **argv) {
     // OpenSlide already evaluated debug flags, so we need to rerun
     // ourselves.  Do it in a cross-platform way.
     char *child_argv[] = {argv[0], "child", NULL};
-    GError *err = NULL;
+    GError *tmp_err = NULL;
     int status;
     if (!g_spawn_sync(NULL, child_argv, NULL, G_SPAWN_SEARCH_PATH,
-                      NULL, NULL, NULL, NULL, &status, &err)) {
-      common_fail("Spawning child failed: %s", err->message);
+                      NULL, NULL, NULL, NULL, &status, &tmp_err)) {
+      common_fail("Spawning child failed: %s", tmp_err->message);
     }
     if (!g_spawn_check_exit_status(status, NULL)) {
       // child already reported the error

--- a/test/synth.c
+++ b/test/synth.c
@@ -35,7 +35,7 @@ static void set_synthetic_debug_flag(void *arg G_GNUC_UNUSED) {
 
 int main(int argc, char **argv) {
   common_fix_argv(&argc, &argv);
-  if (argc < 2 || !g_str_equal(argv[1], "child")) {
+  if (argc < 2) {
     // OpenSlide already evaluated debug flags, so we need to rerun
     // ourselves.  Do it in a cross-platform way.
     char *child_argv[] = {argv[0], "child", NULL};
@@ -51,6 +51,8 @@ int main(int argc, char **argv) {
       return 1;
     }
     return 0;
+  } else if (!g_str_equal(argv[1], "child")) {
+    common_fail("Found unexpected argument");
   }
 
   // open

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -31,6 +31,7 @@ foreach target : tools_binaries
       'slidetool-image.c',
       'slidetool-prop.c',
       'slidetool-slide.c',
+      'slidetool-test.c',
       'slidetool-util.c',
     ],
     include_directories : config_h_include,

--- a/tools/slidetool-test.c
+++ b/tools/slidetool-test.c
@@ -1,7 +1,7 @@
 /*
  *  OpenSlide, a library for reading whole slide image files
  *
- *  Copyright (c) 2022 Benjamin Gilbert
+ *  Copyright (c) 2022-2024 Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -19,26 +19,27 @@
  *
  */
 
+#include "openslide.h"
+#include "openslide-common.h"
+#include "slidetool.h"
+
 // for putenv
 #define _XOPEN_SOURCE
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <glib.h>
-#include <openslide.h>
-
-#include "openslide-common.h"
 
 static void set_synthetic_debug_flag(void *arg G_GNUC_UNUSED) {
   putenv("OPENSLIDE_DEBUG=synthetic");
 }
 
-int main(int argc, char **argv) {
-  common_fix_argv(&argc, &argv);
-  if (argc < 2) {
+static int do_test_deps(int narg, char **args) {
+  if (narg < 1) {
     // OpenSlide already evaluated debug flags, so we need to rerun
-    // ourselves.  Do it in a cross-platform way.
-    char *child_argv[] = {argv[0], "child", NULL};
+    // ourselves.  Do it in a cross-platform way.  args[-1] is the program's
+    // argv[0].
+    char *child_argv[] = {args[-1], "test", "deps", "child", NULL};
     GError *tmp_err = NULL;
     int status;
     if (!g_spawn_sync(NULL, child_argv, NULL, G_SPAWN_SEARCH_PATH,
@@ -51,7 +52,7 @@ int main(int argc, char **argv) {
       return 1;
     }
     return 0;
-  } else if (!g_str_equal(argv[1], "child")) {
+  } else if (!g_str_equal(args[0], "child")) {
     common_fail("Found unexpected argument");
   }
 
@@ -76,3 +77,19 @@ int main(int argc, char **argv) {
 
   return 0;
 }
+
+static const struct command test_subcmds[] = {
+  {
+    .name = "deps",
+    .summary = "Verify that OpenSlide's dependencies work correctly",
+    .max_positional = 1,
+    .handler = do_test_deps,
+  },
+  {}
+};
+
+const struct command test_cmd = {
+  .name = "test",
+  .description = "Commands for testing OpenSlide.",
+  .subcommands = test_subcmds,
+};

--- a/tools/slidetool.c
+++ b/tools/slidetool.c
@@ -61,6 +61,9 @@ static const struct command root_subcmds[] = {
   {
     .command = &slide_cmd,
   },
+  {
+    .command = &test_cmd,
+  },
   {}
 };
 
@@ -108,8 +111,10 @@ static int invoke_cmdline(const struct command *cmd, char *parents,
     for (const struct command *subcmd_ = cmd->subcommands;
          canonicalize(subcmd_)->name; subcmd_++) {
       const struct command *subcmd = canonicalize(subcmd_);
-      g_string_append_printf(summary, "\n  %-16s %s",
-                             subcmd->name, subcmd->summary);
+      if (subcmd->summary) {
+        g_string_append_printf(summary, "\n  %-16s %s",
+                               subcmd->name, subcmd->summary);
+      }
     }
     // stop at first non-option argument so we can invoke the subcommand
     // handler
@@ -163,7 +168,7 @@ static int invoke_cmdline(const struct command *cmd, char *parents,
       }
     }
 
-    // drop argv[0]
+    // argv[0] becomes argv[-1]
     argc--;
     argv++;
     if (cmd->min_positional && argc < cmd->min_positional) {

--- a/tools/slidetool.h
+++ b/tools/slidetool.h
@@ -51,6 +51,7 @@ extern const struct command prop_cmd;
 extern const struct command region_cmd;
 extern const struct command region_icc_cmd;
 extern const struct command slide_cmd;
+extern const struct command test_cmd;
 
 extern const struct command quickhash1sum_cmd;
 extern const struct command show_properties_cmd;


### PR DESCRIPTION
Provide a more accessible way to run self-tests in an installed OpenSlide, rather than `OPENSLIDE_DEBUG=synthetic slidetool prop list ""`.  Omit it from the man page for now, and hide the `test` subcommand from the top-level subcommand list by omitting the summary string.

Have `meson test` run self-tests via the new subcommand.