### PR TITLE
workflows: test on Debian 12 aarch64

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -140,6 +140,8 @@ jobs:
           - os: ubuntu-latest
             container: debian:12
             arch: i386
+          - os: ubuntu-24.04-aarch64
+            container: debian:12
           - os: ubuntu-20.04
             ignore-cloexec-leaks: ignore CLOEXEC leaks
           - os: ubuntu-22.04


### PR DESCRIPTION
Use GitHub's paid support for ARM64 runners, pending the free offering scheduled for later this year.