### PR TITLE
workflows: install PyYAML with pip on macOS

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -174,12 +174,12 @@ jobs:
                 sqlite \
                 cairo \
                 glib \
-                xdelta \
-                pyyaml
+                xdelta
             # Install Python packages that Homebrew does not wish to maintain.
             # Use --break-system-packages so pip doesn't refuse to install
             # outside a virtualenv.
             python3 -m pip install --break-system-packages \
+                PyYAML \
                 requests
             ;;
         ubuntu-*)


### PR DESCRIPTION
Avoids error:

    Error: pyyaml has been disabled because it does not meet homebrew/core's requirements for Python library formulae! It was disabled on 2024-10-06.