### PR TITLE
workflows: switch ARM job to publicly-available runner

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -140,7 +140,7 @@ jobs:
           - os: ubuntu-latest
             container: debian:12
             arch: i386
-          - os: ubuntu-24.04-aarch64
+          - os: ubuntu-24.04-arm
             container: debian:12
           - os: ubuntu-latest
             container: ubuntu:20.04


### PR DESCRIPTION
[Drop](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) the paid runner.