### PR TITLE
Add codespell pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,14 @@ repos:
           - types-requests
         exclude: ^misc/
 
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in pyproject.toml
+    rev: v2.4.1
+    hooks:
+    - id: codespell
+      additional_dependencies:
+      - tomli  # for python_version < '3.11'
+
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/misc/test.c
+++ b/misc/test.c
@@ -290,7 +290,7 @@ int main(int argc, char **argv) {
   }
 
   /*
-  // simulate horizonal scrolling?
+  // simulate horizontal scrolling?
   gettimeofday(&start_tv, NULL);
   printf("test_horizontal_walk start\n");
   test_horizontal_walk(osr, 0, 0, 0, 10, 400, 10);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,13 @@ line-length = 79
 skip-string-normalization = true
 target-version = ["py38", "py39", "py310", "py311", "py312", "py313"]
 
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+[tool.codespell]
+skip = '.git'
+check-hidden = true
+# ignore-regex = ''
+ignore-words-list = 'debbugs,subtile,subtiles,checkin'
+
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
 # requires Flake8-pyproject
 [tool.flake8]


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.