### PR TITLE
meson: convert filename arrays to `files()`

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -1,8 +1,8 @@
-openslide_common_sources = [
+openslide_common_sources = files(
   'openslide-common-cmdline.c',
   'openslide-common-fail.c',
   'openslide-common-fd.c',
-]
+)
 
 openslide_common = static_library(
   'openslide-common',

--- a/meson.format
+++ b/meson.format
@@ -1,5 +1,4 @@
 group_arg_value = true
 indent_by = '  '
 kwargs_force_multiline = true
-sort_files = true
 wide_colon = true

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,7 +28,7 @@ if host_machine.system() == 'windows'
     depend_files : [openslide_dll_manifest],
   )
 else
-  openslide_dll_o = files()
+  openslide_dll_o = []
 endif
 
 # Public headers
@@ -40,10 +40,8 @@ install_headers(
 )
 
 # Library
-openslide_sources = [
-  'openslide.c',
+openslide_sources = files(
   'openslide-cache.c',
-  openslide_dll_o,
   'openslide-decode-dicom.c',
   'openslide-decode-gdkpixbuf.c',
   'openslide-decode-jp2k.c',
@@ -58,7 +56,6 @@ openslide_sources = [
   'openslide-grid.c',
   'openslide-hash.c',
   'openslide-jdatasrc.c',
-  openslide_tables_c,
   'openslide-util.c',
   'openslide-vendor-aperio.c',
   'openslide-vendor-dicom.c',
@@ -72,6 +69,10 @@ openslide_sources = [
   'openslide-vendor-trestle.c',
   'openslide-vendor-ventana.c',
   'openslide-vendor-zeiss.c',
+  'openslide.c',
+) + [
+  openslide_dll_o,
+  openslide_tables_c,
 ]
 libopenslide = library(
   'openslide',

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -25,15 +25,15 @@ endif
 foreach target : tools_binaries
   exe = executable(
     target,
-    [
-      'slidetool.c',
+    files(
       'slidetool-icc.c',
       'slidetool-image.c',
       'slidetool-prop.c',
       'slidetool-slide.c',
       'slidetool-test.c',
       'slidetool-util.c',
-    ],
+      'slidetool.c',
+    ),
     include_directories : config_h_include,
     dependencies : [openslide_dep, openslide_common_dep, glib_dep, png_dep],
     install : true,


### PR DESCRIPTION
Allow `meson format` to automatically sort lists of filenames.

Drop the redundant `sort_files` format option.  Notwithstanding the Meson docs, `sort_files` has always defaulted to `true`.