### PR TITLE
bump libdicom to v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To build OpenSlide, you will need:
 - cairo ≥ 1.2
 - GDK-PixBuf
 - glib ≥ 2.56
-- libdicom ≥ 1.0 (automatically built if missing)
+- libdicom ≥ 1.2 (automatically built if missing)
 - libjpeg
 - libpng
 - libtiff ≥ 4.0

--- a/meson.build
+++ b/meson.build
@@ -154,7 +154,7 @@ dicom_dep = dependency(
   # avoid 'check' dependency
   default_options : ['tests=false'],
   fallback : ['libdicom', 'libdicom_dep'],
-  version : '>=1.0.0',
+  version : '>=1.2.0',
 )
 valgrind_dep = dependency(
   'valgrind',

--- a/subprojects/libdicom.wrap
+++ b/subprojects/libdicom.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = libdicom-1.1.0
-source_url = https://github.com/ImagingDataCommons/libdicom/releases/download/v1.1.0/libdicom-1.1.0.tar.xz
-source_filename = libdicom-1.1.0.tar.xz
-source_hash = 058bfaa7653c60a70798e021001d765e3f91ca4df5a8824b7604eaa57376449b
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libdicom_1.1.0-1/libdicom-1.1.0.tar.xz
-wrapdb_version = 1.1.0-1
+directory = libdicom-1.2.0
+source_url = https://github.com/ImagingDataCommons/libdicom/releases/download/v1.2.0/libdicom-1.2.0.tar.xz
+source_filename = libdicom-1.2.0.tar.xz
+source_hash = 3b8c05ceb6bf667fed997f23b476dd32c3dc6380eee1998185c211d86a7b4918
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libdicom_1.2.0-1/libdicom-1.2.0.tar.xz
+wrapdb_version = 1.2.0-1
 
 [provide]
 dependency_names = libdicom

--- a/test/cases/dicom-level-bad-frame/config.yaml
+++ b/test/cases/dicom-level-bad-frame/config.yaml
@@ -1,5 +1,5 @@
 base: DICOM/3DHISTECH-1.zip
-error: "^libdicom IO error: End of filehandle - Needed 2 bytes beyond end of filehandle$"
+error: "^libdicom IO error: (End|end) of filehandle - (Needed|needed) 2 bytes beyond end of filehandle$"
 slide: 000005.dcm
 success: false
 vendor: dicom

--- a/test/cases/dicom-primary-bad-metadata/config.yaml
+++ b/test/cases/dicom-primary-bad-metadata/config.yaml
@@ -1,5 +1,5 @@
 base: DICOM/3DHISTECH-1.zip
-error: "^libdicom IO error: End of filehandle - Needed 2 bytes beyond end of filehandle$"
+error: "^libdicom IO error: (End|end) of filehandle - (Needed|needed) 2 bytes beyond end of filehandle$"
 slide: 000013.dcm
 success: false
 vendor: dicom


### PR DESCRIPTION
Also define `HAVE_DICOM_GET_FRAME_NUMBER`, we'll need it very shortly for DICOM catenation support.