### PR TITLE
Drop support for Ubuntu 20.04 and Python 3.8

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -144,9 +144,6 @@ jobs:
             arch: i386
           - os: ubuntu-24.04-arm
             container: debian:12
-          - os: ubuntu-latest
-            container: ubuntu:20.04
-            ignore-cloexec-leaks: ignore CLOEXEC leaks
           - os: ubuntu-22.04
           - os: ubuntu-24.04
           - os: macos-latest

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -193,9 +193,9 @@ jobs:
                     dnf install -y 'dnf-command(config-manager)'
                     dnf config-manager --set-enabled powertools
                     dnf install -y epel-release
-                    pyver=38
-                    pydotver=3.8
-                    python=python38
+                    pyver=39
+                    pydotver=3.9
+                    python=python39
                     ;;
                 9)
                     dnf install -y 'dnf-command(config-manager)'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: pyupgrade
         name: Modernize python code
         exclude: ^misc/
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/meson.build
+++ b/meson.build
@@ -8,8 +8,8 @@ project(
     'c_std=gnu99',
     'warning_level=2',
   ],
-  # limited by Ubuntu 20.04
-  meson_version : '>=0.53',
+  # limited by Debian 11 at 0.56
+  meson_version : '>=0.54',
 )
 # Shared library version.  Follow SemVer rules.
 soversion = '1.0.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 79
 skip-string-normalization = true
-target-version = ["py38", "py39", "py310", "py311", "py312", "py313"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 [tool.codespell]
@@ -22,5 +22,5 @@ line_length = 79
 
 [tool.mypy]
 namespace_packages = false
-python_version = "3.8"
+python_version = "3.9"
 strict = true

--- a/src/meson.build
+++ b/src/meson.build
@@ -110,6 +110,4 @@ import('pkgconfig').generate(
   subdirs : include_subdir,
   url : 'https://openslide.org',
 )
-if meson.version().version_compare('>=0.54')
-  meson.override_dependency('openslide', openslide_dep)
-endif
+meson.override_dependency('openslide', openslide_dep)

--- a/test/driver.in
+++ b/test/driver.in
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from configparser import RawConfigParser
 from contextlib import closing, contextmanager
@@ -55,11 +56,8 @@ from time import time as curtime
 from typing import (
     Any,
     BinaryIO,
-    Iterable,
-    Iterator,
     NewType,
     Protocol,
-    Sequence,
     TypeVar,
     cast,
 )
@@ -1310,11 +1308,7 @@ def _run_all(
                 failed += 1
     except BaseException:
         # In particular, KeyboardInterrupt
-        if sys.version_info >= (3, 9):
-            executor.shutdown(cancel_futures=True)
-        else:
-            # not very useful
-            executor.shutdown()
+        executor.shutdown(cancel_futures=True)
         raise
     else:
         executor.shutdown()


### PR DESCRIPTION
After May 31, Ubuntu 20.04 will no longer be under standard security maintenance.

Python 3.8 is EOL and Ubuntu 20.04 is the last officially-supported distro that requires it.