### PR TITLE
Fedora 42 CI fixes

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -63,7 +63,9 @@ jobs:
       uses: actions/checkout@v4
     - name: Build
       run: |
-        if ! meson setup builddir --werror; then
+        # disable werror for libdicom 1.2.0
+        # https://github.com/ImagingDataCommons/libdicom/pull/100
+        if ! meson setup builddir --werror -Dlibdicom:werror=false; then
             cat builddir/meson-logs/meson-log.txt
             exit 1
         fi

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -99,12 +99,13 @@ static uint64_t read_uint(struct _openslide_file *f, int32_t size,
                           bool big_endian, bool *ok) {
   g_assert(ok != NULL);
 
-  uint8_t buf[size];
+  uint8_t buf[8];
+  g_assert(size <= (int32_t) sizeof(buf));
   if (!_openslide_fread_exact(f, buf, size, NULL)) {
     *ok = false;
     return 0;
   }
-  fix_byte_order(buf, sizeof(buf), 1, big_endian);
+  fix_byte_order(buf, size, 1, big_endian);
   switch (size) {
   case 1: {
     uint8_t result;


### PR DESCRIPTION
GCC 15 in Fedora 42 introduces a new libdicom build warning.  Disable `werror` for libdicom in CI until this is fixed.

clang 20 AddressSanitizer throws `dynamic-stack-buffer-overflow` errors on `fread()`'s write to `buf`, though the buffer size appears to be correct.  Work around this by converting `buf` to a fixed-length array.  We need 8 bytes at most, so the VLA isn't really necessary.