### PR TITLE
workflows: build with `--fatal-meson-warnings` on Fedora

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -65,7 +65,7 @@ jobs:
       run: |
         # disable werror for libdicom 1.2.0
         # https://github.com/ImagingDataCommons/libdicom/pull/100
-        if ! meson setup builddir --werror -Dlibdicom:werror=false; then
+        if ! meson setup builddir --fatal-meson-warnings --werror -Dlibdicom:werror=false; then
             cat builddir/meson-logs/meson-log.txt
             exit 1
         fi


### PR DESCRIPTION
We produce warnings on older Meson versions because `install_tag` isn't supported before 0.60.  For now, only check for warnings in the primary test job.