### PR TITLE
workflows: silence Homebrew annotations about pre-existing packages

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -163,7 +163,7 @@ jobs:
                 brew link --overwrite $formula
             done
             brew update
-            brew install \
+            brew install --quiet \
                 meson pkg-config \
                 zlib \
                 zstd \


### PR DESCRIPTION
Prevent Homebrew from producing workflow annotations like:

![image](https://github.com/user-attachments/assets/e0b5abad-6c39-495a-8741-b27665036384)
