### PR TITLE
Drop our copy of libjpeg's `jpeg_mem_src`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To build OpenSlide, you will need:
 - cairo ≥ 1.2
 - glib ≥ 2.56
 - libdicom ≥ 1.2 (automatically built if missing)
-- libjpeg
+- libjpeg-turbo ≥ 1.3 or libjpeg ≥ 9c
 - libpng
 - libtiff ≥ 4.0
 - libxml2

--- a/meson.build
+++ b/meson.build
@@ -164,6 +164,13 @@ doxygen = find_program(
 )
 
 # Dependency checks
+if jpeg_dep.type_name() != 'internal' and not cc.has_function(
+  'jpeg_mem_src',
+  dependencies : jpeg_dep,
+)
+  error('libjpeg-turbo >= 1.3 or libjpeg >= 9c is required')
+endif
+
 if tiff_dep.type_name() == 'internal' or cc.has_function(
   'TIFFOpenOptionsSetErrorHandlerExtR',
   dependencies : tiff_dep,

--- a/src/openslide-decode-jpeg.c
+++ b/src/openslide-decode-jpeg.c
@@ -118,8 +118,7 @@ static void *detect_jcs_alpha_extensions(void *arg G_GNUC_UNUSED) {
   jmp_buf env;
   if (!setjmp(env)) {
     _openslide_jpeg_decompress_init(dc, &env);
-    _openslide_jpeg_mem_src(cinfo, one_pixel_rgb_jpeg,
-                            sizeof(one_pixel_rgb_jpeg));
+    jpeg_mem_src(cinfo, one_pixel_rgb_jpeg, sizeof(one_pixel_rgb_jpeg));
     jpeg_read_header(cinfo, true);
     cinfo->out_color_space = JCS_EXT_BGRA;
     jpeg_start_decompress(cinfo);
@@ -274,7 +273,7 @@ static bool jpeg_get_dimensions(struct _openslide_file *f,  // or:
     if (f) {
       _openslide_jpeg_stdio_src(cinfo, f);
     } else {
-      _openslide_jpeg_mem_src(cinfo, buf, buflen);
+      jpeg_mem_src(cinfo, buf, buflen);
     }
 
     if (jpeg_read_header(cinfo, true) != JPEG_HEADER_OK) {
@@ -331,7 +330,7 @@ static bool jpeg_decode(struct _openslide_file *f,  // or:
     if (f) {
       _openslide_jpeg_stdio_src(cinfo, f);
     } else {
-      _openslide_jpeg_mem_src(cinfo, buf, buflen);
+      jpeg_mem_src(cinfo, buf, buflen);
     }
 
     // read header

--- a/src/openslide-decode-jpeg.c
+++ b/src/openslide-decode-jpeg.c
@@ -106,10 +106,7 @@ static void my_emit_message(j_common_ptr cinfo, int msg_level) {
 // Detect support for JCS_ALPHA_EXTENSIONS.  Even if the extensions were
 // available at compile time, they may not be available at runtime because
 // support for JCS_ALPHA_EXTENSIONS isn't reflected in the libjpeg soname.
-// Previously used the detection method documented in jcstest.c, but
-// libjpeg-turbo 1.2.0 doesn't support JCS_ALPHA_EXTENSIONS for RGB JPEGs
-// and we need that for Aperio slides.  Instead, try enabling the extensions
-// while decoding a tiny RGB JPEG.
+// Try enabling the extensions while decoding a tiny RGB JPEG.
 static void *detect_jcs_alpha_extensions(void *arg G_GNUC_UNUSED) {
   struct jpeg_decompress_struct *cinfo;
   g_auto(_openslide_jpeg_decompress) dc =

--- a/src/openslide-decode-jpeg.h
+++ b/src/openslide-decode-jpeg.h
@@ -74,12 +74,6 @@ bool _openslide_jpeg_add_associated_image(openslide_t *osr,
 void _openslide_jpeg_stdio_src(j_decompress_ptr cinfo,
                                struct _openslide_file *infile);
 
-/*
- * Some libjpegs don't provide mem_src, so we have our own copy.
- */
-void _openslide_jpeg_mem_src (j_decompress_ptr cinfo,
-                              const void *inbuffer, size_t insize);
-
 
 /*
  * Low-level JPEG decoding mechanism

--- a/src/openslide-decode-tiff.c
+++ b/src/openslide-decode-tiff.c
@@ -227,7 +227,7 @@ static bool decode_jpeg(const void *buf, uint32_t buflen,
 
     // load JPEG tables
     if (tables) {
-      _openslide_jpeg_mem_src(cinfo, tables, tables_len);
+      jpeg_mem_src(cinfo, tables, tables_len);
       if (jpeg_read_header(cinfo, false) != JPEG_HEADER_TABLES_ONLY) {
         g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
                     "Couldn't load JPEG tables");
@@ -236,7 +236,7 @@ static bool decode_jpeg(const void *buf, uint32_t buflen,
     }
 
     // set up I/O
-    _openslide_jpeg_mem_src(cinfo, buf, buflen);
+    jpeg_mem_src(cinfo, buf, buflen);
 
     // read header
     if (jpeg_read_header(cinfo, true) != JPEG_HEADER_OK) {

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -268,7 +268,7 @@ static bool jpeg_random_access_src(j_decompress_ptr cinfo,
   }
 
   // pass the buffer off to mem_src
-  _openslide_jpeg_mem_src(cinfo, buffer, buffer_size);
+  jpeg_mem_src(cinfo, buffer, buffer_size);
 
   return true;
 }

--- a/test/clang.supp
+++ b/test/clang.supp
@@ -5,7 +5,6 @@
 # indirect function calls into libraries compiled without instrumentation
 fun:jpeg_random_access_src
 fun:my_output_message
-fun:_openslide_jpeg_mem_src
 fun:_openslide_jpeg_stdio_src
 fun:_openslide_xml_char_free
 


### PR DESCRIPTION
All modern releases of libjpeg-turbo and IJG libjpeg have it.

The OpenSlide codebase should be compatible with IJG libjpeg &ge; 8, but 9c was the first to ship a pkg-config file and our Meson config doesn't do fallback detection, so document 9c as the minimum.
