### PR TITLE
workflows: add Windows build using Windows runner and vcpkg

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -329,8 +329,44 @@ jobs:
       if: matrix.sanitize
       run: cd builddir/test && ./driver sanitize
 
-  windows_setup:
-    name: Set up Windows build
+  windows-build:
+    name: Build (Windows)
+    needs: primary
+    runs-on: windows-2025
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+      # for vcpkg caching
+      packages: write
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+      - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          scripts/vcpkg-install.sh
+          pip install meson requests PyYAML
+      - name: Build
+        run: |
+          if ! meson setup builddir --fatal-meson-warnings --werror; then
+              cat builddir/meson-logs/meson-log.txt
+              exit 1
+          fi
+          ninja -C builddir
+      - name: Check
+        run: |
+          trap "cat builddir/meson-logs/testlog.txt" EXIT
+          meson test -C builddir
+
+  bin-setup:
+    name: Set up openslide-bin build
     runs-on: ubuntu-latest
     outputs:
       suffix: ${{ steps.params.outputs.suffix }}
@@ -358,21 +394,21 @@ jobs:
               exit 1
           esac
 
-  windows_build:
-    name: Windows build
-    needs: windows_setup
+  bin-build:
+    name: Build (openslide-bin)
+    needs: bin-setup
     uses: openslide/openslide-bin/.github/workflows/build.yml@main
     with:
       openslide_repo: ${{ github.repository }}
       openslide_ref: ${{ github.ref }}
-      suffix: ${{ needs.windows_setup.outputs.suffix }}
+      suffix: ${{ needs.bin-setup.outputs.suffix }}
       werror: true
-      windows_builder_repo_and_digest: ${{ needs.windows_setup.outputs.windows_builder_repo_and_digest }}
+      windows_builder_repo_and_digest: ${{ needs.bin-setup.outputs.windows_builder_repo_and_digest }}
 
   release:
     name: Release
     if: github.ref_type == 'tag'
-    needs: [primary, build, windows_build]
+    needs: [primary, build, windows-build, bin-build]
     runs-on: ubuntu-latest
     concurrency: release-${{ github.ref }}
     permissions:

--- a/.github/workflows/vcpkg-cache.yml
+++ b/.github/workflows/vcpkg-cache.yml
@@ -1,0 +1,24 @@
+name: Update vcpkg cache
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency: vcpkg-cache
+
+jobs:
+  vcpkg:
+    name: Cache
+    runs-on: windows-2025
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: vcpkg install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/vcpkg-install.sh

--- a/scripts/vcpkg-install.sh
+++ b/scripts/vcpkg-install.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+# Always use the upstream cache, even in forks
+GH_USERNAME=openslide
+FEED_URL="https://nuget.pkg.github.com/${GH_USERNAME}/index.json"
+
+export VCPKG_BINARY_SOURCES="clear;nuget,${FEED_URL},readwrite"
+export X_VCPKG_NUGET_ID_PREFIX="vcpkg-cache"
+
+if [ -z "${GITHUB_TOKEN}" ]; then
+    echo "No GITHUB_TOKEN."
+    exit 1
+fi
+
+nuget sources add -Source "${FEED_URL}" -StorePasswordInClearText \
+    -Name GitHubPackages -UserName "${GH_USERNAME}" -Password "${GITHUB_TOKEN}"
+nuget setapikey "${GITHUB_TOKEN}" -Source "${FEED_URL}"
+
+vcpkg install \
+    pkgconf \
+    cairo \
+    glib \
+    libdicom \
+    libjpeg-turbo \
+    libpng \
+    libxml2 \
+    openjpeg \
+    sqlite3 \
+    tiff \
+    zlib \
+    zstd
+
+if [ -n "${GITHUB_ENV}" ]; then
+    pfx="$VCPKG_INSTALLATION_ROOT\\installed\\x64-windows"
+    origpath="$(echo $PATH | sed -e 's|:|;|g' -e 's|/c/|C:\\|g' -e 's|/|\\|g')"
+    echo "PKG_CONFIG=${pfx}\\tools\\pkgconf\\pkgconf.exe" >> $GITHUB_ENV
+    echo "PKG_CONFIG_PATH=${pfx}\\lib\\pkgconfig;${pfx}\\share\\pkgconfig;${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+    echo "PATH=${pfx}\\bin;${pfx}\\tools\\glib;${origpath}" >> $GITHUB_ENV
+fi

--- a/test/driver.in
+++ b/test/driver.in
@@ -71,18 +71,18 @@ TESTDATA_URL = os.getenv(
     'https://openslide.cs.cmu.edu/download/openslide-testdata/',
 )
 DEFAULT_FROZEN_BUCKET = 'openslide-frozen-testdata'
-SRCDIR = Path('@SRCDIR@')
-BUILDDIR = Path('@BUILDDIR@')
+SRCDIR = Path(r'@SRCDIR@')
+BUILDDIR = Path(r'@BUILDDIR@')
 CLANG_LSAN_SUPPRESSIONS = SRCDIR / 'clang-lsan.supp'
 VALGRIND_SUPPRESSIONS = SRCDIR / 'valgrind.supp'
 VALGRIND_SUPPRESSIONS_GLIB = Path(
-    '@GLIB2_DATADIR@/glib-2.0/valgrind/glib.supp'
+    r'@GLIB2_DATADIR@/glib-2.0/valgrind/glib.supp'
 )
 CASEROOT = SRCDIR / 'cases'
 SLIDELIST = CASEROOT / 'slides.yaml'
 FROZENLIST = CASEROOT / 'frozen.yaml'
 MOSAICLIST = CASEROOT / 'mosaic.ini'
-CACHE = Path(os.getenv('OPENSLIDE_TEST_CACHE', '@BUILDDIR@/_slidedata'))
+CACHE = Path(os.getenv('OPENSLIDE_TEST_CACHE', r'@BUILDDIR@/_slidedata'))
 CACHE_TAG = CACHE / 'CACHEDIR.TAG'
 WORKROOT = CACHE / 'unpacked'
 PRISTINE = CACHE / 'pristine'


### PR DESCRIPTION
Test building on Windows with MinGW GCC.  We'll eventually run the test suite too.  Retain the openslide-bin Windows job, since it's useful to test that we can build release binaries, but rename it for consistency.

Install our dependencies with vcpkg.  With a cold cache, these take over 30 minutes to build.  We could use GitHub Actions caching, but that would age out unless CI ran on Git main every 7 days, and it wouldn't help forks.  vcpkg also supports per-package caching using the GitHub Packages NuGet registry; use that instead.  Push to the registry on every build on main, and also from a weekly scheduled job to keep the cache fresh.  PRs and forks can read from the registry but cannot update it.

Fix `slidetool test deps` on Windows.