### PR TITLE
Add and use macro defining `GDestroyNotify` wrapper function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,17 @@ repos:
         types: [c]
         entry: "(^|\\s|\\()(off_t|ssize_t)(\\s|\\))"
 
+      # Prevent use of dangerous or deprecated casts
+      #
+      # Deprecated cast   Replacement
+      # (GDestroyNotify)  OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER()
+      - id: deny-prohibited-cast
+        name: Check for use of prohibited casts
+        language: pygrep
+        exclude: ^misc/
+        types: [c]
+        entry: "(\\(GDestroyNotify\\))"
+
       # Prevent use of dangerous or deprecated functions.
       # Wrapper implementations can add "// ci-allow" on the same line to
       # skip the check.

--- a/src/openslide-cache.c
+++ b/src/openslide-cache.c
@@ -118,9 +118,7 @@ static gboolean key_equal_func(gconstpointer a,
     (c_a->y == c_b->y);
 }
 
-static void hash_destroy_value(gpointer data) {
-  struct _openslide_cache_value *value = data;
-
+static void hash_destroy_value(struct _openslide_cache_value *value) {
   // remove the item from the list
   g_queue_delete_link(value->cache->list, value->link);
 
@@ -134,6 +132,7 @@ static void hash_destroy_value(gpointer data) {
   // free the value
   g_free(value);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(hash_destroy_value)
 
 openslide_cache_t *_openslide_cache_create(uint64_t capacity_in_bytes) {
   openslide_cache_t *cache = g_new0(openslide_cache_t, 1);
@@ -148,7 +147,7 @@ openslide_cache_t *_openslide_cache_create(uint64_t capacity_in_bytes) {
   cache->hashtable = g_hash_table_new_full(hash_func,
 					   key_equal_func,
 					   g_free,
-					   hash_destroy_value);
+					   OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(hash_destroy_value));
 
   // init refcount
   cache->refcount = 1;

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -378,15 +378,14 @@ static void tiff_directory_destroy(struct tiff_directory *d) {
 typedef struct tiff_directory tiff_directory;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(tiff_directory, tiff_directory_destroy)
 
-static void tiff_item_destroy(gpointer data) {
-  struct tiff_item *item = data;
-
+static void tiff_item_destroy(struct tiff_item *item) {
   g_free(item->uints);
   g_free(item->sints);
   g_free(item->floats);
   g_free(item->buffer);
   g_free(item);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(tiff_item_destroy)
 
 static struct tiff_directory *read_directory(struct _openslide_file *f,
                                              uint64_t *diroff,
@@ -438,7 +437,8 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
   // initial checks passed, initialize the directory
   g_autoptr(tiff_directory) d = g_new0(struct tiff_directory, 1);
   d->items = g_hash_table_new_full(g_direct_hash, g_direct_equal,
-                                   NULL, tiff_item_destroy);
+                                   NULL,
+                                   OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(tiff_item_destroy));
   d->offset = off;
 
   // read all directory entries

--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -196,6 +196,10 @@ bool _openslide_clip_tile(uint32_t *tiledata,
                           int64_t clip_w, int64_t clip_h,
                           GError **err);
 
+#define OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(f) _openslide_notify_ ## f
+#define OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(f) \
+  static void OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(f)(void *p) {f(p);}
+
 
 // File handling
 struct _openslide_file;

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -63,6 +63,7 @@ static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(destroy_level)
 
 static void destroy(openslide_t *osr) {
   for (int32_t i = 0; i < osr->level_count; i++) {
@@ -453,7 +454,7 @@ static bool aperio_open(openslide_t *osr,
    */
 
   g_autoptr(GPtrArray) level_array =
-    g_ptr_array_new_with_free_func((GDestroyNotify) destroy_level);
+    g_ptr_array_new_with_free_func(OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(destroy_level));
   do {
     // check depth
     uint32_t depth;

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -405,6 +405,7 @@ static void level_destroy(struct dicom_level *l) {
   }
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(level_destroy)
 
 typedef struct dicom_level dicom_level;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(dicom_level, level_destroy)
@@ -1083,7 +1084,8 @@ static bool dicom_open(openslide_t *osr,
   }
 
   g_autoptr(GPtrArray) level_array =
-    g_ptr_array_new_full(10, (GDestroyNotify) level_destroy);
+    g_ptr_array_new_full(10,
+                         OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(level_destroy));
 
   // open the passed-in file and get the slide-id
   g_autoptr(dicom_file) start = dicom_file_new(filename, true, err);

--- a/src/openslide-vendor-generic-tiff.c
+++ b/src/openslide-vendor-generic-tiff.c
@@ -50,6 +50,7 @@ static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(destroy_level)
 
 typedef struct level level;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(level, destroy_level)
@@ -215,7 +216,7 @@ static bool generic_tiff_open(openslide_t *osr,
 
   // accumulate tiled levels
   g_autoptr(GPtrArray) level_array =
-    g_ptr_array_new_with_free_func((GDestroyNotify) destroy_level);
+    g_ptr_array_new_with_free_func(OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(destroy_level));
   do {
     // confirm that this directory is tiled
     if (!TIFFIsTiled(ct.tiff)) {

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -280,6 +280,7 @@ static void jpeg_level_free(struct jpeg_level *l) {
   _openslide_grid_destroy(l->grid);
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(jpeg_level_free)
 
 static void jpeg_free(struct jpeg *jpeg) {
   g_free(jpeg->filename);
@@ -287,12 +288,14 @@ static void jpeg_free(struct jpeg *jpeg) {
   g_free(jpeg->unreliable_mcu_starts);
   g_free(jpeg);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(jpeg_free)
 
 static struct jpeg_setup *jpeg_setup_new(void) {
   struct jpeg_setup *setup = g_new0(struct jpeg_setup, 1);
   setup->levels =
-    g_ptr_array_new_with_free_func((GDestroyNotify) jpeg_level_free);
-  setup->jpegs = g_ptr_array_new_with_free_func((GDestroyNotify) jpeg_free);
+    g_ptr_array_new_with_free_func(OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(jpeg_level_free));
+  setup->jpegs =
+    g_ptr_array_new_with_free_func(OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(jpeg_free));
   return setup;
 }
 
@@ -1182,7 +1185,7 @@ static void create_scaled_jpeg_levels(openslide_t *osr,
                                       GPtrArray *levels) {
   g_autoptr(GHashTable) expanded_levels =
     g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free,
-                          (GDestroyNotify) jpeg_level_free);
+                          OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(jpeg_level_free));
 
   for (guint i = 0; i < levels->len; i++) {
     struct jpeg_level *l = g_steal_pointer(&levels->pdata[i]);
@@ -1520,6 +1523,7 @@ static void ngr_level_free(struct ngr_level *l) {
   _openslide_grid_destroy(l->grid);
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(ngr_level_free)
 
 static void ngr_destroy(openslide_t *osr) {
   for (int i = 0; i < osr->level_count; i++) {
@@ -1634,7 +1638,7 @@ static bool hamamatsu_vmu_part2(openslide_t *osr,
 				GError **err) {
   // initialize individual ngr structs
   g_autoptr(GPtrArray) level_array =
-    g_ptr_array_new_with_free_func((GDestroyNotify) ngr_level_free);
+    g_ptr_array_new_with_free_func(OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(ngr_level_free));
 
   // open files
   for (int i = 0; i < num_levels; i++) {

--- a/src/openslide-vendor-philips-tiff.c
+++ b/src/openslide-vendor-philips-tiff.c
@@ -81,6 +81,7 @@ static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(destroy_level)
 
 static void destroy(openslide_t *osr) {
   struct philips_tiff_ops_data *data = osr->data;
@@ -566,7 +567,7 @@ static bool philips_tiff_open(openslide_t *osr,
 
   // create levels
   g_autoptr(GPtrArray) level_array =
-    g_ptr_array_new_with_free_func((GDestroyNotify) destroy_level);
+    g_ptr_array_new_with_free_func(OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(destroy_level));
   struct level *prev_l = NULL;
   do {
     // get directory

--- a/src/openslide-vendor-sakura.c
+++ b/src/openslide-vendor-sakura.c
@@ -162,6 +162,7 @@ static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(destroy_level)
 
 static void destroy(openslide_t *osr) {
   struct sakura_ops_data *data = osr->data;
@@ -789,7 +790,7 @@ static bool sakura_open(openslide_t *osr, const char *filename,
   // create levels; gather tileids for top level
   g_autoptr(GHashTable) level_hash =
     g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free,
-                          (GDestroyNotify) destroy_level);
+                          OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(destroy_level));
   g_autoptr(tileid_queue) quickhash_tileids = g_queue_new();
   int64_t quickhash_downsample = 0;
   g_autofree char *sql =

--- a/src/openslide-vendor-trestle.c
+++ b/src/openslide-vendor-trestle.c
@@ -56,6 +56,7 @@ static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(destroy_level)
 
 static void destroy(openslide_t *osr) {
   for (int32_t i = 0; i < osr->level_count; i++) {
@@ -293,7 +294,7 @@ static bool trestle_open(openslide_t *osr, const char *filename,
 
   // create levels
   g_autoptr(GPtrArray) level_array =
-    g_ptr_array_new_with_free_func((GDestroyNotify) destroy_level);
+    g_ptr_array_new_with_free_func(OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(destroy_level));
   bool report_geometry = true;
   do {
     // verify that we can read this compression (hard fail if not)

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -135,6 +135,7 @@ static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(destroy_level)
 
 static void destroy(openslide_t *osr) {
   struct ventana_ops_data *data = osr->data;
@@ -348,6 +349,7 @@ static void area_free(struct area *area) {
   g_free(area->tiles);
   g_free(area);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(area_free)
 
 static void bif_free(struct bif *bif) {
   for (int32_t i = 0; i < bif->num_areas; i++) {
@@ -467,7 +469,7 @@ static struct bif *parse_level0_xml(const char *xml,
 
   // walk AOIs
   g_autoptr(GPtrArray) area_array =
-    g_ptr_array_new_with_free_func((GDestroyNotify) area_free);
+    g_ptr_array_new_with_free_func(OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(area_free));
   double total_offset_x = 0;
   double total_offset_y = 0;
   int64_t total_x_weight = 0;
@@ -759,7 +761,7 @@ static bool ventana_open(openslide_t *osr, const char *filename,
 
   // walk directories
   g_autoptr(GPtrArray) level_array =
-    g_ptr_array_new_with_free_func((GDestroyNotify) destroy_level);
+    g_ptr_array_new_with_free_func(OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(destroy_level));
   g_autoptr(bif) bif = NULL;
   int64_t next_level = 0;
   double prev_magnification = INFINITY;

--- a/src/openslide-vendor-zeiss.c
+++ b/src/openslide-vendor-zeiss.c
@@ -292,6 +292,7 @@ static void destroy_level(struct level *l) {
   _openslide_grid_destroy(l->grid);
   g_free(l);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(destroy_level)
 
 static void destroy_czi(struct czi *czi) {
   g_free(czi->subblks);
@@ -1188,7 +1189,8 @@ static GPtrArray *create_levels(openslide_t *osr, struct czi *czi,
                                 GError **err) {
   // walk subblocks, create a level struct for each valid downsample
   g_autoptr(GPtrArray) levels =
-    g_ptr_array_new_full(10, (GDestroyNotify) destroy_level);
+    g_ptr_array_new_full(10,
+                         OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(destroy_level));
   g_autoptr(GHashTable) level_hash =
     g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free, NULL);
   for (int i = 0; i < czi->nsubblk; i++) {

--- a/src/openslide.c
+++ b/src/openslide.c
@@ -67,11 +67,10 @@ static void __attribute__((constructor)) _openslide_init(void) {
   openslide_was_dynamically_loaded = true;
 }
 
-static void destroy_associated_image(gpointer data) {
-  struct _openslide_associated_image *img = data;
-
+static void destroy_associated_image(struct _openslide_associated_image *img) {
   img->ops->destroy(img);
 }
+OPENSLIDE_DEFINE_G_DESTROY_NOTIFY_WRAPPER(destroy_associated_image)
 
 static bool level_in_range(openslide_t *osr, int32_t level) {
   if (level < 0) {
@@ -219,7 +218,7 @@ openslide_t *openslide_open(const char *filename) {
                                           g_free, g_free);
   osr->associated_images = g_hash_table_new_full(g_str_hash, g_str_equal,
                                                  g_free,
-                                                 destroy_associated_image);
+                                                 OPENSLIDE_G_DESTROY_NOTIFY_WRAPPER(destroy_associated_image));
 
   // refuse to run on unpatched pixman 0.38.x
   static GOnce pixman_once = G_ONCE_INIT;

--- a/test/extended.c
+++ b/test/extended.c
@@ -24,10 +24,7 @@
 #include <stdbool.h>
 #include <inttypes.h>
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#else
+#ifndef _WIN32
 #include <sys/types.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -210,11 +207,7 @@ static void check_shared_cache(const char *slide) {
   cache_thread_start(params, osrs, 4,  100,  100,       0, &stop);
 
   // let them run
-#ifdef _WIN32
-  Sleep(1000);
-#else
-  sleep(1);
-#endif
+  g_usleep(G_USEC_PER_SEC);
 
   g_atomic_int_set(&stop, 1);
   for (int i = 0; i < CACHE_THREADS; i++) {


### PR DESCRIPTION
Calling a `void (struct foo *)` function through a `void(*)(void *)` function pointer is apparently UB and Clang UBSan has [started complaining about it](https://reviews.llvm.org/D148827).  We often do this with `GDestroyNotify`, but UBSan doesn't catch it because we don't test with an instrumented glib.

Add macros to define and reference a `GDestroyNotify` wrapper for a typed free function.  Use them consistently, both where we were incorrectly casting to `GDestroyNotify` and where we had free functions taking void pointers.

Have pre-commit check for `GDestroyNotify` casts.