### PR TITLE
Add support for reversible JP2K DICOM (trivial patch)

### DIFF
--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -982,6 +982,11 @@ static bool maybe_add_file(openslide_t *osr,
     if (g_str_equal(photometric, "YBR_ICT")) {
       f->jp2k_colorspace = OPENSLIDE_JP2K_YCBCR;
       found = true;
+    } else if (g_str_equal(photometric, "YBR_RCT")) {
+      // openjpeg does the reversible transform for us, so we can treat this
+      // case as RGB
+      f->jp2k_colorspace = OPENSLIDE_JP2K_RGB;
+      found = true;
     } else if (g_str_equal(photometric, "RGB")) {
       f->jp2k_colorspace = OPENSLIDE_JP2K_RGB;
       found = true;


### PR DESCRIPTION
Lossless JP2K usually has `PhotometricInterpretation` set to `YBR_RCT` (reversible YCbCr). OpenJPEG does the conversion to RGB, so we can just use the RGB path in this case.

See https://github.com/openslide/openslide/issues/662