### PR TITLE
meson: use `lib` library prefix when building on Windows

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -81,6 +81,9 @@ libopenslide = library(
   openslide_sources,
   version : soversion,
   c_args : ['-D_OPENSLIDE_BUILDING_DLL', '-DG_LOG_DOMAIN="OpenSlide"'],
+  # Meson omits 'lib' by default on Windows except on MinGW.  Maintain
+  # compatibility with the MinGW build, since it was here first.
+  name_prefix : host_machine.system() == 'windows' ? 'lib' : [],
   gnu_symbol_visibility : visibility,
   include_directories : config_h_include,
   dependencies : [


### PR DESCRIPTION
Meson defaults to omitting the `lib` library prefix on Windows except when building with MinGW, producing `openslide-1.dll`.  OpenSlide Java, OpenSlide Python, and other bindings assume the library is `libopenslide-1.dll`, since that's what openslide-bin ships.  Ensure we use that name.