### PR TITLE
meson: add program overrides

### DIFF
--- a/tools/meson.build
+++ b/tools/meson.build
@@ -40,6 +40,7 @@ foreach target : tools_binaries
     install_tag : 'bin',
   )
   set_variable(target.underscorify(), exe)
+  meson.override_find_program(target, exe)
 endforeach
 
 mans = [


### PR DESCRIPTION
Allow a parent project to invoke slidetool after it's built.  Also do this for the legacy programs if they're built separately.  Probably no one should add a dependency on those, but it's consistent and makes the Meson code a bit cleaner.