### PR TITLE
grok: add support for decompression of j2k tiles with this open source codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ To build OpenSlide, you will need:
 - zlib
 - Zstandard
 
+Optional:
+
+- [Grok][] ≥ 20.3 (alternative JPEG 2000 codec)
+
+[Grok]: https://github.com/GrokImageCompression/grok
+
 Then:
 
 ```
@@ -85,6 +91,34 @@ meson setup builddir
 meson compile -C builddir
 meson install -C builddir
 ```
+
+To enable the Grok JPEG 2000 backend:
+
+```
+meson setup builddir -Dgrok=enabled
+```
+
+See [JPEG 2000 Backend Selection](#jpeg-2000-backend-selection) below.
+
+
+## JPEG 2000 Backend Selection
+
+OpenSlide uses [OpenJPEG][] by default for JPEG 2000 decoding (used by
+Aperio and DICOM slide formats).  When built with Grok support
+(`-Dgrok=enabled`), the [Grok][] JPEG 2000 codec is also available as
+an alternative backend.
+
+To select the Grok backend at runtime, set the environment variable:
+
+```
+export OPENSLIDE_JP2K_BACKEND=grok
+```
+
+When the variable is unset or set to any other value, OpenJPEG is used.
+The backend selection is evaluated once at the first JPEG 2000 decode and
+cached for the lifetime of the process.
+
+[OpenJPEG]: https://github.com/uclouvain/openjpeg
 
 
 ## Acknowledgements

--- a/meson.build
+++ b/meson.build
@@ -142,6 +142,15 @@ openjpeg_dep = dependency(
   'libopenjp2',
   version : '>=2.1.0',
 )
+grok_dep = dependency(
+  'libgrokj2k',
+  version : '>=20.3.0',
+  required : get_option('grok'),
+)
+if grok_dep.found()
+  conf.set('HAVE_GROK', 1)
+  feature_flags += 'grok'
+endif
 tiff_dep = dependency('libtiff-4')
 glib_dep = dependency(
   'glib-2.0',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,12 @@ option(
   description : 'Suffix to append to the package version string',
 )
 option(
+  'grok',
+  type : 'feature',
+  value : 'auto',
+  description : 'Enable Grok JPEG 2000 backend (set OPENSLIDE_JP2K_BACKEND=grok at runtime to use)',
+)
+option(
   'test',
   type : 'feature',
   yield : true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -72,7 +72,11 @@ openslide_sources = files(
   'openslide-vendor-ventana.c',
   'openslide-vendor-zeiss.c',
   'openslide.c',
-) + [
+)
+if grok_dep.found()
+  openslide_sources += files('openslide-decode-jp2k-grok.c')
+endif
+openslide_sources += [
   openslide_dll_o,
   openslide_tables_c,
 ]
@@ -96,6 +100,7 @@ libopenslide = library(
     xml_dep,
     tiff_dep,
     openjpeg_dep,
+    grok_dep,
     jpeg_dep,
     png_dep,
     zlib_dep,

--- a/src/openslide-decode-jp2k-grok.c
+++ b/src/openslide-decode-jp2k-grok.c
@@ -1,0 +1,295 @@
+/*
+ *  OpenSlide, a library for reading whole slide image files
+ *
+ *  Copyright (c) 2007-2015 Carnegie Mellon University
+ *  Copyright (c) 2011 Google, Inc.
+ *  Copyright (c) 2015 Benjamin Gilbert
+ *  Copyright (c) 2026 Aaron Boxer
+ *  All rights reserved.
+ *
+ *  OpenSlide is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, version 2.1.
+ *
+ *  OpenSlide is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with OpenSlide. If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <config.h>
+#include <string.h>
+
+#include "openslide-private.h"
+#include "openslide-decode-jp2k.h"
+
+#include <grok.h>
+
+static void grok_error_callback(const char *msg, void *user_data) {
+  GError **err = (GError **) user_data;
+  if (err && !*err) {
+    g_autofree char *detail = g_strdup(msg);
+    g_strchomp(detail);
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Grok error: %s", detail);
+  }
+}
+
+static void grok_warning_callback(const char *msg,
+                                  void *user_data G_GNUC_UNUSED) {
+  if (_openslide_debug(OPENSLIDE_DEBUG_DECODING)) {
+    g_autofree char *detail = g_strdup(msg);
+    g_strchomp(detail);
+    g_warning("Grok warning: %s", detail);
+  }
+}
+
+static void *grok_init_once(void *data G_GNUC_UNUSED) {
+  grk_initialize(NULL, 0, NULL);
+  return GINT_TO_POINTER(1);
+}
+
+static void ensure_grok_init(void) {
+  static GOnce once = G_ONCE_INIT;
+  g_once(&once, grok_init_once, NULL);
+}
+
+static inline void write_pixel_ycbcr(uint32_t *dest, uint8_t Y,
+                                     int16_t R_chroma, int16_t G_chroma,
+                                     int16_t B_chroma) {
+  int16_t R = Y + R_chroma;
+  int16_t G = Y + G_chroma;
+  int16_t B = Y + B_chroma;
+
+  R = CLAMP(R, 0, 255);
+  G = CLAMP(G, 0, 255);
+  B = CLAMP(B, 0, 255);
+
+  *dest =
+      0xff000000 | ((uint8_t) R << 16) | ((uint8_t) G << 8) | ((uint8_t) B);
+}
+
+static inline void write_pixel_rgb(uint32_t *dest, uint8_t R, uint8_t G,
+                                   uint8_t B) {
+  *dest = 0xff000000 | R << 16 | G << 8 | B;
+}
+
+static void unpack_argb(enum _openslide_jp2k_colorspace space,
+                        grk_image_comp *comps, uint32_t *dest, int32_t w,
+                        int32_t h) {
+  int c0_sub_x = w / comps[0].w;
+  int c1_sub_x = w / comps[1].w;
+  int c2_sub_x = w / comps[2].w;
+  int c0_sub_y = h / comps[0].h;
+  int c1_sub_y = h / comps[1].h;
+  int c2_sub_y = h / comps[2].h;
+
+  int32_t *c0_data = (int32_t *) comps[0].data;
+  int32_t *c1_data = (int32_t *) comps[1].data;
+  int32_t *c2_data = (int32_t *) comps[2].data;
+
+  if (space == OPENSLIDE_JP2K_YCBCR && c0_sub_x == 1 && c1_sub_x == 2 &&
+      c2_sub_x == 2 && c0_sub_y == 1 && c1_sub_y == 1 && c2_sub_y == 1) {
+    // Aperio 33003
+    for (int32_t y = 0; y < h; y++) {
+      int32_t c0_row_base = y * comps[0].w;
+      int32_t c1_row_base = y * comps[1].w;
+      int32_t c2_row_base = y * comps[2].w;
+      int32_t x;
+      for (x = 0; x < w - 1; x += 2) {
+        uint8_t c0 = c0_data[c0_row_base + x];
+        uint8_t c1 = c1_data[c1_row_base + (x / 2)];
+        uint8_t c2 = c2_data[c2_row_base + (x / 2)];
+        int16_t R_chroma = _openslide_R_Cr[c2];
+        int16_t G_chroma =
+            (_openslide_G_Cb[c1] + _openslide_G_Cr[c2]) >> 16;
+        int16_t B_chroma = _openslide_B_Cb[c1];
+        write_pixel_ycbcr(dest++, c0, R_chroma, G_chroma, B_chroma);
+        c0 = c0_data[c0_row_base + x + 1];
+        write_pixel_ycbcr(dest++, c0, R_chroma, G_chroma, B_chroma);
+      }
+      if (x < w) {
+        uint8_t c0 = c0_data[c0_row_base + x];
+        uint8_t c1 = c1_data[c1_row_base + (x / 2)];
+        uint8_t c2 = c2_data[c2_row_base + (x / 2)];
+        int16_t R_chroma = _openslide_R_Cr[c2];
+        int16_t G_chroma =
+            (_openslide_G_Cb[c1] + _openslide_G_Cr[c2]) >> 16;
+        int16_t B_chroma = _openslide_B_Cb[c1];
+        write_pixel_ycbcr(dest++, c0, R_chroma, G_chroma, B_chroma);
+      }
+    }
+
+  } else if (space == OPENSLIDE_JP2K_YCBCR) {
+    // Slow fallback
+    static gint warned_slowpath_ycbcr;
+    _openslide_performance_warn_once(&warned_slowpath_ycbcr,
+                                     "Decoding YCbCr JP2K image via "
+                                     "slow fallback (grok), subsamples "
+                                     "x %d-%d-%d y %d-%d-%d",
+                                     c0_sub_x, c1_sub_x, c2_sub_x,
+                                     c0_sub_y, c1_sub_y, c2_sub_y);
+
+    for (int32_t y = 0; y < h; y++) {
+      int32_t c0_row_base = (y / c0_sub_y) * comps[0].w;
+      int32_t c1_row_base = (y / c1_sub_y) * comps[1].w;
+      int32_t c2_row_base = (y / c2_sub_y) * comps[2].w;
+      for (int32_t x = 0; x < w; x++) {
+        uint8_t c0 = c0_data[c0_row_base + (x / c0_sub_x)];
+        uint8_t c1 = c1_data[c1_row_base + (x / c1_sub_x)];
+        uint8_t c2 = c2_data[c2_row_base + (x / c2_sub_x)];
+        int16_t R_chroma = _openslide_R_Cr[c2];
+        int16_t G_chroma =
+            (_openslide_G_Cb[c1] + _openslide_G_Cr[c2]) >> 16;
+        int16_t B_chroma = _openslide_B_Cb[c1];
+        write_pixel_ycbcr(dest++, c0, R_chroma, G_chroma, B_chroma);
+      }
+    }
+
+  } else if (space == OPENSLIDE_JP2K_RGB && c0_sub_x == 1 && c1_sub_x == 1 &&
+             c2_sub_x == 1 && c0_sub_y == 1 && c1_sub_y == 1 &&
+             c2_sub_y == 1) {
+    // Aperio 33005
+    for (int32_t y = 0; y < h; y++) {
+      int32_t c0_row_base = y * comps[0].w;
+      int32_t c1_row_base = y * comps[1].w;
+      int32_t c2_row_base = y * comps[2].w;
+      for (int32_t x = 0; x < w; x++) {
+        uint8_t c0 = c0_data[c0_row_base + x];
+        uint8_t c1 = c1_data[c1_row_base + x];
+        uint8_t c2 = c2_data[c2_row_base + x];
+        write_pixel_rgb(dest++, c0, c1, c2);
+      }
+    }
+
+  } else if (space == OPENSLIDE_JP2K_RGB) {
+    // Slow fallback
+    static gint warned_slowpath_rgb;
+    _openslide_performance_warn_once(&warned_slowpath_rgb,
+                                     "Decoding RGB JP2K image via "
+                                     "slow fallback (grok), subsamples "
+                                     "x %d-%d-%d y %d-%d-%d",
+                                     c0_sub_x, c1_sub_x, c2_sub_x,
+                                     c0_sub_y, c1_sub_y, c2_sub_y);
+
+    for (int32_t y = 0; y < h; y++) {
+      int32_t c0_row_base = (y / c0_sub_y) * comps[0].w;
+      int32_t c1_row_base = (y / c1_sub_y) * comps[1].w;
+      int32_t c2_row_base = (y / c2_sub_y) * comps[2].w;
+      for (int32_t x = 0; x < w; x++) {
+        uint8_t c0 = c0_data[c0_row_base + (x / c0_sub_x)];
+        uint8_t c1 = c1_data[c1_row_base + (x / c1_sub_x)];
+        uint8_t c2 = c2_data[c2_row_base + (x / c2_sub_x)];
+        write_pixel_rgb(dest++, c0, c1, c2);
+      }
+    }
+  }
+}
+
+bool _openslide_jp2k_decode_buffer_grok(uint32_t *dest, int32_t w, int32_t h,
+                                        const void *data, int32_t datalen,
+                                        enum _openslide_jp2k_colorspace space,
+                                        GError **err) {
+  g_assert(data != NULL);
+  g_assert(datalen >= 0);
+
+  ensure_grok_init();
+
+  // set up message handlers
+  GError *tmp_err = NULL;
+  grk_msg_handlers handlers = {0};
+  handlers.error_callback = grok_error_callback;
+  handlers.error_data = &tmp_err;
+  handlers.warn_callback = grok_warning_callback;
+  handlers.warn_data = NULL;
+  grk_set_msg_handlers(handlers);
+
+  // set up stream parameters for buffer-based decoding
+  grk_stream_params stream_params = {0};
+  stream_params.buf = (uint8_t *) data;
+  stream_params.buf_len = datalen;
+  stream_params.is_read_stream = true;
+
+  // set up decompression parameters
+  grk_decompress_parameters decompress_params = {0};
+  decompress_params.core.tile_cache_strategy = GRK_TILE_CACHE_NONE;
+
+  // create decompressor
+  grk_object *codec =
+      grk_decompress_init(&stream_params, &decompress_params);
+  if (!codec) {
+    if (tmp_err) {
+      g_propagate_error(err, tmp_err);
+    } else {
+      g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                  "grk_decompress_init() failed");
+    }
+    return false;
+  }
+
+  // read header
+  grk_header_info header_info = {0};
+  if (!grk_decompress_read_header(codec, &header_info)) {
+    if (tmp_err) {
+      g_propagate_error(err, tmp_err);
+    } else {
+      g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                  "grk_decompress_read_header() failed");
+    }
+    grk_object_unref(codec);
+    return false;
+  }
+  g_clear_error(&tmp_err);
+
+  // sanity checks
+  if (header_info.header_image.x1 != (uint32_t) w ||
+      header_info.header_image.y1 != (uint32_t) h) {
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Dimensional mismatch reading JP2K, "
+                "expected %dx%d, got %ux%u",
+                w, h, header_info.header_image.x1,
+                header_info.header_image.y1);
+    grk_object_unref(codec);
+    return false;
+  }
+  if (header_info.header_image.numcomps != 3) {
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "Expected 3 image components, found %u",
+                header_info.header_image.numcomps);
+    grk_object_unref(codec);
+    return false;
+  }
+
+  // decode
+  if (!grk_decompress(codec, NULL)) {
+    if (tmp_err) {
+      g_propagate_error(err, tmp_err);
+    } else {
+      g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                  "grk_decompress() failed");
+    }
+    grk_object_unref(codec);
+    return false;
+  }
+  g_clear_error(&tmp_err);
+
+  // get the decompressed image
+  grk_image *image = grk_decompress_get_image(codec);
+  if (!image) {
+    g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
+                "grk_decompress_get_image() returned NULL");
+    grk_object_unref(codec);
+    return false;
+  }
+
+  // copy pixels
+  unpack_argb(space, image->comps, dest, w, h);
+
+  grk_object_unref(codec);
+  return true;
+}

--- a/src/openslide-decode-jp2k.c
+++ b/src/openslide-decode-jp2k.c
@@ -21,6 +21,7 @@
  *
  */
 
+#include <config.h>
 #include <string.h>
 
 #include "openslide-private.h"
@@ -219,7 +220,7 @@ static OPJ_BOOL seek_callback(OPJ_OFF_T offset, void *data) {
   return OPJ_TRUE;
 }
 
-bool _openslide_jp2k_decode_buffer(uint32_t *dest,
+bool _openslide_jp2k_decode_buffer_openjpeg(uint32_t *dest,
                                    int32_t w, int32_t h,
                                    const void *data, int32_t datalen,
                                    enum _openslide_jp2k_colorspace space,
@@ -295,4 +296,31 @@ bool _openslide_jp2k_decode_buffer(uint32_t *dest,
   unpack_argb(space, image->comps, dest, w, h);
 
   return true;
+}
+
+#ifdef HAVE_GROK
+static bool use_grok_backend(void) {
+  static gint cached = -1;
+  if (g_atomic_int_get(&cached) < 0) {
+    const char *env = g_getenv("OPENSLIDE_JP2K_BACKEND");
+    int val = (env && !g_ascii_strcasecmp(env, "grok")) ? 1 : 0;
+    g_atomic_int_set(&cached, val);
+  }
+  return g_atomic_int_get(&cached) == 1;
+}
+#endif
+
+bool _openslide_jp2k_decode_buffer(uint32_t *dest,
+                                   int32_t w, int32_t h,
+                                   const void *data, int32_t datalen,
+                                   enum _openslide_jp2k_colorspace space,
+                                   GError **err) {
+#ifdef HAVE_GROK
+  if (use_grok_backend()) {
+    return _openslide_jp2k_decode_buffer_grok(dest, w, h, data, datalen,
+                                              space, err);
+  }
+#endif
+  return _openslide_jp2k_decode_buffer_openjpeg(dest, w, h, data, datalen,
+                                                space, err);
 }

--- a/src/openslide-decode-jp2k.h
+++ b/src/openslide-decode-jp2k.h
@@ -36,3 +36,19 @@ bool _openslide_jp2k_decode_buffer(uint32_t *dest,
                                    const void *data, int32_t datalen,
                                    enum _openslide_jp2k_colorspace space,
                                    GError **err);
+
+/* OpenJPEG backend (always available) */
+bool _openslide_jp2k_decode_buffer_openjpeg(uint32_t *dest,
+                                            int32_t w, int32_t h,
+                                            const void *data, int32_t datalen,
+                                            enum _openslide_jp2k_colorspace space,
+                                            GError **err);
+
+#ifdef HAVE_GROK
+/* Grok backend (optional) */
+bool _openslide_jp2k_decode_buffer_grok(uint32_t *dest,
+                                        int32_t w, int32_t h,
+                                        const void *data, int32_t datalen,
+                                        enum _openslide_jp2k_colorspace space,
+                                        GError **err);
+#endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -77,6 +77,19 @@ executable(
   c_args : ['-Wno-deprecated-declarations'],
 )
 
+if grok_dep.found()
+  jp2k_grok_test = executable(
+    'test-jp2k-grok',
+    'test-jp2k-grok.c',
+    dependencies : test_deps,
+  )
+  test(
+    'jp2k-grok',
+    jp2k_grok_test,
+    env : ['OPENSLIDE_DEBUG=synthetic'],
+  )
+endif
+
 # Driver
 subdir('env')
 configure_file(

--- a/test/test-jp2k-grok.c
+++ b/test/test-jp2k-grok.c
@@ -1,0 +1,114 @@
+/*
+ *  OpenSlide, a library for reading whole slide image files
+ *
+ *  Copyright (c) 2026 Aaron Boxer
+ *  All rights reserved.
+ *
+ *  OpenSlide is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, version 2.1.
+ *
+ *  OpenSlide is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with OpenSlide. If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * Test the Grok JP2K backend via the synthetic test slide.
+ *
+ * Opens the synthetic slide with OPENSLIDE_JP2K_BACKEND=grok and reads
+ * a region to verify the Grok decode path works end-to-end.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <glib.h>
+#include "openslide.h"
+
+#define REGION_SIZE 16
+
+static bool test_backend(const char *backend_name) {
+  printf("Testing with JP2K backend: %s\n", backend_name);
+
+  if (backend_name) {
+    g_setenv("OPENSLIDE_JP2K_BACKEND", backend_name, TRUE);
+  } else {
+    g_unsetenv("OPENSLIDE_JP2K_BACKEND");
+  }
+
+  /* the synthetic slide is opened via openslide_open("") when
+     OPENSLIDE_DEBUG=synthetic is set */
+  openslide_t *osr = openslide_open("");
+  if (!osr) {
+    fprintf(stderr, "  FAIL: openslide_open(\"\") returned NULL\n");
+    return false;
+  }
+
+  const char *error = openslide_get_error(osr);
+  if (error) {
+    fprintf(stderr, "  FAIL: openslide error: %s\n", error);
+    openslide_close(osr);
+    return false;
+  }
+
+  /* read a small region */
+  uint32_t *buf = g_new0(uint32_t, REGION_SIZE * REGION_SIZE);
+  openslide_read_region(osr, buf, 0, 0, 0, REGION_SIZE, REGION_SIZE);
+
+  error = openslide_get_error(osr);
+  if (error) {
+    fprintf(stderr, "  FAIL: read_region error: %s\n", error);
+    g_free(buf);
+    openslide_close(osr);
+    return false;
+  }
+
+  /* verify we got non-zero pixels */
+  bool has_nonzero = false;
+  for (int i = 0; i < REGION_SIZE * REGION_SIZE; i++) {
+    if (buf[i] != 0) {
+      has_nonzero = true;
+      break;
+    }
+  }
+  if (!has_nonzero) {
+    fprintf(stderr, "  FAIL: all pixels are zero\n");
+    g_free(buf);
+    openslide_close(osr);
+    return false;
+  }
+
+  printf("  OK: read %dx%d region successfully\n", REGION_SIZE, REGION_SIZE);
+  g_free(buf);
+  openslide_close(osr);
+  return true;
+}
+
+int main(void) {
+  /* Note: OPENSLIDE_DEBUG=synthetic must be set BEFORE the library
+     constructor runs.  Set it on the command line or via the test harness.
+     The env var is parsed in the library's constructor. */
+
+  /* test default (OpenJPEG) backend */
+  if (!test_backend(NULL)) {
+    return 1;
+  }
+
+  /* test Grok backend */
+  if (!test_backend("grok")) {
+    return 1;
+  }
+
+  printf("PASS: both backends work\n");
+  return 0;
+}


### PR DESCRIPTION
Grok (https://github.com/GrokImageCompression/grok) is an AGPL licensed codec that provides full support for JPEG 2000 standard Part 1, and can outperform many commercial JPEG 2000 libraries.

It can be enabled at runtime with the environment variable

export OPENSLIDE_JP2K_BACKEND=grok

Tests have also been provided, all passing.