### PR TITLE
test/driver: use `HeadBucket` to get S3 bucket region

### DIFF
--- a/test/driver.py
+++ b/test/driver.py
@@ -739,10 +739,7 @@ class S3Uploader:
     def __init__(self, bucket: str):
         self._s3 = boto3.client('s3')
         self._bucket = bucket
-        region = (
-            self._s3.get_bucket_location(Bucket=bucket)['LocationConstraint']
-            or 'us-east-1'
-        )
+        region = self._s3.head_bucket(Bucket=bucket)['BucketRegion']
         self._baseurl = (
             f'https://{bucket}.s3.dualstack.{region}.amazonaws.com/'
         )


### PR DESCRIPTION
`GetBucketLocation` is now discouraged, and also requires a special permission `s3:GetBucketLocation`.  Use `HeadBucket` (with `s3:ListBucket`) instead.