### PR TITLE
Use `g_new()` to allocate arrays with elements larger than 1

### DIFF
--- a/src/openslide-decode-png.c
+++ b/src/openslide-decode-png.c
@@ -72,7 +72,7 @@ static struct png_ctx *png_ctx_new(uint32_t *dest,
   g_auto(png_ctx) ctx = g_new0(struct png_ctx, 1);
 
   // allocate row pointers
-  ctx->rows = g_malloc(h * sizeof(*ctx->rows));
+  ctx->rows = g_new(png_byte *, h);
   for (int64_t y = 0; y < h; y++) {
     ctx->rows[y] = (png_byte *) &dest[y * w];
   }

--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -189,7 +189,7 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, tw * th);
     if (!decode_tile(l, tiff, buf, tile_col, tile_row, err)) {
       return false;
     }

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -495,7 +495,7 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_autofree uint32_t *buf = g_malloc(l->base.tile_w * l->base.tile_h * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, l->base.tile_w * l->base.tile_h);
     GError *tmp_err = NULL;
     if (!decode_frame(l->file, tile_col, tile_row,
                       buf, l->base.tile_w, l->base.tile_h,

--- a/src/openslide-vendor-generic-tiff.c
+++ b/src/openslide-vendor-generic-tiff.c
@@ -98,7 +98,7 @@ static bool read_tile(openslide_t *osr,
       return true;
     }
 
-    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, tw * th);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
                                    buf, tile_col, tile_row,
                                    err)) {

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -684,7 +684,7 @@ static bool read_jpeg_tile(openslide_t *osr,
                                             &cache_entry);
 
   if (!tiledata) {
-    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, tw * th);
     if (!read_from_jpeg(osr,
                         jp, tileno,
                         l->scale_denom,
@@ -1543,7 +1543,6 @@ static bool ngr_read_tile(openslide_t *osr,
 
   int64_t tw = l->column_width;
   int64_t th = MIN(NGR_TILE_HEIGHT, l->base.h - tile_y * NGR_TILE_HEIGHT);
-  int tilesize = tw * th * 4;
   g_autoptr(_openslide_cache_entry) cache_entry = NULL;
   // look up tile in cache
   uint32_t *tiledata = _openslide_cache_get(osr->cache, level, tile_x, tile_y,
@@ -1574,7 +1573,7 @@ static bool ngr_read_tile(openslide_t *osr,
     }
 
     // got the data, now convert to 8-bit xRGB
-    tiledata = g_malloc(tilesize);
+    tiledata = g_new(uint32_t, tw * th);
     for (int i = 0; i < tw * th; i++) {
       // scale down from 12 bits
       uint8_t r = GINT16_FROM_LE(buf[(i * 3)]) >> 4;
@@ -1587,7 +1586,7 @@ static bool ngr_read_tile(openslide_t *osr,
     // put it in the cache
     _openslide_cache_put(osr->cache, level, tile_x, tile_y,
                          tiledata,
-                         tilesize,
+                         tw * th * 4,
                          &cache_entry);
   }
 

--- a/src/openslide-vendor-leica.c
+++ b/src/openslide-vendor-leica.c
@@ -162,7 +162,7 @@ static bool read_tile(openslide_t *osr,
                                             args->area, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, tw * th);
     if (!_openslide_tiff_read_tile(tiffl, args->tiff,
                                    buf, tile_col, tile_row,
                                    err)) {

--- a/src/openslide-vendor-mirax.c
+++ b/src/openslide-vendor-mirax.c
@@ -220,7 +220,7 @@ static uint32_t *read_image(openslide_t *osr,
   struct mirax_ops_data *data = osr->data;
   bool result = false;
 
-  g_autofree uint32_t *dest = g_malloc(w * h * 4);
+  g_autofree uint32_t *dest = g_new(uint32_t, w * h);
 
   g_autoptr(_openslide_file) f =
     _openslide_fopen(data->datafile_paths[image->fileno], err);

--- a/src/openslide-vendor-philips-tiff.c
+++ b/src/openslide-vendor-philips-tiff.c
@@ -126,7 +126,7 @@ static bool read_tile(openslide_t *osr,
       return true;
     }
 
-    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, tw * th);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
                                    buf, tile_col, tile_row,
                                    err)) {

--- a/src/openslide-vendor-sakura.c
+++ b/src/openslide-vendor-sakura.c
@@ -339,7 +339,7 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_autofree uint32_t *buf = g_malloc(tile_size * tile_size * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, tile_size * tile_size);
 
     // read tile
     if (!read_image(buf, tile_col, tile_row, l->base.downsample,

--- a/src/openslide-vendor-trestle.c
+++ b/src/openslide-vendor-trestle.c
@@ -90,7 +90,7 @@ static bool read_tile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, tw * th);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
                                    buf, tile_col, tile_row,
                                    err)) {

--- a/src/openslide-vendor-ventana.c
+++ b/src/openslide-vendor-ventana.c
@@ -177,7 +177,7 @@ static bool read_subtile(openslide_t *osr,
                                             level, tile_col, tile_row,
                                             &cache_entry);
   if (!tiledata) {
-    g_autofree uint32_t *buf = g_malloc(tw * th * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, tw * th);
     if (!_openslide_tiff_read_tile(tiffl, tiff,
                                    buf, tile_col, tile_row,
                                    err)) {

--- a/src/openslide-vendor-zeiss.c
+++ b/src/openslide-vendor-zeiss.c
@@ -527,7 +527,7 @@ static bool read_tile(openslide_t *osr, cairo_t *cr,
   uint32_t *tiledata = _openslide_cache_get(osr->cache, level, tid, 0,
                                             &cache_entry);
   if (!tiledata) {
-    g_autofree uint32_t *buf = g_malloc(sb->w * sb->h * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, sb->w * sb->h);
     if (!read_subblk(f, czi->zisraw_offset, sb, buf, err)) {
       return false;
     }

--- a/test/extended.c
+++ b/test/extended.c
@@ -156,7 +156,7 @@ struct cache_thread_params {
 
 static void *cache_thread(void *data) {
   struct cache_thread_params *params = data;
-  g_autofree uint32_t *buf = g_malloc(4 * params->w * params->h);
+  g_autofree uint32_t *buf = g_new(uint32_t, params->w * params->h);
   while (!g_atomic_int_get(params->stop)) {
     // read some tiles
     openslide_read_region(params->osr[0], buf, 0, 0, 0, params->w, params->h);

--- a/test/mosaic.c
+++ b/test/mosaic.c
@@ -78,7 +78,7 @@ static void render_tile(cairo_t *cr, const char *name, const char *path,
   if (osr) {
     error = g_strdup(openslide_get_error(osr));
     if (!error) {
-      g_autofree uint32_t *buf = g_malloc(TILE_WIDTH * TILE_HEIGHT * 4);
+      g_autofree uint32_t *buf = g_new(uint32_t, TILE_WIDTH * TILE_HEIGHT);
       openslide_read_region(osr, buf, x, y, level, TILE_WIDTH, TILE_HEIGHT);
       error = g_strdup(openslide_get_error(osr));
       if (!error) {

--- a/test/parallel.c
+++ b/test/parallel.c
@@ -47,7 +47,7 @@ static struct tile sentinel;
 static void *thread_func(void *data) {
   struct state *state = data;
   struct tile *tile;
-  g_autofree uint32_t *buf = g_malloc(TILE_SIZE * TILE_SIZE * sizeof(uint32_t));
+  g_autofree uint32_t *buf = g_new(uint32_t, TILE_SIZE * TILE_SIZE);
 
   g_async_queue_push(state->completions, &sentinel);
   while (1) {

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -163,7 +163,7 @@ static void check_regions(openslide_t *osr) {
     int64_t w = g_ascii_strtoll(args[3], NULL, 10);
     int64_t h = g_ascii_strtoll(args[4], NULL, 10);
 
-    g_autofree uint32_t *buf = g_malloc(w * h * 4);
+    g_autofree uint32_t *buf = g_new(uint32_t, w * h);
     openslide_read_region(osr, buf, x, y, level, w, h);
     check_error(osr);
   }

--- a/tools/slidetool-image.c
+++ b/tools/slidetool-image.c
@@ -155,7 +155,7 @@ static void write_png(openslide_t *osr, FILE *f,
   png_write_info(png_ptr, info_ptr);
 
   const int32_t lines_at_a_time = MAX(BUFSIZE / (w * 4), 1);
-  g_autofree uint32_t *dest = g_malloc(lines_at_a_time * w * 4);
+  g_autofree uint32_t *dest = g_new(uint32_t, lines_at_a_time * w);
   int32_t lines_to_draw = h;
   double ds = openslide_get_level_downsample(osr, level);
   int32_t yy = y / ds;
@@ -301,7 +301,7 @@ static void assoc_read(openslide_t *osr, const char *image, FILE *f,
   // start writing
   png_write_info(png_ptr, info_ptr);
 
-  g_autofree uint32_t *dest = g_malloc(w * h * 4);
+  g_autofree uint32_t *dest = g_new(uint32_t, w * h);
   openslide_read_associated_image(osr, image, dest);
   common_fail_on_error(osr, "Reading associated image");
 

--- a/tools/slidetool-test.c
+++ b/tools/slidetool-test.c
@@ -56,7 +56,7 @@ static int do_test_deps(int narg, char **args) {
   common_fail_on_error(osr, "Opening synthetic slide");
 
   // read region
-  g_autofree void *buf = g_malloc(4 * 1000 * 100);
+  g_autofree uint32_t *buf = g_new(uint32_t, 1000 * 100);
   openslide_read_region(osr, buf, 0, 0, 0, 1000, 100);
   common_fail_on_error(osr, "Reading region");
 


### PR DESCRIPTION
except in the synthetic driver, which is pretty hardcoded.