### PR TITLE
test: distinguish between missing and empty properties

### DIFF
--- a/test/cases/aperio-label-bad-subfile-type/config.yaml
+++ b/test/cases/aperio-label-bad-subfile-type/config.yaml
@@ -2,3 +2,5 @@ base: Aperio/CMU-1.svs
 slide: CMU-1.svs
 success: true
 vendor: aperio
+properties:
+  openslide.associated.label.width: ~

--- a/test/cases/aperio-label-no-subfile-type/config.yaml
+++ b/test/cases/aperio-label-no-subfile-type/config.yaml
@@ -2,3 +2,5 @@ base: Aperio/CMU-1.svs
 slide: CMU-1.svs
 success: true
 vendor: aperio
+properties:
+  openslide.associated.label.width: ~

--- a/test/cases/aperio-thumbnail-empty-imagedescription/config.yaml
+++ b/test/cases/aperio-thumbnail-empty-imagedescription/config.yaml
@@ -4,4 +4,4 @@ slide: CMU-1.svs
 success: true
 vendor: aperio
 properties:
-  openslide.associated.thumbnail.icc-size: ""
+  openslide.associated.thumbnail.icc-size: ~

--- a/test/cases/aperio-thumbnail-mismatched-icc-profile/config.yaml
+++ b/test/cases/aperio-thumbnail-mismatched-icc-profile/config.yaml
@@ -4,4 +4,4 @@ slide: CMU-1.svs
 success: true
 vendor: aperio
 properties:
-  openslide.associated.thumbnail.icc-size: ""
+  openslide.associated.thumbnail.icc-size: ~

--- a/test/cases/aperio-thumbnail-no-imagedescription/config.yaml
+++ b/test/cases/aperio-thumbnail-no-imagedescription/config.yaml
@@ -3,4 +3,5 @@ slide: CMU-1.svs
 success: true
 vendor: aperio
 properties:
+  openslide.associated.thumbnail.icc-size: ~
   openslide.associated.thumbnail.width: '1024'

--- a/test/cases/empty-file/config.yaml
+++ b/test/cases/empty-file/config.yaml
@@ -2,4 +2,4 @@ base: Aperio/CMU-1.svs
 error: ^$
 slide: CMU-1.svs
 success: false
-vendor: null
+vendor: ~

--- a/test/cases/generic-tiff-directory-loop/config.yaml
+++ b/test/cases/generic-tiff-directory-loop/config.yaml
@@ -2,6 +2,6 @@ base: Generic-TIFF/CMU-1.tiff
 error: "tifflike: Loop detected"
 slide: CMU-1.tiff
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/generic-tiff-no-directories/config.yaml
+++ b/test/cases/generic-tiff-no-directories/config.yaml
@@ -2,6 +2,6 @@ base: Generic-TIFF/CMU-1.tiff
 error: "tifflike: TIFF contains no directories"
 slide: CMU-1.tiff
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/generic-tiff-resolution-zero-denominator/config.yaml
+++ b/test/cases/generic-tiff-resolution-zero-denominator/config.yaml
@@ -3,5 +3,5 @@ slide: CMU-1.tiff
 success: true
 vendor: generic-tiff
 properties:
-  openslide.mpp-x: null
-  openslide.mpp-y: null
+  openslide.mpp-x: ~
+  openslide.mpp-y: ~

--- a/test/cases/generic-tiff-resolution-zero-numerator/config.yaml
+++ b/test/cases/generic-tiff-resolution-zero-numerator/config.yaml
@@ -3,5 +3,5 @@ slide: CMU-1.tiff
 success: true
 vendor: generic-tiff
 properties:
-  openslide.mpp-x: null
-  openslide.mpp-y: null
+  openslide.mpp-x: ~
+  openslide.mpp-y: ~

--- a/test/cases/hamamatsu-ndpi-bad-image-dimension-nontiled/config.yaml
+++ b/test/cases/hamamatsu-ndpi-bad-image-dimension-nontiled/config.yaml
@@ -1,5 +1,4 @@
 base: Hamamatsu/CMU-1.ndpi
-error: "^JPEG dimension mismatch for directory 3: expected 804x596, found 800x596$"
 slide: CMU-1.ndpi
 success: true
 vendor: hamamatsu

--- a/test/cases/hamamatsu-ndpi-no-format-flag/config.yaml
+++ b/test/cases/hamamatsu-ndpi-no-format-flag/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "hamamatsu-ndpi: No TIFF tag 65420"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-ndpi-tiff-bad-bigtiff-header/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-bad-bigtiff-header/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "tifflike: Unexpected value in BigTIFF header"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-ndpi-tiff-bad-field-type/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-bad-field-type/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "tifflike: Unknown type encountered: 221"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-ndpi-tiff-bad-header/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-bad-header/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "tifflike: Can't read TIFF header"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-ndpi-tiff-bad-magic/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-bad-magic/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "tifflike: Unrecognized TIFF magic number"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-ndpi-tiff-bad-resolution-unit/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-bad-resolution-unit/config.yaml
@@ -3,5 +3,5 @@ slide: CMU-1.ndpi
 success: true
 vendor: hamamatsu
 properties:
-  openslide.mpp-x: null
-  openslide.mpp-y: null
+  openslide.mpp-x: ~
+  openslide.mpp-y: ~

--- a/test/cases/hamamatsu-ndpi-tiff-bad-version/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-bad-version/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "tifflike: Unrecognized TIFF version"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-ndpi-tiff-no-directory-count/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-no-directory-count/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "tifflike: Cannot read dircount"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-ndpi-tiff-no-magic/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-no-magic/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "tifflike: Can't read TIFF magic number"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-ndpi-tiff-no-next-directory-offset/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-no-next-directory-offset/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "tifflike: Cannot read value/offset extensions"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-ndpi-tiff-no-value-offset/config.yaml
+++ b/test/cases/hamamatsu-ndpi-tiff-no-value-offset/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu/CMU-1.ndpi
 error: "tifflike: Cannot read value/offset"
 slide: CMU-1.ndpi
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-vms-macro-missing/config.yaml
+++ b/test/cases/hamamatsu-vms-macro-missing/config.yaml
@@ -2,3 +2,5 @@ base: Hamamatsu-vms/CMU-1.zip
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: true
 vendor: hamamatsu
+properties:
+  openslide.associated.macro.width: ~

--- a/test/cases/hamamatsu-vms-vms-bad-group/config.yaml
+++ b/test/cases/hamamatsu-vms-vms-bad-group/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu-vms/CMU-1.zip
 error: "hamamatsu-vms-vmu: Not VMS or VMU file"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-vms-vms-bad-physicalheight/config.yaml
+++ b/test/cases/hamamatsu-vms-vms-bad-physicalheight/config.yaml
@@ -3,4 +3,4 @@ slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: true
 vendor: hamamatsu
 properties:
-  openslide.mpp-y: null
+  openslide.mpp-y: ~

--- a/test/cases/hamamatsu-vms-vms-bad-rows/config.yaml
+++ b/test/cases/hamamatsu-vms-vms-bad-rows/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu-vms/CMU-1.zip
 error: "hamamatsu-vms-vmu: VMS file has no rows"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-vms-vms-blank-macro/config.yaml
+++ b/test/cases/hamamatsu-vms-vms-blank-macro/config.yaml
@@ -2,3 +2,5 @@ base: Hamamatsu-vms/CMU-1.zip
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: true
 vendor: hamamatsu
+properties:
+  openslide.associated.macro.width: ~

--- a/test/cases/hamamatsu-vms-vms-large-256KB/config.yaml
+++ b/test/cases/hamamatsu-vms-vms-large-256KB/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu-vms/CMU-1.zip
 error: "hamamatsu-vms-vmu: Can't read key file: Key file .*CMU-1-40x - 2010-01-12 13.24.05.vms too large"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-vms-vms-large-nearly-4GB/config.yaml
+++ b/test/cases/hamamatsu-vms-vms-large-nearly-4GB/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu-vms/CMU-1.zip
 error: "hamamatsu-vms-vmu: Can't read key file: Key file .*CMU-1-40x - 2010-01-12 13.24.05.vms too large"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-vms-vms-no-cols/config.yaml
+++ b/test/cases/hamamatsu-vms-vms-no-cols/config.yaml
@@ -2,6 +2,6 @@ base: Hamamatsu-vms/CMU-1.zip
 error: "hamamatsu-vms-vmu: VMS file has no columns"
 slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/hamamatsu-vms-vms-no-physicalwidth/config.yaml
+++ b/test/cases/hamamatsu-vms-vms-no-physicalwidth/config.yaml
@@ -3,4 +3,4 @@ slide: CMU-1-40x - 2010-01-12 13.24.05.vms
 success: true
 vendor: hamamatsu
 properties:
-  openslide.mpp-x: null
+  openslide.mpp-x: ~

--- a/test/cases/leica-tiff-bad-value-count/config.yaml
+++ b/test/cases/leica-tiff-bad-value-count/config.yaml
@@ -2,6 +2,6 @@ base: Leica/Leica-1.scn
 error: "tifflike: Value count too large"
 slide: Leica-1.scn
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/leica-tiff-directory-bad-offset/config.yaml
+++ b/test/cases/leica-tiff-directory-bad-offset/config.yaml
@@ -2,6 +2,6 @@ base: Leica/Leica-1.scn
 error: "tifflike: Bad offset"
 slide: Leica-1.scn
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/leica-xml-no-macro-image/config.yaml
+++ b/test/cases/leica-xml-no-macro-image/config.yaml
@@ -2,3 +2,5 @@ base: Leica/Leica-1.scn
 slide: Leica-1.scn
 success: true
 vendor: leica
+properties:
+  openslide.associated.macro.width: ~

--- a/test/cases/mirax-mrxs-missing/config.yaml
+++ b/test/cases/mirax-mrxs-missing/config.yaml
@@ -4,4 +4,4 @@ slide: CMU-1.mrxs
 success: false
 debug:
   - detection
-vendor: null
+vendor: ~

--- a/test/cases/mirax-slidedat-missing/config.yaml
+++ b/test/cases/mirax-slidedat-missing/config.yaml
@@ -2,6 +2,6 @@ base: Mirax/CMU-1.zip
 error: "mirax: Slidedat.ini does not exist"
 slide: CMU-1.mrxs
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/cases/nonexistent-file/config.yaml
+++ b/test/cases/nonexistent-file/config.yaml
@@ -2,4 +2,4 @@ base: Aperio/CMU-1.svs
 error: ^$
 slide: CMU-1.svs
 success: false
-vendor: null
+vendor: ~

--- a/test/cases/philips-tiff-associated-xml-bad-jpeg/config.yaml
+++ b/test/cases/philips-tiff-associated-xml-bad-jpeg/config.yaml
@@ -2,3 +2,5 @@ base: Philips-TIFF/Philips-2.tiff
 slide: Philips-2.tiff
 success: true
 vendor: philips
+properties:
+  openslide.associated.macro.width: ~

--- a/test/cases/synthetic-disabled/config.yaml
+++ b/test/cases/synthetic-disabled/config.yaml
@@ -2,5 +2,5 @@ base: Aperio/CMU-1.svs
 error: "^$"
 slide: ""
 success: false
-vendor: null
+vendor: ~
 # no synthetic debug flag

--- a/test/cases/trestle-no-associated-images/config.yaml
+++ b/test/cases/trestle-no-associated-images/config.yaml
@@ -2,3 +2,5 @@ base: Trestle/CMU-1.zip
 slide: CMU-1.tif
 success: true
 vendor: trestle
+properties:
+  openslide.associated.macro.width: ~

--- a/test/cases/untiled-tiff/config.yaml
+++ b/test/cases/untiled-tiff/config.yaml
@@ -5,6 +5,6 @@ base: Aperio/CMU-1.svs
 error: "generic-tiff: TIFF is not tiled"
 slide: CMU-1.svs
 success: false
-vendor: null
+vendor: ~
 debug:
   - detection

--- a/test/driver.py
+++ b/test/driver.py
@@ -319,7 +319,7 @@ class UnpackedSlide:
 
         args = []
         if vendor is not Skip:
-            vendor_str = cast(str, 'none' if vendor is None else vendor)
+            vendor_str = cast(str, 'NULL' if vendor is None else vendor)
             args.extend(['-n', vendor_str])
         if properties:
             for k, v in properties.items():

--- a/test/driver.py
+++ b/test/driver.py
@@ -306,7 +306,7 @@ class UnpackedSlide:
         progdir: Path | None = None,
         debug: Iterable[str] | None = None,
         vendor: str | None | type[Skip] = Skip,
-        properties: dict[str, str] | None = None,
+        properties: dict[str, str | None] | None = None,
         regions: Iterable[Iterable[int]] | None = None,
     ) -> str | None:
         """Try opening the slide file, under Valgrind if specified, using
@@ -323,7 +323,9 @@ class UnpackedSlide:
             args.extend(['-n', vendor_str])
         if properties:
             for k, v in properties.items():
-                args.extend(['-p', '='.join([k, (v or '')])])
+                args.extend(
+                    ['-p', '='.join([k, ('ABSENT' if v is None else v)])]
+                )
         if regions:
             for region in regions:
                 args.extend(['-r', ' '.join(str(d) for d in region)])
@@ -398,7 +400,7 @@ class TestCaseConfig:
         self.required_features: set[str] = set(conf.get('requires', []))
         self.debug: set[str] = set(conf.get('debug', []))
         self.regions: list[list[int]] = conf.get('regions', [])
-        self.properties: dict[str, str] = conf.get('properties', {})
+        self.properties: dict[str, str | None] = conf.get('properties', {})
         self.generators = self._generator_map(conf, 'generate')
         self.copies = self._file_map(conf, 'copy')
         self.renames = self._file_map(conf, 'rename')

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -134,7 +134,7 @@ static void check_props(openslide_t *osr) {
     const char *value = openslide_get_property_value(osr, key);
     check_error(osr);
 
-    if (!*expected_value) {
+    if (!strcmp(expected_value, "ABSENT")) {
       // value should be missing
       if (value != NULL) {
         fail("Property %s exists; should be missing", key);
@@ -143,7 +143,7 @@ static void check_props(openslide_t *osr) {
       if (value == NULL) {
         fail("Property %s does not exist", key);
       } else if (strcmp(value, expected_value)) {
-        fail("Property %s is %s; should be %s", key, value, expected_value);
+        fail("Property %s is \"%s\"; should be \"%s\"", key, value, expected_value);
       }
     }
   }
@@ -173,7 +173,7 @@ static GOptionEntry options[] = {
   {"vendor", 'n', 0, G_OPTION_ARG_STRING, &vendor_check,
    "Check for specified vendor (\"NULL\" for NULL)", "\"VENDOR\""},
   {"property", 'p', 0, G_OPTION_ARG_STRING_ARRAY, &prop_checks,
-   "Check for specified property value", "\"NAME=VALUE\""},
+   "Check property value (\"ABSENT\" for absent)", "\"NAME=VALUE\""},
   {"region", 'r', 0, G_OPTION_ARG_STRING_ARRAY, &region_checks,
    "Read specified region", "\"X Y LEVEL W H\""},
   {"time", 't', 0, G_OPTION_ARG_NONE, &time_check,

--- a/test/try_open.c
+++ b/test/try_open.c
@@ -171,7 +171,7 @@ static void check_regions(openslide_t *osr) {
 
 static GOptionEntry options[] = {
   {"vendor", 'n', 0, G_OPTION_ARG_STRING, &vendor_check,
-   "Check for specified vendor (\"none\" for NULL)", "\"VENDOR\""},
+   "Check for specified vendor (\"NULL\" for NULL)", "\"VENDOR\""},
   {"property", 'p', 0, G_OPTION_ARG_STRING_ARRAY, &prop_checks,
    "Check for specified property value", "\"NAME=VALUE\""},
   {"region", 'r', 0, G_OPTION_ARG_STRING_ARRAY, &region_checks,
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
   // Check vendor if requested
   if (vendor_check) {
     const char *expected_vendor = vendor_check;
-    if (!strcmp(expected_vendor, "none")) {
+    if (!strcmp(expected_vendor, "NULL")) {
       expected_vendor = NULL;
     }
     if ((expected_vendor == NULL) != (vendor == NULL) ||


### PR DESCRIPTION
Check for an empty property when the test case YAML specifies an empty string and a missing property when it specifies `null` or `~`.  Add some additional required-missing properties.