### PR TITLE
util: do not JIT the regex

### DIFF
--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -113,7 +113,7 @@ GKeyFile *_openslide_read_key_file(const char *filename, int32_t max_size,
     // g_once_init_enter_pointer() on glib 2.80+
     if (g_once_init_enter(&have_re)) {
       re = g_regex_new("^\\s*=.*$",
-                       G_REGEX_MULTILINE | G_REGEX_RAW | G_REGEX_OPTIMIZE,
+                       G_REGEX_MULTILINE | G_REGEX_RAW,
                        G_REGEX_MATCH_NEWLINE_ANYCRLF, err);
       g_once_init_leave(&have_re, 1);
       if (!re) {

--- a/test/cases/dicom-level-bad-frame/config.yaml
+++ b/test/cases/dicom-level-bad-frame/config.yaml
@@ -1,5 +1,5 @@
 base: DICOM/3DHISTECH-1.zip
-error: "^libdicom IO error: (End|end) of filehandle - (Needed|needed) 2 bytes beyond end of filehandle$"
+error: "^libdicom IO error: end of filehandle - needed 2 bytes beyond end of filehandle$"
 slide: 000005.dcm
 success: false
 vendor: dicom

--- a/test/cases/dicom-primary-bad-metadata/config.yaml
+++ b/test/cases/dicom-primary-bad-metadata/config.yaml
@@ -1,5 +1,5 @@
 base: DICOM/3DHISTECH-1.zip
-error: "^libdicom IO error: (End|end) of filehandle - (Needed|needed) 2 bytes beyond end of filehandle$"
+error: "^libdicom IO error: end of filehandle - needed 2 bytes beyond end of filehandle$"
 slide: 000013.dcm
 success: false
 vendor: dicom


### PR DESCRIPTION
The PCRE2 JIT causes `Conditional jump or move depends on uninitialised value(s)` Valgrind warnings (in `mirax-slidedat-garbage`) and can reportedly cause SELinux AVCs.  In any case, this regex isn't very performance-sensitive.