### PR TITLE
Add `openslide.barcode` property

### DIFF
--- a/src/openslide-private.h
+++ b/src/openslide-private.h
@@ -186,7 +186,12 @@ double _openslide_parse_double(const char *value);
 /* Serialize double to string */
 char *_openslide_format_double(double d);
 
+/* Decode Base64 to string */
+char *_openslide_decode_base64_str(const char *base64);
+
 /* Duplicate OpenSlide properties */
+void _openslide_duplicate_str_prop(openslide_t *osr, const char *src,
+                                   const char *dest);
 void _openslide_duplicate_int_prop(openslide_t *osr, const char *src,
                                    const char *dest);
 void _openslide_duplicate_double_prop(openslide_t *osr, const char *src,

--- a/src/openslide-util.c
+++ b/src/openslide-util.c
@@ -298,6 +298,27 @@ char *_openslide_format_double(double d) {
   return g_strdup(buf);
 }
 
+char *_openslide_decode_base64_str(const char *base64) {
+  gsize len;
+  char *decoded = (char *) g_base64_decode(base64, &len);
+  decoded = g_realloc(decoded, len + 1);
+  decoded[len] = 0;
+  return decoded;
+}
+
+// copy the src prop to dest if it exists
+void _openslide_duplicate_str_prop(openslide_t *osr, const char *src,
+                                   const char *dest) {
+  g_return_if_fail(g_hash_table_lookup(osr->properties, dest) == NULL);
+
+  char *value = g_hash_table_lookup(osr->properties, src);
+  if (value) {
+    g_hash_table_insert(osr->properties,
+                        g_strdup(dest),
+                        g_strdup(value));
+  }
+}
+
 // if the src prop is an int, canonicalize it and copy it to dest
 void _openslide_duplicate_int_prop(openslide_t *osr, const char *src,
                                    const char *dest) {

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -1071,7 +1071,7 @@ static void add_properties(openslide_t *osr, struct dicom_level *level0) {
   add_properties_dataset(level0->files[0]->file_meta, 0, &iter);
   add_properties_dataset(level0->files[0]->metadata, 0, &iter);
 
-  // add MPP and objective power
+  // add MPP, objective power, barcode
   // pixel spacing is in mm, so convert to microns
   // row spacing, then column spacing
   _openslide_duplicate_double_prop_scaled(osr,
@@ -1085,6 +1085,9 @@ static void add_properties(openslide_t *osr, struct dicom_level *level0) {
   _openslide_duplicate_double_prop(osr,
                                    "dicom.OpticalPathSequence[0].ObjectiveLensPower",
                                    OPENSLIDE_PROPERTY_NAME_OBJECTIVE_POWER);
+  _openslide_duplicate_str_prop(osr,
+                                "dicom.BarcodeValue",
+                                OPENSLIDE_PROPERTY_NAME_BARCODE);
 }
 
 static gint compare_level_width(const void *a, const void *b) {

--- a/src/openslide-vendor-leica.c
+++ b/src/openslide-vendor-leica.c
@@ -404,11 +404,7 @@ static struct collection *parse_xml_description(const char *xml,
     _openslide_xml_xpath_get_string(ctx, "/d:scn/d:collection/d:barcode/text()");
   if (barcode) {
     // Decode Base64
-    gsize len;
-    void *decoded = g_base64_decode(barcode, &len);
-    // null-terminate
-    collection->barcode = g_realloc(decoded, len + 1);
-    collection->barcode[len] = 0;
+    collection->barcode = _openslide_decode_base64_str(barcode);
   } else {
     // Fall back to 2010/03/10 namespace.  It's not clear whether this
     // namespace also Base64-encodes the barcode, so we avoid performing
@@ -554,8 +550,9 @@ static bool create_levels_from_collection(openslide_t *osr,
                                           GError **err) {
   *quickhash_dir = -1;
 
-  // set barcode property
+  // set barcode properties
   set_prop(osr, "leica.barcode", collection->barcode);
+  set_prop(osr, OPENSLIDE_PROPERTY_NAME_BARCODE, collection->barcode);
 
   // determine quickhash mode
   bool legacy_quickhash = should_use_legacy_quickhash(collection);

--- a/src/openslide-vendor-philips-tiff.c
+++ b/src/openslide-vendor-philips-tiff.c
@@ -461,6 +461,14 @@ static void add_openslide_properties(openslide_t *osr) {
                           g_strdup_printf("%u", objective_power));
     }
   }
+
+  const char *barcode = g_hash_table_lookup(osr->properties,
+                                            "philips.PIM_DP_UFS_BARCODE");
+  if (barcode) {
+    g_hash_table_insert(osr->properties,
+                        g_strdup(OPENSLIDE_PROPERTY_NAME_BARCODE),
+                        _openslide_decode_base64_str(barcode));
+  }
 }
 
 static bool fix_level_dimensions(struct level **levels,

--- a/src/openslide-vendor-zeiss.c
+++ b/src/openslide-vendor-zeiss.c
@@ -1038,6 +1038,15 @@ static bool parse_xml_set_prop(openslide_t *osr, struct czi *czi,
                                      OPENSLIDE_PROPERTY_NAME_OBJECTIVE_POWER);
   }
 
+  // schema allows for more than one barcode; just take the first one
+  char *barcode =
+    _openslide_xml_xpath_get_string(ctx, "(/ImageDocument/Metadata/AttachmentInfos/AttachmentInfo/Label/Barcodes/Barcode/Content)[1]/text()");
+  if (barcode) {
+    g_hash_table_insert(osr->properties,
+                        g_strdup(OPENSLIDE_PROPERTY_NAME_BARCODE),
+                        barcode);
+  }
+
   return true;
 }
 

--- a/src/openslide.h
+++ b/src/openslide.h
@@ -301,6 +301,13 @@ const char *openslide_get_error(openslide_t *osr);
 #define OPENSLIDE_PROPERTY_NAME_BACKGROUND_COLOR "openslide.background-color"
 
 /**
+ * The name of the property containing a slide's barcode, if any.
+ *
+ * @since 4.0.1
+ */
+#define OPENSLIDE_PROPERTY_NAME_BARCODE "openslide.barcode"
+
+/**
  * The name of the property containing the height of the rectangle bounding
  * the non-empty region of the slide, if available.
  *

--- a/test/cases/dicom-tiled-sparse-jpeg/config.yaml
+++ b/test/cases/dicom-tiled-sparse-jpeg/config.yaml
@@ -9,6 +9,7 @@ properties:
   openslide.associated.macro.width: "1491"
   openslide.associated.thumbnail.icc-size: "13113264"
   openslide.associated.thumbnail.width: "1920"
+  openslide.barcode: "PV22;LEI;Case-D;Slide-D-5\r\n"
   openslide.icc-size: "13113264"
   openslide.quickhash-1: 7ca87626aa9842b867f284a4ac0c9474f5de295455c8bb25be2ed837efcc5b10
   openslide.vendor: dicom

--- a/test/cases/leica/config.yaml
+++ b/test/cases/leica/config.yaml
@@ -6,5 +6,6 @@ primary: true
 properties:
   leica.barcode: 04050629C
   openslide.associated.macro.width: '1616'
+  openslide.barcode: 04050629C
   openslide.quickhash-1: f600ae1d83abaa21b6fda9284ff35a51d7031f60854b5674fac88c8ac6d66298
   openslide.vendor: leica

--- a/test/cases/philips-tiff/config.yaml
+++ b/test/cases/philips-tiff/config.yaml
@@ -4,5 +4,6 @@ success: true
 vendor: philips
 primary: true
 properties:
+  openslide.barcode: '3311940'
   openslide.quickhash-1: 072a69dc8ae0b35c963dde0c5329fa597f5dac8305b0824120aadb3902860a40
   openslide.vendor: philips

--- a/test/cases/zeiss-czi-uncompressed-pyramidal/config.yaml
+++ b/test/cases/zeiss-czi-uncompressed-pyramidal/config.yaml
@@ -7,6 +7,7 @@ properties:
   openslide.associated.label.width: "640"
   openslide.associated.macro.width: "1260"
   openslide.associated.thumbnail.width: "256"
+  openslide.barcode: "3348"
   openslide.objective-power: "10"
   openslide.quickhash-1: b085249786ac3dae62bc71eeda5d53679651eda3119e414626f9267446448206
   openslide.vendor: zeiss


### PR DESCRIPTION
Support it in DICOM, Leica, Philips TIFF, and Zeiss CZI.

The Leica-4 barcode has a trailing `\r\n`.  The DICOM spec for the LT VR says we're allowed to strip trailing spaces, but those aren't spaces.