### PR TITLE
dicom: switch to `dcm_filehandle_find_frame_number()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To build OpenSlide, you will need:
 - Meson
 - cairo ≥ 1.2
 - glib ≥ 2.56
-- libdicom ≥ 1.2 (automatically built if missing)
+- libdicom ≥ 1.3 (automatically built if missing)
 - libjpeg-turbo ≥ 1.3 or libjpeg ≥ 9c
 - libpng
 - libtiff ≥ 4.0

--- a/meson.build
+++ b/meson.build
@@ -170,7 +170,7 @@ dicom_dep = dependency(
   'libdicom',
   # avoid 'check' dependency
   default_options : ['tests=false'],
-  version : '>=1.2.0',
+  version : '>=1.3.0',
 )
 
 # Dependency checks

--- a/src/openslide-vendor-dicom.c
+++ b/src/openslide-vendor-dicom.c
@@ -490,9 +490,9 @@ static bool read_tile(openslide_t *osr,
       DcmError *dcm_error = NULL;
       g_autoptr(GMutexLocker) locker G_GNUC_UNUSED =
         g_mutex_locker_new(&file->lock);
-      if (!dcm_filehandle_get_frame_number(&dcm_error, file->filehandle,
-                                           tile_col, tile_row,
-                                           &frame_number)) {
+      if (!dcm_filehandle_find_frame_number(&dcm_error, file->filehandle,
+                                            tile_col, tile_row,
+                                            &frame_number)) {
         _openslide_dicom_propagate_error(err, dcm_error);
         return false;
       }
@@ -1160,20 +1160,19 @@ static bool finalize_level(struct dicom_level *l, GPtrArray *files,
         uint16_t file_num;
         for (file_num = 0; file_num < l->file_count; file_num++) {
           DcmError *dcm_error = NULL;
-          uint32_t n;
-          if (dcm_filehandle_get_frame_number(&dcm_error,
-                                              l->files[file_num]->filehandle,
-                                              tile_col, tile_row, &n)) {
+          uint32_t frame;
+          if (!dcm_filehandle_find_frame_number(&dcm_error,
+                                                l->files[file_num]->filehandle,
+                                                tile_col, tile_row, &frame)) {
+            _openslide_dicom_propagate_error(err, dcm_error);
+            return false;
+          }
+          if (frame) {
             // found one, record the file that has this tile and break
             if (l->tile_files) {
               l->tile_files[tile_index] = file_num;
             }
             break;
-          } else if (dcm_error_get_code(dcm_error) == DCM_ERROR_CODE_MISSING_FRAME) {
-            dcm_error_clear(&dcm_error);
-          } else {
-            _openslide_dicom_propagate_error(err, dcm_error);
-            return false;
           }
         }
         if (file_num == l->file_count) {

--- a/subprojects/libdicom.wrap
+++ b/subprojects/libdicom.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = libdicom-1.2.1
-source_url = https://github.com/ImagingDataCommons/libdicom/releases/download/v1.2.1/libdicom-1.2.1.tar.xz
-source_filename = libdicom-1.2.1.tar.xz
-source_hash = 7a448d295b179a4c0b311c09f5253655446a44bf66b3b7d2aa4c09d15f02f1f8
-source_fallback_url = https://wrapdb.mesonbuild.com/v2/libdicom_1.2.1-1/get_source/libdicom-1.2.1.tar.xz
-wrapdb_version = 1.2.1-1
+directory = libdicom-1.3.0
+source_url = https://github.com/ImagingDataCommons/libdicom/releases/download/v1.3.0/libdicom-1.3.0.tar.xz
+source_filename = libdicom-1.3.0.tar.xz
+source_hash = 75f1167f5153c659cdd58f2b432d2592bf0477abe0087e195bc621b5594ef10a
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/libdicom_1.3.0-1/get_source/libdicom-1.3.0.tar.xz
+wrapdb_version = 1.3.0-1
 
 [provide]
 dependency_names = libdicom


### PR DESCRIPTION
Avoid a `DcmError` allocation for every missing tile.

Bump minimum to libdicom 1.3.  We haven't yet had a release that requires 1.2 so this doesn't seem too burdensome.