### PR TITLE
workflows: rebuild vcpkg cache once upon PR; prune cached packages once a month

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -326,9 +326,31 @@ jobs:
       if: matrix.sanitize
       run: cd builddir/test && ./driver sanitize
 
+  vcpkg-wait:
+    name: Wait for vcpkg cache
+    # ideally ubuntu-slim, but that has a hard timeout of 15 minutes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for cache
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          repo="${{ github.repository }}"
+          # always use upstream repo
+          repo_arg="-R openslide/${repo##*/}"
+          # Give the run some time to populate, less than the job ever takes
+          # to complete.  If we lose the race, we may redundantly build
+          # vcpkg packages.
+          sleep 60
+          info=$(gh run list $repo_arg -w vcpkg-cache.yml -L 1 \
+              --json databaseId,url)
+          echo "Waiting for $(echo $info | jq -r .[].url)"
+          gh run watch $repo_arg \
+              "$(echo $info | jq -r .[].databaseId)" >/dev/null
+
   windows-build:
     name: Build (Windows, ${{ matrix.toolchain }})
-    needs: primary
+    needs: [primary, vcpkg-wait]
     runs-on: windows-latest
     strategy:
       matrix:
@@ -343,7 +365,7 @@ jobs:
     permissions:
       contents: read
       # for vcpkg caching
-      packages: write
+      packages: read
     steps:
       - name: Check out repo
         uses: actions/checkout@v6

--- a/.github/workflows/vcpkg-cache.yml
+++ b/.github/workflows/vcpkg-cache.yml
@@ -1,6 +1,9 @@
 name: Update vcpkg cache
 
 on:
+  pull_request_target:
+    branches: [main]
+    tags: ["*"]
   schedule:
     - cron: '0 12 * * 1'
   workflow_dispatch:
@@ -19,7 +22,9 @@ jobs:
     if: github.repository_owner == 'openslide'
     steps:
       - name: Check out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
+        with:
+          ref: main
       - name: vcpkg install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vcpkg-cache.yml
+++ b/.github/workflows/vcpkg-cache.yml
@@ -15,6 +15,8 @@ jobs:
   vcpkg:
     name: Cache
     runs-on: windows-latest
+    # vcpkg-install.sh ignores caches in forks
+    if: github.repository_owner == 'openslide'
     steps:
       - name: Check out repo
         uses: actions/checkout@v6

--- a/.github/workflows/vcpkg-prune.yml
+++ b/.github/workflows/vcpkg-prune.yml
@@ -1,0 +1,32 @@
+name: Prune vcpkg cache
+
+on:
+  schedule:
+    - cron: '0 10 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency: vcpkg-prune
+
+jobs:
+  prune:
+    name: Prune cache
+    runs-on: ubuntu-slim
+    # vcpkg-install.sh ignores caches in forks
+    if: github.repository_owner == 'openslide'
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+      - name: Install dependencies
+        run: python -m pip install requests
+      - name: Prune package versions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: scripts/vcpkg-prune.py

--- a/scripts/vcpkg-prune.py
+++ b/scripts/vcpkg-prune.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import os
+
+import requests
+
+GH_USERNAME = 'openslide'
+PACKAGE_PREFIX = 'vcpkg-cache'
+
+HEADERS = {
+    'Accept': 'application/vnd.github+json',
+    'Authorization': f'Bearer {os.environ["GITHUB_TOKEN"]}',
+    'X-GitHub-Api-Version': '2026-03-10',
+}
+
+resp = requests.get(
+    f'https://api.github.com/orgs/{GH_USERNAME}/packages?package_type=nuget',
+    headers=HEADERS,
+)
+resp.raise_for_status()
+for pkg in sorted(resp.json(), key=lambda pkg: pkg['name']):
+    if not pkg['name'].startswith(PACKAGE_PREFIX):
+        continue
+    resp = requests.get(f'{pkg["url"]}/versions', headers=HEADERS)
+    resp.raise_for_status()
+    versions = sorted(resp.json(), key=lambda ver: ver['created_at'])
+    for ver in versions[:-3]:
+        print(
+            f'Deleting {pkg["name"]} {ver["name"]} created at {ver["created_at"]}'
+        )
+        # versions with more than 5k downloads cannot be deleted
+        resp = requests.delete(ver['url'], headers=HEADERS)
+        if resp.status_code != 204:
+            print('...failed:', resp.text)


### PR DESCRIPTION
Currently if the vcpkg cache is stale (which happens with some regularity) every CI run builds vcpkg packages twice until the `vcpkg-cache` workflow runs on its timer or a build happens on `main`.  Add a `pull_request_target` trigger for the `vcpkg-cache` workflow (carefully, because it has security implications) and a job that waits for that workflow run to finish.

Old cached package versions aren't used once they're supplanted, so there's no point in leaving them lying around.  Prune them once a month, but keep a couple old versions for debuggability.