### PR TITLE
scripts/vcpkg-install: update vcpkg before installing packages

### DIFF
--- a/scripts/vcpkg-install.sh
+++ b/scripts/vcpkg-install.sh
@@ -22,7 +22,11 @@ nuget sources add -Source "${FEED_URL}" -StorePasswordInClearText \
     -Name GitHubPackages -UserName "${GH_USERNAME}" -Password "${GITHUB_TOKEN}"
 nuget setapikey "${GITHUB_TOKEN}" -Source "${FEED_URL}"
 
-( cd "${VCPKG_INSTALLATION_ROOT}" && git pull )
+(
+    cd "${VCPKG_INSTALLATION_ROOT}" &&
+    git pull &&
+    ./bootstrap-vcpkg.sh -disableMetrics
+)
 
 vcpkg install \
     pkgconf \


### PR DESCRIPTION
vcpkg has pushed a forward- and backward-incompatible change to the schema version of `vcpkg-tools.json`, so apparently the tool and the Git repo are expected to be kept in sync.